### PR TITLE
Fixed iframe reference for GraphQL API reference

### DIFF
--- a/src/pages/graphql/reference.md
+++ b/src/pages/graphql/reference.md
@@ -1,3 +1,3 @@
 ---
-frameSrc: /graphql-api/
+frameSrc: /graphql-api/index.html
 ---


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `frameSrc` element that we're using to embed the GraphQL API reference generated with Spectaql seems to require `index.html` to render all sections properly.

## Related Issue

#91 

## Motivation and Context

Without the `index.html`, styling breaks starting at Queries > currency.

https://developer.adobe.com/commerce/webapi/graphql/reference/

![Screenshot 2023-02-22 at 3 48 53 PM](https://user-images.githubusercontent.com/13662379/220767203-332b616e-70c3-4892-98d7-8cbe851c5d75.png)

## How Has This Been Tested?

Locally and by modifying page settings with Chrome Dev Tools.

## Screenshots (if appropriate):

After adding `index.html`:

![Screenshot 2023-02-22 at 3 49 41 PM](https://user-images.githubusercontent.com/13662379/220767365-0a354858-6607-4749-b82b-b315583155b5.png)

## Types of changes

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
