### PR TITLE
Add warning about X-Magento-Cache-Id with FPC

### DIFF
--- a/src/pages/graphql/usage/caching.md
+++ b/src/pages/graphql/usage/caching.md
@@ -77,6 +77,11 @@ To define additional factors for computing `X-Magento-Cache-Id` hash values, add
 </type>
 ```
 
+<InlineAlert variant="warning" slots="text"/>
+
+X-Magento-Cache-Id response header is only compatible with Varnish or Fastly.  It cannot be reliably used with built-in Full Page Cache.
+
+
 <InlineAlert variant="info" slots="text" />
 
 Adding factors could generate too many unique cache keys, thereby reducing the number of caching hits and affecting performance.


### PR DESCRIPTION
- Warn about consumption of X-Magento-Cache-Id when using built-in Full Page Caching

## Purpose of this pull request

This pull request (PR) warns readers that X-Magento-Cache-Id response header is not for use with built-in (Magento) Full Page Cache; it only is designed for use with Varnish or Fastly.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi/graphql/usage/caching/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- It's not enough to simply point out lines here, but built-in FPC will cache the response headers during a cache miss and deliver most of them verbatim on subsequent HITs.  Built-in FPC does not pay any mind to X-Magento-Cache-Id's value nor does it attempt to recalculate it upon any given HIT.  As far as I know we do not have a logged issue for this yet, but should be prioritized since learning that integration environments in Adobe Commerce Cloud do not offer Fastly, forcing the developer to turn off FPC to properly test X-Magento-Cache-Id.

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
