### PR TITLE
ACP2E-1598: [Documentation] Update GraphQL documentation to reflect changes introduced in ACP2E-1494

### DIFF
--- a/src/pages/graphql/schema/products/interfaces/routable.md
+++ b/src/pages/graphql/schema/products/interfaces/routable.md
@@ -214,7 +214,7 @@ In the following example, an internal URL `community.html` is configured to redi
     "route": {
       "__typename": "RoutableUrl",
       "relative_url": "https://community.example.com/",
-      "redirect_code": 322,
+      "redirect_code": 302,
       "type": null
     }
   }

--- a/src/pages/graphql/schema/products/interfaces/routable.md
+++ b/src/pages/graphql/schema/products/interfaces/routable.md
@@ -189,9 +189,13 @@ The following query returns information about the specified URL key. The query c
 
 `RoutableUrl` is the default implementation of RoutableInterface. This type is returned when the URL is not linked to an entity.
 
+<InlineAlert variant="info" slots="text" />
+
+`RoutableUrl.type` will always return `null` for this type as it is not linked to any of the predefined entities.
+
 ### Example
 
-In the following example, an internal URL `support.html` is configured to redirect to an external URL `https://support.example.com/` using URL Rewrite.
+In the following example, an internal URL `support.html` is configured to redirect to an external URL `https://support.example.com/` using URL Rewrite. 
 
 **Request:**
 

--- a/src/pages/graphql/schema/products/interfaces/routable.md
+++ b/src/pages/graphql/schema/products/interfaces/routable.md
@@ -188,3 +188,35 @@ The following query returns information about the specified URL key. The query c
 ## Routable URL
 
 `RoutableUrl` is the default implementation of RoutableInterface. This type is returned when the URL is not linked to an entity.
+
+### Example
+
+In the following example, an internal URL `community.html` is configured to redirect to an external URL `https://community.adobe.com/` using URL Rewrite.
+
+**Request:**
+
+```graphql
+{
+  route(url: "community.html") {
+    __typename
+    relative_url
+    redirect_code
+    type
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "route": {
+      "__typename": "RoutableUrl",
+      "relative_url": "https://community.adobe.com/",
+      "redirect_code": 322,
+      "type": null
+    }
+  }
+}
+```

--- a/src/pages/graphql/schema/products/interfaces/routable.md
+++ b/src/pages/graphql/schema/products/interfaces/routable.md
@@ -4,7 +4,7 @@ title: RoutableInterface attributes | Commerce Web APIs
 
 # RoutableInterface attributes
 
-Some entities are "routable", meaning that they have URLs and can serve as the model for a rendered page. The following implementations of the `RoutableInterface` allow you to return details in the [`route` query](../queries/route.md).
+Some entities are "routable", meaning that they have URLs and can serve as the model for a rendered page. The following implementations of the `RoutableInterface` allow you to return details in the [`route` query](../queries/route.md). `RoutableUrl` is returned when the URL is not linked to an entity.
 
 *  [BundleProduct](types/bundle.md)
 *  [CategoryTree](../queries/category-list.md#output-attributes)
@@ -15,6 +15,7 @@ Some entities are "routable", meaning that they have URLs and can serve as the m
 *  [GroupedProduct](types/grouped.md)
 *  [SimpleProduct](types/simple.md)
 *  [VirtualProduct](types/virtual.md)
+*  [RoutableUrl](#routable-url)
 
 ## RoutableInterface attributes
 
@@ -183,3 +184,7 @@ The following query returns information about the specified URL key. The query c
   }
 }
 ```
+
+## Routable URL
+
+`RoutableUrl` is the default implementation of RoutableInterface. This type is returned when the URL is not linked to an entity.

--- a/src/pages/graphql/schema/products/interfaces/routable.md
+++ b/src/pages/graphql/schema/products/interfaces/routable.md
@@ -191,13 +191,13 @@ The following query returns information about the specified URL key. The query c
 
 ### Example
 
-In the following example, an internal URL `community.html` is configured to redirect to an external URL `https://community.example.com/` using URL Rewrite.
+In the following example, an internal URL `support.html` is configured to redirect to an external URL `https://support.example.com/` using URL Rewrite.
 
 **Request:**
 
 ```graphql
 {
-  route(url: "community.html") {
+  route(url: "support.html") {
     __typename
     relative_url
     redirect_code
@@ -213,7 +213,7 @@ In the following example, an internal URL `community.html` is configured to redi
   "data": {
     "route": {
       "__typename": "RoutableUrl",
-      "relative_url": "https://community.example.com/",
+      "relative_url": "https://support.example.com/",
       "redirect_code": 302,
       "type": null
     }

--- a/src/pages/graphql/schema/products/interfaces/routable.md
+++ b/src/pages/graphql/schema/products/interfaces/routable.md
@@ -187,7 +187,7 @@ The following query returns information about the specified URL key. The query c
 
 ## Routable URL
 
-`RoutableUrl` is the default implementation of RoutableInterface. This type is returned when the URL is not linked to an entity.
+`RoutableUrl` is the default implementation of RoutableInterface. This type is returned when the URL is not linked to a product or CMS page or to a category. As a result, the `RoutableUrl.type` field always returns `null`.
 
 <InlineAlert variant="info" slots="text" />
 

--- a/src/pages/graphql/schema/products/interfaces/routable.md
+++ b/src/pages/graphql/schema/products/interfaces/routable.md
@@ -189,10 +189,6 @@ The following query returns information about the specified URL key. The query c
 
 `RoutableUrl` is the default implementation of RoutableInterface. This type is returned when the URL is not linked to a product or CMS page or to a category. As a result, the `RoutableUrl.type` field always returns `null`.
 
-<InlineAlert variant="info" slots="text" />
-
-`RoutableUrl.type` will always return `null` for this type as it is not linked to any of the predefined entities.
-
 ### Example
 
 In the following example, an internal URL `support.html` is configured to redirect to an external URL `https://support.example.com/` using URL Rewrite. 

--- a/src/pages/graphql/schema/products/interfaces/routable.md
+++ b/src/pages/graphql/schema/products/interfaces/routable.md
@@ -191,7 +191,7 @@ The following query returns information about the specified URL key. The query c
 
 ### Example
 
-In the following example, an internal URL `community.html` is configured to redirect to an external URL `https://community.adobe.com/` using URL Rewrite.
+In the following example, an internal URL `community.html` is configured to redirect to an external URL `https://community.example.com/` using URL Rewrite.
 
 **Request:**
 
@@ -213,7 +213,7 @@ In the following example, an internal URL `community.html` is configured to redi
   "data": {
     "route": {
       "__typename": "RoutableUrl",
-      "relative_url": "https://community.adobe.com/",
+      "relative_url": "https://community.example.com/",
       "redirect_code": 322,
       "type": null
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

New concrete type `RoutableUrl` was added that implements `RoutableInterface` and inherits the following fields with no additional fields.
```
relative_url
redirect_code
type
```

Document to be updated:
https://developer.adobe.com/commerce/webapi/graphql/schema/products/interfaces/routable/

## Related Issue

[ACP2E-1494](https://jira.corp.adobe.com/browse/ACP2E-1494): Url Rewrite to external URL does not work on GraphQL

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
