### PR TITLE
Update CustomerAddress.custom_attributes deprecation message and usage

### DIFF
--- a/src/pages/_includes/graphql/customer-address-input-24.md
+++ b/src/pages/_includes/graphql/customer-address-input-24.md
@@ -8,7 +8,8 @@ Attribute |  Data Type | Description
 `company` | String | The customer's company
 `country_code` | String | The customer's country
 `country_id` | String | Deprecated. Use `country_code` instead. The customer's country
-`custom_attributes` | [AttributeValueInput](#attributevalueinput-attributes)| Custom attributes assigned to the customer address
+`custom_attributes` | [CustomerAddressAttributeInput](#customeraddressattributeinput-attributes) | Deprecated. Use `custom_attributesV2` instead
+`custom_attributesV2` | [AttributeValueInput](#attributevalueinput-attributes)| Custom attributes assigned to the customer address
 `default_billing` | Boolean | Indicates whether the address is the default billing address
 `default_shipping` | Boolean | Indicates whether the address is the default shipping address
 `fax` | String | The fax number
@@ -39,6 +40,15 @@ This object contains the following attributes:
 Attribute |  Data Type | Description
 --- | --- | ---
 `value` | String! | The attribute option value
+
+### CustomerAddressAttributeInput attributes
+
+The `CustomerAddressAttributeInput` data type has been deprecated. Use `custom_attributesV2` instead. It can contain the following attributes:
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`attribute_code` | String | Attribute code
+`value` | String | Attribute value
 
 ### CustomerAddressRegionInput attributes
 

--- a/src/pages/_includes/graphql/customer-address-output-24.md
+++ b/src/pages/_includes/graphql/customer-address-output-24.md
@@ -63,7 +63,7 @@ Attribute |  Data Type | Description
 
 ### CustomerAddressAttribute attributes
 
-The `CustomerAddressAttribute` output data type has been deprecated because the contents are not applicable for GraphQL. It can contain the following attributes:
+The `CustomerAddressAttribute` output data type has been deprecated. Use `custom_attributesV2` instead. It can contain the following attributes:
 
 Attribute |  Data Type | Description
 --- | --- | ---

--- a/src/pages/graphql/schema/customer/mutations/create-address.md
+++ b/src/pages/graphql/schema/customer/mutations/create-address.md
@@ -37,7 +37,7 @@ mutation {
     lastname: "Loblaw"
     default_shipping: true
     default_billing: false
-    custom_attributes: [
+    custom_attributesV2: [
       {
         attribute_code: "station"
         value: "Encanto/Central Ave"

--- a/src/pages/graphql/schema/customer/mutations/update-address.md
+++ b/src/pages/graphql/schema/customer/mutations/update-address.md
@@ -23,7 +23,7 @@ mutation {
   updateCustomerAddress(id:3, input: {
     city: "New City"
     postcode: "55555"
-    custom_attributes: [
+    custom_attributesV2: [
       {
         attribute_code: "station",
         value: "Times Sq - 42 St"


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to update documentation:
- taking into account deprecated `custom_attributes` field for Customer address.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

src/pages/_includes/graphql/customer-address-input-24.md
src/pages/_includes/graphql/customer-address-output-24.md
src/pages/graphql/schema/customer/mutations/create-address.md
src/pages/graphql/schema/customer/mutations/update-address.md

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
