### PR TITLE
COMDOX-429: Revert formatting for arrays (setShippingAddressesOnCart mutation)

### DIFF
--- a/src/pages/_includes/graphql/cart-object-24.md
+++ b/src/pages/_includes/graphql/cart-object-24.md
@@ -1,12 +1,12 @@
 Attribute |  Data Type | Description
 --- | --- | ---
 `applied_coupon` | [AppliedCoupon][AppliedCoupon] | Deprecated. Use `applied_coupons` instead
-`applied_coupons` | [AppliedCoupon][AppliedCoupon] | An array of `AppliedCoupon` objects. Each object contains the `code` text attribute, which specifies the coupon code
-`applied_gift_cards` | [AppliedGiftCard][AppliedGiftCard] | An array of `AppliedGiftCard` objects. An `AppliedGiftCard` object contains the `code` text attribute, which specifies the gift card code. `applied_gift_cards` is a Commerce-only attribute, defined in the GiftCardAccountGraphQl module
+`applied_coupons` | [[AppliedCoupon]][AppliedCoupon] | An array of `AppliedCoupon` objects. Each object contains the `code` text attribute, which specifies the coupon code
+`applied_gift_cards` | [[AppliedGiftCard]][AppliedGiftCard] | An array of `AppliedGiftCard` objects. An `AppliedGiftCard` object contains the `code` text attribute, which specifies the gift card code. `applied_gift_cards` is a Commerce-only attribute, defined in the GiftCardAccountGraphQl module
 `applied_reward_points`| [RewardPointsAmount][RewardPointsAmount] | The amount of reward points applied to the cart
 `applied_store_credit` | [AppliedStoreCredit][AppliedStoreCredit] | Contains store credit information applied to the cart. `applied_store_credit` is a Commerce-only attribute, defined in the CustomerBalanceGraphQl module
-`available_gift_wrappings` | [GiftWrapping][GiftWrapping]! | The list of available gift wrapping options for the cart
-`available_payment_methods` | [AvailablePaymentMethod][AvailablePaymentMethod] | Available payment methods
+`available_gift_wrappings` | [[GiftWrapping]][GiftWrapping]! | The list of available gift wrapping options for the cart
+`available_payment_methods` | [[AvailablePaymentMethod]][AvailablePaymentMethod] | Available payment methods
 `billing_address` | [BillingCartAddress][BillingCartAddress] | Contains the billing address specified in the customer's cart
 `email` | String | The customer's email address
 `gift_message` | [GiftMessage][GiftMessage] | A gift message added to the cart

--- a/src/pages/_includes/graphql/cart-object-24.md
+++ b/src/pages/_includes/graphql/cart-object-24.md
@@ -14,11 +14,11 @@ Attribute |  Data Type | Description
 `gift_wrapping` | [GiftWrapping][GiftWrapping] | The selected gift wrapping for the cart
 `id` | ID! | The unique ID of the cart
 `is_virtual` | Boolean! | Indicates whether the cart contains only virtual products
-`items` | [CartItemInterface][CartItemInterface] | Contains the items in the customer's cart
+`items` | [[CartItemInterface]][CartItemInterface] | Contains the items in the customer's cart
 `prices` | [CartPrices][CartPrices] | Contains subtotals and totals
 `printed_card_included` | Boolean! | Indicates if the customer requested a printed card for the cart
 `selected_payment_method` | [SelectedPaymentMethod][SelectedPaymentMethod] | Selected payment method
-`shipping_addresses` | [ShippingCartAddress][ShippingCartAddress]! | Contains one or more shipping addresses
+`shipping_addresses` | [[ShippingCartAddress]][ShippingCartAddress]! | Contains one or more shipping addresses
 `total_quantity` | Float! | Total Quantity of products in the cart
 
 [AppliedCoupon]: /src/pages/graphql/schema/cart/queries/cart.md#appliedcoupon-object


### PR DESCRIPTION
## Description

This PR reverts formatting changes made in #67, which are necessary for indicating an array. 

## Related Issue

- COMDOX-429
- #67 

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
