### PR TITLE
Replace obsolete devdocs links

### DIFF
--- a/src/pages/get-started/api-security.md
+++ b/src/pages/get-started/api-security.md
@@ -18,14 +18,14 @@ Imposing restrictions on the size and number of resources that a user can reques
 By default, these input limits are disabled, but you can use the following methods to enable them:
 
 -  Set the values in the [Admin](https://docs.magento.com/user-guide/configuration/services/magento-web-api.html).
--  Run the [`bin/magento config:set` command](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-set.html#config-cli-config-set).
--  Add entries to the [`env.php` file](https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-configphp.html#system).
--  Set [environment variables](https://devdocs.magento.com/guides/v2.4/config-guide/deployment/pipeline/example/environment-variables.html).
+-  Run the [`bin/magento config:set` command](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/configuration-management/set-configuration-values.html).
+-  Add entries to the [`env.php` file](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/files/config-reference-configphp.html#system).
+-  Set [environment variables](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/deployment/examples/example-environment-variables.html).
 
 When input limiting has been enabled, the system uses the default value for each limitation listed above. You can also configure custom values.
 
-Although some simple examples for configuring these values from the CLI are provided below, all of the values can be [configured per website and per store view](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-config-mgmt-set.html#config-cli-config-set) in addition to being configurable globally. In addition, these values can also be configured [via `env.php`](https://devdocs.magento.com/guides/v2.4/config-guide/prod/config-reference-configphp.html#system)
-as well as via [environment variables](https://devdocs.magento.com/guides/v2.4/config-guide/deployment/pipeline/example/environment-variables.html).
+Although some simple examples for configuring these values from the CLI are provided below, all of the values can be [configured per website and per store view](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/configuration-management/set-configuration-values.html) in addition to being configurable globally. In addition, these values can also be configured [via `env.php`](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/files/config-reference-configphp.html#system)
+as well as via [environment variables](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/deployment/examples/example-environment-variables.html).
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/get-started/authentication/gs-authentication-token.md
+++ b/src/pages/get-started/authentication/gs-authentication-token.md
@@ -158,7 +158,7 @@ echo send($request);
 
 Commerce provides a separate token service for administrators and customers. When you request a token from one of these services, the service returns a unique access token in exchange for an account's username and password.
 
-The web API framework allows *guest users* to access resources that are configured with the permission level of anonymous. Guest users are users who the framework cannot authenticate through existing authentication mechanisms. As a guest user, you do not need to, but you can, specify a token in a web API call for a resource with anonymous permission. [Restricting access to anonymous web APIs](https://devdocs.magento.com/guides/v2.4/rest/anonymous-api-security.html) contains a list of APIs that do not require a token.
+The web API framework allows *guest users* to access resources that are configured with the permission level of anonymous. Guest users are users who the framework cannot authenticate through existing authentication mechanisms. As a guest user, you do not need to, but you can, specify a token in a web API call for a resource with anonymous permission. [Restricting access to anonymous web APIs](https://developer.adobe.com/commerce/webapi/rest/use-rest/anonymous-api-security/) contains a list of APIs that do not require a token.
 
 The following table lists endpoints and services that can be used to get an authentication token. Admin accounts must be authenticated with a [two factor authentication](https://devdocs.magento.com/guides/v2.4/security/two-factor-authentication.html) provider. Some providers may require multiple calls.
 
@@ -241,4 +241,4 @@ For example, to make a web API call with a customer token:
 
 [Configure services as web APIs](https://developer.adobe.com/commerce/php/development/components/web-api/services/)
 
-[Restricting access to anonymous web APIs](https://devdocs.magento.com/guides/v2.4/rest/anonymous-api-security.html)
+[Restricting access to anonymous web APIs](https://developer.adobe.com/commerce/webapi/rest/use-rest/anonymous-api-security/)

--- a/src/pages/get-started/authentication/index.md
+++ b/src/pages/get-started/authentication/index.md
@@ -170,4 +170,4 @@ Proceed to the authentication method for your preferred client:
 
 *  [Configure services as web APIs](https://developer.adobe.com/commerce/php/development/components/web-api/services/)
 
-*  [Create an ACL rule](https://devdocs.magento.com/guides/v2.4/ext-best-practices/tutorials/create-access-control-list-rule.html)
+*  [Create an ACL rule](https://developer.adobe.com/commerce/php/tutorials/backend/create-access-control-list-rule/)

--- a/src/pages/get-started/gs-web-api-request.md
+++ b/src/pages/get-started/gs-web-api-request.md
@@ -146,7 +146,7 @@ The following example builds a Customers Search request based on search criteria
 
 1. Open the [Magento/Customer/etc/webapi.xml](https://github.com/magento/magento2/tree/2.4/app/code/Magento/Customer/etc/webapi.xml)  configuration file and find the [CustomerRepositoryInterface](https://github.com/magento/magento2/tree/2.4/app/code/Magento/Customer/Api/CustomerRepositoryInterface.php) interface with the `getList` method.
 
-1. Set the headers, URI and method to a request object. Use URI `/V1/customers/search` and method `GET` values. Use the `searchCriteria` parameter to complete the Customer Search query. See [searchCriteria usage](https://devdocs.magento.com/guides/v2.4/rest/performing-searches.html).
+1. Set the headers, URI and method to a request object. Use URI `/V1/customers/search` and method `GET` values. Use the `searchCriteria` parameter to complete the Customer Search query. See [searchCriteria usage](https://developer.adobe.com/commerce/webapi/rest/use-rest/performing-searches/).
 
    The following example finds customers whose first name contains "ver" or whose last name contains "Costello".
 

--- a/src/pages/get-started/index.md
+++ b/src/pages/get-started/index.md
@@ -7,7 +7,7 @@ description: A high-level overview of Magento web APIs.
 
 The Adobe Commerce and Magento Open Source web [API](https://glossary.magento.com/api) framework provides integrators and developers the means to use web services that communicate with the application. Key features include:
 
-*  Support for [GraphQL](https://devdocs.magento.com/guides/v2.4/graphql/index.html), [REST](https://devdocs.magento.com/guides/v2.4/rest/bk-rest.html) (Representational State Transfer) and [SOAP](https://devdocs.magento.com/guides/v2.4/soap/bk-soap.html) (Simple Object Access Protocol).
+*  Support for [GraphQL](https://devdocs.magento.com/guides/v2.4/graphql/index.html), [REST](https://developer.adobe.com/commerce/webapi/rest/) (Representational State Transfer) and [SOAP](https://devdocs.magento.com/guides/v2.4/soap/bk-soap.html) (Simple Object Access Protocol).
 
 *  Three types of [authentication](./authentication/index.md):
    *  Third-party applications authenticate with [OAuth 1.0a](./authentication/gs-authentication-oauth.md).

--- a/src/pages/rest/b2b/negotiable-order-workflow.md
+++ b/src/pages/rest/b2b/negotiable-order-workflow.md
@@ -965,7 +965,7 @@ The buyer is now ready to complete the purchase. Since the buyer has already spe
 
 <InlineAlert variant="info" slots="text"/>
 
-The `/V1/negotiable-carts/:cartId/payment-information` endpoint runs asynchronously if the `AsyncOrder` module has been enabled. By default, the mutation runs synchronously. [Asynchronous order placement](https://devdocs.magento.com/guides/v2.4/performance-best-practices/high-throughput-order-processing.html#asynchronous-order-placement) describes the benefits of enabling the module.
+The `/V1/negotiable-carts/:cartId/payment-information` endpoint runs asynchronously if the `AsyncOrder` module has been enabled. By default, the mutation runs synchronously. [Asynchronous order placement](https://experienceleague.adobe.com/docs/commerce-operations/performance-best-practices/high-throughput-order-processing.html) describes the benefits of enabling the module.
 
 **Headers:**
 

--- a/src/pages/rest/quick-reference/generate-local.md
+++ b/src/pages/rest/quick-reference/generate-local.md
@@ -15,7 +15,7 @@ Commerce provides two ways to get detailed information about the structure of th
 <InlineAlert variant="info" slots="text"/>
 
 For improved application security, starting from Commerce 2.4.4, Swagger UI does not function if the operation mode is set to Production. It only functions in Developer mode.
-See how to switch operation mode [here](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-mode.html#change-to-developer-mode).
+See how to switch operation mode [here](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/set-mode.html#change-to-developer-mode).
 
 The Swagger UI is installed automatically on your server. As a result, you can generate live REST API documentation that can include <Vars.sitedatavaree/> modules, third-party modules, and [extension](https://glossary.magento.com/extension) attributes that have been installed on your system. To view this documentation, go to:
 

--- a/src/pages/rest/tutorials/inventory/configure-environment.md
+++ b/src/pages/rest/tutorials/inventory/configure-environment.md
@@ -58,7 +58,7 @@ This tutorial uses an offline method to calculate distances for shipping and in-
 
    `bin/magento inventory-geonames:import us`
 
-   [Inventory CLI reference](https://devdocs.magento.com/guides/v2.4/inventory/inventory-cli-reference.html#import-geocodes) provides additional information about this command.
+   [Inventory CLI reference](https://experienceleague.adobe.com/docs/commerce-admin/inventory/cli.html#import-geocodes) provides additional information about this command.
 
 ## Deactivate a cart price rule
 

--- a/src/pages/rest/tutorials/inventory/create-sources.md
+++ b/src/pages/rest/tutorials/inventory/create-sources.md
@@ -11,7 +11,7 @@ You cannot delete or disable the default source. You can create, modify, enable,
 
 This step guides you through the process of creating sources for your inventory, including warehouses for the physical products and another source for virtual and downloadable products.
 
-For more information about sources, see [Inventory Management overview](https://devdocs.magento.com/guides/v2.4/inventory/index.html).
+For more information about sources, see [Inventory Management overview](https://developer.adobe.com/commerce/webapi/rest/inventory/).
 
 <InlineAlert variant="info" slots="text"/>
 

--- a/src/pages/rest/tutorials/inventory/create-stock.md
+++ b/src/pages/rest/tutorials/inventory/create-stock.md
@@ -11,7 +11,7 @@ A sales channel can only be assigned to one stock.
 
 The `stock_id` of the default stock is `1`.  You cannot delete or add sources to the default stock, but you can perform these actions with custom stocks.
 
-For more information about stock, see [Inventory Management overview](https://devdocs.magento.com/guides/v2.4/inventory/index.html).
+For more information about stock, see [Inventory Management overview](https://developer.adobe.com/commerce/webapi/rest/inventory/).
 
 ## Create the stock
 

--- a/src/pages/rest/tutorials/inventory/index.md
+++ b/src/pages/rest/tutorials/inventory/index.md
@@ -7,7 +7,7 @@ description: In this tutorial you will process orders using Inventory Management
 
 This tutorial builds upon the workflow described in the [Order Processing with REST APIs tutorial](/rest/tutorials/orders/). The Order Processing with Inventory Management tutorial provides additional steps that detail how to create stocks and sources, assign products to a custom source, and run the Source Selection Algorithms to recommend shipping options.
 
-For more information about key inventory features, see [Inventory Management overview](https://devdocs.magento.com/guides/v2.4/inventory/index.html).
+For more information about key inventory features, see [Inventory Management overview](https://developer.adobe.com/commerce/webapi/rest/inventory/).
 
 This **14-step tutorial** generally takes **1 hour**.
 

--- a/src/pages/rest/use-rest/bulk-endpoints.md
+++ b/src/pages/rest/use-rest/bulk-endpoints.md
@@ -11,7 +11,7 @@ Bulk API endpoints differ from other REST endpoints in that they combine multipl
 
 <InlineAlert variant="info" slots="text"/>
 
-Use the [`bin/magento queue:consumers:start async.operations.all`](https://devdocs.magento.com/guides/v2.4/config-guide/cli/config-cli-subcommands-queue.html) command to start the consumer that handles asynchronous and bulk API messages. Also, before using the Bulk API to process messages, you must install and configure RabbitMQ, which is the default message broker. See [RabbitMQ](https://devdocs.magento.com/guides/v2.4/install-gde/prereq/install-rabbitmq.html).
+Use the [`bin/magento queue:consumers:start async.operations.all`](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/start-message-queues.html) command to start the consumer that handles asynchronous and bulk API messages. Also, before using the Bulk API to process messages, you must install and configure RabbitMQ, which is the default message broker. See [RabbitMQ](https://devdocs.magento.com/guides/v2.4/install-gde/prereq/install-rabbitmq.html).
 
 ## Routes
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces links to `https://devdocs.magento.com` topics that have already been migrated to the Adobe Devsite (`https://developer.adobe.com`).

## Affected pages

- See changed files

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My changes follow the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
