### PR TITLE
Redoc link name change

### DIFF
--- a/src/pages/rest/quick-reference/index.md
+++ b/src/pages/rest/quick-reference/index.md
@@ -1,7 +1,7 @@
 ---
 title: REST endpoints (ReDoc)
 description: Links out to our ReDoc REST documentation
-frameSrc: https://good-stingray-87.redoc.ly
+frameSrc: https://adobe-commerce.redoc.ly
 --- 
 
 # REST endpoints (ReDoc)


### PR DESCRIPTION
Changing link in Redoc from https://good-stingray-87.redoc.ly to
https://adobe-commerce.redoc.ly

See also: https://github.com/magento-commerce/devdocs/pull/3204