### PR TITLE
Replace link to old redocly site

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -17,7 +17,7 @@ The Commerce Web APIs allow you to access and interact with your, integrate thir
 
 *  [PHP Developer Guide](https://developer.adobe.com/commerce/php/development)
 *  [Configuring a Service as a Web API](https://developer.adobe.com/commerce/php/development/components/web-api/services/)
-*  [REST API Reference](https://magento.redoc.ly/2.4.5-admin/)
+*  [REST API Reference](rest/quick-reference/index.md)
 
 ## Overview
 

--- a/src/pages/rest/index.md
+++ b/src/pages/rest/index.md
@@ -5,7 +5,7 @@ description: Overview of the available REST API documentation
  
 # REST API Overview
 
-The [REST API documentation][] describes the REST APIs that are available in Adobe Commerce.
+The REST API documentation describes the REST APIs that are available in Adobe Commerce.
 
 <TextBlock slots="image, heading, text, links" width="50%" />
 
@@ -46,5 +46,3 @@ Get an introduction to Adobe Commerce web APIs through these step-by-step tutori
 Learn about managing your catalog, managing your inventory, and refunding sales using the REST API
 
 -  [Learn more](modules/)
-
-[REST API documentation]: https://magento.redoc.ly

--- a/src/pages/rest/tutorials/index.md
+++ b/src/pages/rest/tutorials/index.md
@@ -30,7 +30,7 @@ Before you begin any tutorial, make sure you know the basics about <Vars.sitedat
 
 *  Know how to construct a REST call in Commerce. See [Construct a request](/get-started/gs-web-api-request) for details.
 
-*  Find the Commerce REST API documentation. You can view the [static REST API documentation on devdocs](https://magento.redoc.ly/) or [generate a local API reference](/rest/use-rest/generate-local/).
+*  Find the Commerce REST API documentation. You can view the [static REST API documentation on devdocs](../quick-reference/index.md) or [generate a local API reference](/rest/use-rest/generate-local/).
 
 *  Find the Commerce Merchant documentation. Refer to [Getting Started with <Vars.sitedatavarce/>](https://docs.magento.com/user-guide/getting-started.html) for information about the Luma store that is created when you install Commerce with the sample data.
 

--- a/src/pages/rest/tutorials/inventory/index.md
+++ b/src/pages/rest/tutorials/inventory/index.md
@@ -23,4 +23,4 @@ This **14-step tutorial** generally takes **1 hour**.
 
 ### Other resources
 
-*  Commerce uses [Swagger](https://swagger.io) to provide REST API documentation on local instances of Commerce. See [Generate a local API reference](/rest/use-rest/generate-local/) for more information. You can view the [static REST API documentation](https://magento.redoc.ly/), which displays reference information using ReDoc.
+*  Commerce uses [Swagger](https://swagger.io) to provide REST API documentation on local instances of Commerce. See [Generate a local API reference](/rest/use-rest/generate-local/) for more information. You can view the [static REST API documentation](../../quick-reference/index.md), which displays reference information using ReDoc.

--- a/src/pages/rest/tutorials/orders/index.md
+++ b/src/pages/rest/tutorials/orders/index.md
@@ -24,7 +24,7 @@ Complete the following prerequisites:
 
 *  Know how to construct a REST call in Commerce. See [Construct a request](/get-started/gs-web-api-request) for details.
 
-*  Find the Commerce REST API documentation. You can view the [static REST API documentation on devdocs](https://magento.redoc.ly/) or [generate a local API reference](/rest/use-rest/generate-local/).
+*  Find the Commerce REST API documentation. You can view the [static REST API documentation on devdocs](../../quick-reference/index.md) or [generate a local API reference](/rest/use-rest/generate-local/).
 
 *  Find the Commerce Merchant documentation. Refer to [Getting Started with <Vars.sitedatavarce/> 2.1](https://docs.magento.com/user-guide/getting-started.html) for information about the Luma store that is created when you install Commerce with the sample data.
 

--- a/src/pages/rest/tutorials/orders/order-issue-refund.md
+++ b/src/pages/rest/tutorials/orders/order-issue-refund.md
@@ -71,4 +71,4 @@ Log in to [Admin](https://glossary.magento.com/admin). Click **Sales** > **Credi
 *  [Getting Started with Adobe Commerce Web APIs](/get-started/)
 *  [Create a configurable product Tutorial](/rest/tutorials/configurable-product/)
 *  [REST API Reference Overview](/rest/)
-*  [REST API documentation](https://magento.redoc.ly/)
+*  [REST API documentation](../../quick-reference/index.md)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replaced links to magento.redoc.ly.

## Related Issue

#50 

## Motivation and Context

The old link no longer works because we cancelled our Pro Redocly subscription when we migrated to the Enterpise plan under the Adobe Developers org.

We're not able to create a redirect.

## How Has This Been Tested?

GitHub Actions PR validation

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
