### PR TITLE
Change 'routes' to 'route'

### DIFF
--- a/src/pages/graphql/schema/products/queries/route.md
+++ b/src/pages/graphql/schema/products/queries/route.md
@@ -6,11 +6,11 @@ title: routes query | Commerce Web APIs
 
 A merchant can reconfigure (rewrite) the URL to any product, category, or CMS page. When the rewrite goes into effect, any links that point to the previous URL are redirected to the new address.
 
-The `routes` query returns the canonical URL for a specified product, category, or CMS page. An external app can render a page by a URL without any prior knowledge about the landing page.
+The `route` query returns the canonical URL for a specified product, category, or CMS page. An external app can render a page by a URL without any prior knowledge about the landing page.
 
 ## Syntax
 
-`{routes(url: String!): RoutableInterface}`
+`{route(url: String!): RoutableInterface}`
 
 ## Example usage
 
@@ -101,7 +101,7 @@ The following query returns information about the product with the URL key of `j
 
 ## Input attributes
 
-The `routes` query requires the following attribute.
+The `route` query requires the following attribute.
 
 Attribute | Type | Description
 --- | --- | ---


### PR DESCRIPTION
I think its better to use singular 'route' instead of 'routes'.

<!--- Provide a general summary of your changes in the Title above -->

## Description

"The `routes` query returns..." such phrases look a little disorienting, when 'routes' are specified in plural.
<!--- Describe your changes in detail -->

## Affected pages

<!-- REQUIRED List the pages/URLs on the [Adobe devsite](https://developer.adobe.com/. Not needed for large numbers of files. -->

-  https://developer.adobe.com/commerce/webapi/graphql/schema/products/queries/route/

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
