### PR TITLE
Fix wrong description on is_subscribed

### DIFF
--- a/src/pages/_includes/graphql/create-customer.md
+++ b/src/pages/_includes/graphql/create-customer.md
@@ -5,7 +5,7 @@ Attribute |  Data Type | Description
 `email` | String | The customer's email address. Required to create a customer
 `firstname` | String | The customer's first name. Required to create a customer
 `gender` | Int | The customer's gender (Male - 1, Female - 2)
-`is_subscribed` | Boolean | The customer's new password
+`is_subscribed` | Boolean | Indicates whether the customer is subscribed to the company's newsletter
 `lastname` | String | The customer's last name. Required to create a customer
 `middlename` | String | The customer's middle name
 `password` | String | The customer's password. Required to create a customer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The description was not correct for the field is_subscribed in [Input Attributes](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/create/#input-attributes) :  
Previous value: 'The customer's new password'
Proposed value: 'Indicates whether the customer is subscribed to the company's newsletter'
Same value as in the [Output Attributes](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/create/#output-attributes). 

<!--- Describe your changes in detail -->

## Related Issue
N/A

## Motivation and Context
Incorrect information

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
