### PR TITLE
Remove duplicate section from left nav

### DIFF
--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -552,22 +552,6 @@ module.exports = [
         ],
       },
       {
-        title: "Attributes",
-        path: "/graphql/schema/attributes/",
-        pages: [
-          {
-            title: "Queries",
-            path: "/graphql/schema/attributes/queries/",
-            pages: [
-              {
-                title: "customAttributeMetadataV2",
-                path: "/graphql/schema/attributes/queries/custom-attribute-metadata-v2/",
-              },
-            ],
-          }
-        ]
-      },
-      {
         title: "Gift registry",
         path: "/graphql/schema/gift-registry/",
         pages: [


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes a duplicated section of the left navigation of the GraphQL guide. Most likely, this duplication came from a merge non-conflict.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
