### PR TITLE
Use include file in customer query

### DIFF
--- a/src/pages/_includes/graphql/customer-address-output-24.md
+++ b/src/pages/_includes/graphql/customer-address-output-24.md
@@ -1,5 +1,3 @@
-### CustomerAddress attributes
-
 The values assigned to attributes such as `firstname` and `lastname` in this object may be different from those defined in the `Customer` object.
 
 The `CustomerAddress` output returns the following attributes:

--- a/src/pages/graphql/schema/customer/mutations/create-address.md
+++ b/src/pages/graphql/schema/customer/mutations/create-address.md
@@ -40,7 +40,10 @@ Attribute |  Data Type | Description
 
 ## Output attributes
 
-The `createCustomerAddress` mutation returns the following attributes:
+The `createCustomerAddress` mutation returns a `CustomerAddress` object.
+
+### CustomerAddress attributes
+
 
 <CustomerAddressOutput />
 

--- a/src/pages/graphql/schema/customer/mutations/create-address.md
+++ b/src/pages/graphql/schema/customer/mutations/create-address.md
@@ -44,7 +44,6 @@ The `createCustomerAddress` mutation returns a `CustomerAddress` object.
 
 ### CustomerAddress attributes
 
-
 <CustomerAddressOutput />
 
 ## Errors

--- a/src/pages/graphql/schema/customer/mutations/update-address.md
+++ b/src/pages/graphql/schema/customer/mutations/update-address.md
@@ -44,6 +44,8 @@ Attribute |  Data Type | Description
 
 The `updateCustomerAddress` mutation returns the `CustomerAddress` object.
 
+### CustomerAddress attributes
+
 <CustomerAddressOutput />
 
 ## Errors

--- a/src/pages/graphql/schema/customer/queries/customer.md
+++ b/src/pages/graphql/schema/customer/queries/customer.md
@@ -7,6 +7,7 @@ import BetaNote2 from '/src/pages/_includes/graphql/notes/beta.md'
 import BetaNote3 from '/src/pages/_includes/graphql/notes/beta.md'
 import BetaNote4 from '/src/pages/_includes/graphql/notes/beta.md'
 import CompareListOutput from '/src/pages/_includes/graphql/compare-list-output.md'
+import CustomerAddressOutput from '/src/pages/_includes/graphql/customer-address-output-24.md'
 import CustomerOrdersOutput from '/src/pages/_includes/graphql/customer-orders-output.md'
 import ProductReview from '/src/pages/_includes/graphql/product-review.md'
 import RequisitionList from '/src/pages/_includes/graphql/requisition-list.md'
@@ -1102,54 +1103,7 @@ Attribute |  Data Type | Description
 
 ### CustomerAddress attributes
 
-The values assigned to attributes such as `firstname` and `lastname` in this object may be different from those defined in the `Customer` object.
-
-The `CustomerAddress` output returns the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`city` | String | The city or town
-`company` | String | The customer's company
-`country_code` | CountryCodeEnum | The customer's country
-`country_id` | String | Deprecated. Use `country_code` instead. The customer's country
-`custom_attributes` | [CustomerAddressAttribute](#customeraddressattribute-attributes) | Deprecated. Use `custom_attributesV2` instead
-`custom_attributesV2` | [AttributeValueInterface](#attributevalueinterface-attributes) | Custom attributes assigned to the customer address
-`customer_id` | Int | Deprecated. This attribute is not applicable for GraphQL. The ID assigned to the customer
-`default_billing` | Boolean | Indicates whether the address is the default billing address
-`default_shipping` | Boolean | Indicates whether the address is the default shipping address
-`extension_attributes` | [CustomerAddressAttribute](#customeraddressattribute-attributes) | Address extension attributes
-`fax` | String | The fax number
-`firstname` | String | The first name of the person associated with the shipping/billing address
-`id` | Int | The ID assigned to the address object
-`lastname` | String | The family name of the person associated with the shipping/billing address
-`middlename` | String | The middle name of the person associated with the shipping/billing address
-`postcode` | String | The customer's ZIP or postal code
-`prefix` | String | An honorific, such as Dr., Mr., or Mrs.
-`region` | [CustomerAddressRegion](#customeraddressregion-attributes) | An object that defines the customer's state or province
-`region_id` | Int | The unique ID for a pre-defined region
-`street` | [String] | An array of strings that define the street number and name
-`suffix` | String | A value such as Sr., Jr., or III
-`telephone` | String | The telephone number
-`vat_id` | String | The customer's Tax/VAT number (for corporate customers)
-
-#### CustomerAddressAttribute attributes
-
-The `CustomerAddressAttribute` output data type has been deprecated because the contents are not applicable for GraphQL. It can contain the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`attribute_code` | String | Attribute code
-`value` | String | Attribute value
-
-#### CustomerAddressRegion attributes
-
-The `customerAddressRegion` output returns the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`region` | String | The state or province name
-`region_code` | String | The address region code
-`region_id` | Int | The unique ID for a pre-defined region
+<CustomerAddressOutput />
 
 ### orders input attributes
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces duplicated `CustomerAddress` object in the `customer` query with an include file. The other changes in this PR ensure all queries/mutations that return this object display this information in a consistent manner.

Sergio Vera alerted me to these discrepancies.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
