### PR TITLE
Format categoryList GQL cache annotation example

### DIFF
--- a/src/pages/graphql/develop/identity-class.md
+++ b/src/pages/graphql/develop/identity-class.md
@@ -53,8 +53,7 @@ class MyIdentity implements IdentityInterface
 Use the `@cache` directive in your module's [`graphqls` file](index.md) to specify the location to your `Identity` class. Your module's `graphqls` file must point to your `Identity` class, as shown below:
 
 ```text
-      categoryList(
+categoryList(
     filters: CategoryFilterInput @doc(description: "Identifies which Category filter inputs to search for and return.")
-    ): [CategoryTree] @doc(description: "Returns an array of categories based on the specified filters.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryList") @cache(cacheIdentity: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\CategoriesIdentity")
-}
+): [CategoryTree] @doc(description: "Returns an array of categories based on the specified filters.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\CategoryList") @cache(cacheIdentity: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\CategoriesIdentity")
 ```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) formats GraphQL categoryList cache annotation example and removes trailing closing curly brace where there is no respective opening curly brace

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi/graphql/develop/identity-class/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- Much nicer looking [here](https://github.com/magento-commerce/magento2ce/blob/137bd3740bc3cbc1e5bb4c5c15794e1d19cdce29/app/code/Magento/CatalogGraphQl/etc/schema.graphqls#L17) than the current formatting in the doc

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
