### PR TITLE
Adding external links in side nav

### DIFF
--- a/src/data/navigation/sections/rest.js
+++ b/src/data/navigation/sections/rest.js
@@ -8,8 +8,26 @@ module.exports = [
       path: "/rest/quick-reference/",
       pages: [
         {
-          title: "Generate a local API Reference",
-          path: "/rest/quick-reference/generate-local.md",
+        title: "REST Endpoints (ReDoc)",
+        path: "/rest/quick-reference/",
+        pages: [
+            {
+                title: "Admin REST endpoints",
+                path: "https://magento.redoc.ly/2.4.4-admin/",
+            },
+            {
+                title: "Customer REST endpoints",
+                path: "https://magento.redoc.ly/2.4.4-customer/",
+            },
+            {
+                title: "Guest REST endpoints",
+                path: "https://magento.redoc.ly/2.4.4-guest/",
+            },
+        ],
+        },       
+        {
+            title: "Generate a local API Reference",
+            path: "/rest/quick-reference/generate-local.md",
         },
       ],
     },


### PR DESCRIPTION
I've added external links in the side nav to the redoc.ly docs. 
I've left the `/quick-reference/index.md` in place because making a top-level page `path` external causes the an error when viewing the page.