### PR TITLE
Fix naming of entered_options

### DIFF
--- a/src/pages/graphql/schema/cart/mutations/add-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-products.md
@@ -10,7 +10,7 @@ The `addProductsToCart` mutation adds any type of product to the shopping cart. 
 
 You must specify the Cart ID along with the list of SKU and quantity pairs as parameters to add the products to the shopping cart.
 
-The `CartItemInput` object now contains the `selected_options` and `enter_options` attributes. A selected option is predefined, and the shopper chooses from a set of possible values. Entered options generally contain text the shopper types, but other possibilities exist.
+The `CartItemInput` object now contains the `selected_options` and `entered_options` attributes. A selected option is predefined, and the shopper chooses from a set of possible values. Entered options generally contain text the shopper types, but other possibilities exist.
 
 Selected options can be used in the following product types:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes naming of "entered_options"

## Affected pages
https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/add-products/
<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

## Links to Magento Open Source code
https://github.com/magento-commerce/magento2ce/blob/4c325de7a8a3182d3fde9ee2040df1279c67431f/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L61
<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
