### PR TITLE
Fixed typo cache:clear to cache:clean in page

### DIFF
--- a/src/pages/get-started/api-security.md
+++ b/src/pages/get-started/api-security.md
@@ -132,7 +132,7 @@ Some custom module
 Clear the configuration cache for the changes to take effect.
 
 ```bash
-bin/magento cache:clear config
+bin/magento cache:clean config
 ```
 
 ### Values by default for REST endpoints


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reading the documentation, and this page in particular, i've noticed a typo in the magento command "cache:clean"
it was reported as cache:clear instead.
<!--- Describe your changes in detail -->

## Related Issue
i've found no issue, sorry, but willing to help, it's just a typo fixing.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
the command was wrong.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
trying the command in a project.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
