### PR TITLE
Change routes to route

### DIFF
--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -788,7 +788,7 @@ module.exports = [
                 path: "/graphql/schema/products/queries/product-review-ratings-metadata/",
               },
               {
-                title: "routes",
+                title: "route",
                 path: "/graphql/schema/products/queries/route/",
               },
               {

--- a/src/pages/graphql/schema/products/queries/route.md
+++ b/src/pages/graphql/schema/products/queries/route.md
@@ -1,8 +1,8 @@
 ---
-title: routes query | Commerce Web APIs
+title: route query | Commerce Web APIs
 ---
 
-# routes query
+# route query
 
 A merchant can reconfigure (rewrite) the URL to any product, category, or CMS page. When the rewrite goes into effect, any links that point to the previous URL are redirected to the new address.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes incorrect references to the `route` query.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
