### PR TITLE
Beta2: LYNX-187: prefix, sufix, middlename and fax fields missing in setShippingAddressesOnCart and setBillingAddressOnCart graphQL mutations

### DIFF
--- a/src/pages/_includes/graphql/cart-address-input-24.md
+++ b/src/pages/_includes/graphql/cart-address-input-24.md
@@ -4,6 +4,9 @@ Attribute |  Data Type | Description
 `company` | String | The company specified for the billing or shipping address
 `country_code` | String! | The country code and label for the billing or shipping address
 `firstname` | String! | The customer's first name
+`middlename`| String | The middle name of the person associated with the billing/shipping address
+`prefix` | String | An honorific, such as Dr., Mr., or Mrs.
+`suffix` | String | A value such as Sr., Jr., or III
 `lastname` | String! | The customer's last name
 `postcode` | String | The postal code for the billing or shipping address
 `region` | String | The region code for the billing or shipping address
@@ -11,4 +14,5 @@ Attribute |  Data Type | Description
 `save_in_address_book` | Boolean | Determines whether to save the address in the customer's address book. The default value is true
 `street` | [String]! | An array containing the street for the billing or shipping address
 `telephone` | String | The telephone number for the billing or shipping address
+`fax` | String | The customer's fax number
 `vat_id` | String | The VAT company identification number for billing or shipping address

--- a/src/pages/graphql/schema/cart/mutations/set-billing-address.md
+++ b/src/pages/graphql/schema/cart/mutations/set-billing-address.md
@@ -24,7 +24,10 @@ mutation {
       billing_address: {
         address: {
           firstname: "Bob"
+          middlename: "Joe"
           lastname: "Roll"
+          prefix: "Mr."
+          suffix: "Jr."
           company: "Magento"
           street: ["Magento Pkwy", "Main Street"]
           city: "Austin"
@@ -32,6 +35,7 @@ mutation {
           postcode: "78758"
           country_code: "US"
           telephone: "8675309"
+          fax: "8675311"
           save_in_address_book: true
         }
         same_as_shipping: false
@@ -41,7 +45,10 @@ mutation {
     cart {
       billing_address {
         firstname
+        middlename
         lastname
+        prefix
+        suffix
         company
         street
         city
@@ -51,6 +58,7 @@ mutation {
         }
         postcode
         telephone
+        fax
         country{
           code
           label
@@ -70,7 +78,10 @@ mutation {
       "cart": {
         "billing_address": {
           "firstname": "Bob",
+          "middlename": "Joe",
           "lastname": "Roll",
+          "prefix": "Mr.",
+          "suffix": "Jr.",
           "company": "Magento",
           "street": [
             "Magento Pkwy",
@@ -83,6 +94,7 @@ mutation {
             },
           "postcode": "78758",
           "telephone": "8675309",
+          "fax": "8675311",
            "country": {
              "code": "US",
              "label": "US"

--- a/src/pages/graphql/schema/cart/mutations/set-shipping-address.md
+++ b/src/pages/graphql/schema/cart/mutations/set-shipping-address.md
@@ -26,7 +26,10 @@ mutation {
         {
           address: {
             firstname: "Bob"
+            middlename: "Joe"
             lastname: "Roll"
+            prefix: "Mr."
+            suffix: "Jr."
             company: "Magento"
             street: ["Magento Pkwy", "Main Street"]
             city: "Austin"
@@ -34,6 +37,7 @@ mutation {
             postcode: "78758"
             country_code: "US"
             telephone: "8675309"
+            fax: "8675311"
             save_in_address_book: false
           },
           pickup_location_code: "txspeqs"
@@ -44,7 +48,10 @@ mutation {
     cart {
       shipping_addresses {
         firstname
+        middlename
         lastname
+        prefix
+        suffix
         company
         street
         city
@@ -54,6 +61,7 @@ mutation {
         }
         postcode
         telephone
+        fax
         country {
           code
           label
@@ -75,7 +83,10 @@ mutation {
         "shipping_addresses": [
           {
             "firstname": "Bob",
+            "middlename": "Joe",
             "lastname": "Roll",
+            "prefix": "Mr.",
+            "suffix": "Jr.",
             "company": "Magento",
             "street": [
               "Magento Pkwy",
@@ -88,6 +99,7 @@ mutation {
             },
             "postcode": "78758",
             "telephone": "8675309",
+            "fax": "8675311",
             "country": {
               "code": "US",
               "label": "US"


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds missing `middlename`, `prefix`, `suffix` and `fax` to `setShippingAddressesOnCart` and `setBillingAddressOnCart` mutations.

## Affected pages
- src/pages/graphql/schema/cart/mutations/set-shipping-address.md
- src/pages/graphql/schema/cart/mutations/set-billing-address.md
- src/pages/_includes/graphql/cart-address-input-24.md
<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->
