### PR TITLE
Fix incorrect `validationStrategy` parameter

### DIFF
--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -53,7 +53,7 @@ POST /rest/<store_view_code>/V1/import/csv
 |-----|-----|-----|-----|
 |`entity` | The type of entity to be imported | string | Required. One of `advanced_pricing`, `catalog_product`, `customer`, `customer_address`, `customer_composite`, or `customer_finance` |
 |`behavior` | The action  to perform | string | Required. One of `append`, `replace`, `delete`|
-|`validationStrategy` | Strategy to use when entities are invalid | string | Required. Either `validation_stop_on_errors` or `validation-skip-errors` |
+|`validationStrategy` | Strategy to use when entities are invalid | string | Required. Either `validation-stop-on-errors` or `validation-skip-errors` |
 |`allowedErrorCount` | The maximum number of errors that can occur until import is canceled | string | Required |
 |`csvData` | Base64 encoded string containing CSV data (optionally gzip compressed before base64) | string | Required |
 |`ImportFieldSeparator` | Separator used in CSV.  Default is ',' | string | Optional |


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fix incorrect `validationStrategy` parameter allowed value. The correct value for `validationStrategy` parameter should be `validation-stop-on-errors` or `validation-skip-errors`

## Affected pages

- https://developer.adobe.com/commerce/webapi/rest/modules/import/
