### PR TITLE
Update CustomizableOptionInput attributes

### DIFF
--- a/src/pages/_includes/graphql/customizable-option-input-24.md
+++ b/src/pages/_includes/graphql/customizable-option-input-24.md
@@ -1,4 +1,5 @@
 Attribute |  Data Type | Description
 --- | --- | ---
+`uid` | ID | A unique ID for the `CartItemInterface` object
 `id` | Int | A unique ID assigned to the customizable option
 `value_string` | String! | A value assigned to the customizable option

--- a/src/pages/_includes/graphql/customizable-option-input-24.md
+++ b/src/pages/_includes/graphql/customizable-option-input-24.md
@@ -1,5 +1,5 @@
 Attribute |  Data Type | Description
 --- | --- | ---
+`id` | Int | Deprecated. Use `uid` instead. A unique ID assigned to the customizable option
 `uid` | ID | A unique ID for the `CartItemInterface` object
-`id` | Int | A unique ID assigned to the customizable option
 `value_string` | String! | A value assigned to the customizable option


### PR DESCRIPTION
Changes to reflect functionality added in https://jira.corp.adobe.com/browse/ACP2E-1612

<!--- Provide a general summary of your changes in the Title above -->

## Description

<p>Update public documentation to reflect changes in the CustomizableOptionInput object</p>
<div class="table-wrap">


`id` | Int | Deprecated. Use `uid` instead. A unique ID assigned to the customizable option
-- | -- | --
`uid` | ID | A unique ID for the `CartItemInterface` object

</div>



## Related Issue
https://github.com/magento-l3/magento2ce/pull/972
https://github.com/magento-l3/magento2ee/pull/283
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ *] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
