### PR TITLE
ACP2E-1617: [Documentation] Change related to Orders REST endpoint

### DIFF
--- a/src/pages/rest/use-rest/performing-searches.md
+++ b/src/pages/rest/use-rest/performing-searches.md
@@ -231,7 +231,7 @@ This example shows how to use search criteria to determine the sort order and at
 
 **Endpoint:**
 
-`GET <host>/rest/<store_code>/V1/orders/`
+`GET <host>/rest/V1/orders/`
 
 **Headers:**
 


### PR DESCRIPTION
## Purpose of this pull request

This PR is to remove the mention of the <store_code> in Rest Urls related to Orders REST endpoint because we do not support them

## Affected pages
- https://developer.adobe.com/commerce/webapi/rest/use-rest/performing-searches/#example-for-search-criteria-to-determine-the-sort-order-and-attributes-to-return

## AC release version
_Which AC release(s) are affected by the content changes: 2.4, 2.3? Specify a patch release number, if applicable._

- Existing AC 2.4.x
- 
## Product editions

_Is this update specific to a product edition: Magento Open Source only, Adobe Commerce only?_

- No.

_Is this update specific to an installed feature extension: B2B extension, other feature set (please, specify)?_

- No.