### PR TITLE
GraphQL: Remove reference info from Store entities

### DIFF
--- a/src/pages/graphql/schema/store/index.md
+++ b/src/pages/graphql/schema/store/index.md
@@ -1,6 +1,7 @@
 ---
 title: Store | Commerce Web APIs
-description:
 ---
 
 # Store
+
+The store schema primarily retrieves system and store configuration data. It also contains the `contactUs` mutation, which enables a shopper to submit feedback to the merchant.

--- a/src/pages/graphql/schema/store/mutations/contact-us.md
+++ b/src/pages/graphql/schema/store/mutations/contact-us.md
@@ -42,26 +42,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `contactUs` mutation requires the  `contactUsInput` object.
-
-### contactUsInput object
-
-The `contactUsInput` object must contain the following attributes:
-
-Attribute | Data Type | Description
---- | --- | ---
-`email` | String! | The email address of the shopper
-`name` | String! | The full name of the shopper
-`telephone` | String | The shopper's telephone number
-`comment` | String! | The shopper's comment to the merchant
-
-## Output attributes
-
-The `contactUsOutput` object returns a Boolean value indicting the success or failure of the request.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`status` | Boolean! | Indicates whether the request was successful

--- a/src/pages/graphql/schema/store/mutations/contact-us.md
+++ b/src/pages/graphql/schema/store/mutations/contact-us.md
@@ -42,3 +42,26 @@ mutation {
   }
 }
 ```
+
+## Input attributes
+
+The `contactUs` mutation requires the  `contactUsInput` object.
+
+### contactUsInput object
+
+The `contactUsInput` object must contain the following attributes:
+
+Attribute | Data Type | Description
+--- | --- | ---
+`email` | String! | The email address of the shopper
+`name` | String! | The full name of the shopper
+`telephone` | String | The shopper's telephone number
+`comment` | String! | The shopper's comment to the merchant
+
+## Output attributes
+
+The `contactUsOutput` object returns a Boolean value indicting the success or failure of the request.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`status` | Boolean! | Indicates whether the request was successful

--- a/src/pages/graphql/schema/store/mutations/index.md
+++ b/src/pages/graphql/schema/store/mutations/index.md
@@ -3,3 +3,5 @@ title: Store mutations | Commerce Web APIs
 ---
 
 # Store mutations
+
+The `contactUs` mutation enables you to create a Contact Us form on your storefront.

--- a/src/pages/graphql/schema/store/queries/available-stores.md
+++ b/src/pages/graphql/schema/store/queries/available-stores.md
@@ -16,7 +16,7 @@ Specify the [Store header](../../../usage/headers.md) to determine the scope of 
 
 ## Reference
 
-[`availableStores`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-availableStores) query
+The [`availableStores`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-availableStores) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/available-stores.md
+++ b/src/pages/graphql/schema/store/queries/available-stores.md
@@ -14,9 +14,14 @@ Specify the [Store header](../../../usage/headers.md) to determine the scope of 
 
 `availableStores(useCurrentGroup: Boolean): [StoreConfig]`
 
+## Reference
+
+[`availableStores`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-availableStores) query
+
 ## Example usage
 
 The following query returns information about the store's basic catalog configuration.
+
 **Request:**
 
 ```graphql
@@ -94,15 +99,3 @@ query {
   }
 }
 ```
-
-## Input attributes
-
-Attribute | Data type | Description
---- | --- | ---
-`useCurrentGroup` | Boolean | Filter store views by current store group
-
-## Output attributes
-
-import StoreConfig from '/src/pages/_includes/graphql/store-config.md'
-
-<StoreConfig />

--- a/src/pages/graphql/schema/store/queries/cms-blocks.md
+++ b/src/pages/graphql/schema/store/queries/cms-blocks.md
@@ -14,7 +14,7 @@ Return the contents of one or more CMS blocks:
 
 ## Reference
 
-[`cmsBlocks`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-cmsBlocks) query
+The [`cmsBlocks`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-cmsBlocks) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/cms-blocks.md
+++ b/src/pages/graphql/schema/store/queries/cms-blocks.md
@@ -12,6 +12,10 @@ Return the contents of one or more CMS blocks:
 
 `cmsBlocks(identifiers: [String]): CmsBlocks`
 
+## Reference
+
+[`cmsBlocks`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-cmsBlocks) query
+
 ## Example usage
 
 The following query returns information about the `login-data` block:
@@ -47,23 +51,6 @@ The following query returns information about the `login-data` block:
   }
 }
 ```
-
-## Input attributes
-
-Attribute | Data type | Description
---- | --- | ---
-`id` | Int | Deprecated. Use `identifier` instead.
-`identifiers` | [String] | An array containing a comma-separated list of block identifiers
-
-## Output attributes
-
-The `CmsBlocks` object contains an array of `items`, each of which can contain a `CmsBlock` object.
-
-### CmsBlock attributes
-
-import CmsBlockObject from '/src/pages/_includes/graphql/cms-block-object.md'
-
-<CmsBlockObject />
 
 ## Errors
 

--- a/src/pages/graphql/schema/store/queries/cms-page.md
+++ b/src/pages/graphql/schema/store/queries/cms-page.md
@@ -14,7 +14,7 @@ Return the contents of a CMS page:
 
 ## Reference
 
-[`cmsPage`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-cmsPage) query
+The [`cmsPage`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-cmsPage) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/cms-page.md
+++ b/src/pages/graphql/schema/store/queries/cms-page.md
@@ -12,6 +12,10 @@ Return the contents of a CMS page:
 
 `cmsPage(identifier: String): CmsPage`
 
+## Reference
+
+[`cmsPage`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-cmsPage) query
+
 ## Example usage
 
 You must include the CMS page identifier value to retrieve the content of a specific CMS page. The following query returns information about the "404 Not Found" CMS page:
@@ -54,36 +58,13 @@ You must include the CMS page identifier value to retrieve the content of a spec
 }
 ```
 
-## Input attributes
-
-Attribute | Data type | Description
---- | --- | ---
-`id` | Int | Deprecated. Use `identifier` instead.
-`identifier` | String | The identifier of a CMS page
-
-## Output attributes
-
-The `CmsPage` object can contain the following attributes:
-
-Attribute | Data type | Description
---- | --- | ---
-`content` | String | The content of the CMS page in raw HTML
-`content_heading` | String | The heading that displays at the top of the CMS page
-`identifier` | String | The identifier of the CMS page
-`meta_description` | String | A brief description of the page for search results listings
-`meta_keywords` | String | A set of keywords that search engines can use to index the page
-`meta_title` | String | A page title that is indexed by search engines and appears in search results listings
-`page_layout` | String | The design layout of the page, indicating the number of columns and navigation features used on the page
-`title` | String | The name that appears in the breadcrumb trail navigation and in the browser title bar and tab
-`url_key` |String | The URL key of the CMS page, which is often based on the `content_heading`
-
-## Related topics
-
-[cmsBlocks query](../../store/queries/cms-blocks.md)
-
 ## Errors
 
 Error | Description
 --- | ---
 `The CMS page with the "XXXX" ID doesn't exist` | The specified CMS page ID is invalid.
 `Page id/identifier should be specified"` | The `identifier` parameter is required for identifying the CMS page.
+
+## Related topics
+
+[cmsBlocks query](cms-blocks.md)

--- a/src/pages/graphql/schema/store/queries/countries.md
+++ b/src/pages/graphql/schema/store/queries/countries.md
@@ -14,7 +14,7 @@ Use the [country](country.md) query if you want to retrieve information about a 
 
 ## Reference
 
-[`countries`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-countries) query
+The [`countries`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-countries) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/countries.md
+++ b/src/pages/graphql/schema/store/queries/countries.md
@@ -14,7 +14,7 @@ Use the [country](country.md) query if you want to retrieve information about a 
 
 ## Reference
 
-The [`countries`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-countries) reference provides detailed information about the types and fields defined in this query.
+The [`countries`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-countries) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/countries.md
+++ b/src/pages/graphql/schema/store/queries/countries.md
@@ -12,6 +12,10 @@ Use the [country](country.md) query if you want to retrieve information about a 
 
 `{countries {Countries}}`
 
+## Reference
+
+[`countries`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-countries) query
+
 ## Example usage
 
 The following query returns all countries listed for the current instance of Magento:
@@ -133,14 +137,6 @@ In this example, the response is intentionally truncated. The `available_regions
   }
 }
 ```
-
-## Output attributes
-
-The query returns an array of `Country` objects.
-
-import CountryOutput from '/src/pages/_includes/graphql/country-output.md'
-
-<CountryOutput />
 
 ## Related topics
 

--- a/src/pages/graphql/schema/store/queries/country.md
+++ b/src/pages/graphql/schema/store/queries/country.md
@@ -14,7 +14,7 @@ Use the [countries](../../store/queries/countries.md) query to retrieve a list o
 
 ## Reference
 
-The [`country`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-country) reference provides detailed information about the types and fields defined in this query.
+The [`country`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-country) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/country.md
+++ b/src/pages/graphql/schema/store/queries/country.md
@@ -14,7 +14,7 @@ Use the [countries](../../store/queries/countries.md) query to retrieve a list o
 
 ## Reference
 
-[`country`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-country) query
+The [`country`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-country) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/country.md
+++ b/src/pages/graphql/schema/store/queries/country.md
@@ -12,6 +12,10 @@ Use the [countries](../../store/queries/countries.md) query to retrieve a list o
 
 `{country(id: String) {Country}}`
 
+## Reference
+
+[`country`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-country) query
+
 ## Example usage
 
 The following query uses a two-letter abbreviation for the country ID (id: "AU"), which returns information about Australia.
@@ -92,22 +96,6 @@ query {
   }
 }
 ```
-
-## Input attributes
-
-The `country` query requires the following input:
-
-Attribute | Data type | Description
---- | --- | ---
-`id` | String | A unique ID for the country
-
-## Output attributes
-
-The query returns a single `Country` object.
-
-import CountryOutput from '/src/pages/_includes/graphql/country-output.md'
-
-<CountryOutput />
 
 ## Related topics
 

--- a/src/pages/graphql/schema/store/queries/currency.md
+++ b/src/pages/graphql/schema/store/queries/currency.md
@@ -12,7 +12,7 @@ Use the `currency` query to return information about the store's currency config
 
 ## Reference
 
-[`currency`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-currency) query
+The [`currency`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-currency) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/currency.md
+++ b/src/pages/graphql/schema/store/queries/currency.md
@@ -10,6 +10,10 @@ Use the `currency` query to return information about the store's currency config
 
 `{currency {Currency}}`
 
+## Reference
+
+[`currency`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-currency) query
+
 ## Example usage
 
 The following query returns currency information for an instance of the application that is configured for multiple currencies, USD and EUR. The default (base) currency for the store is US Dollar (USD). The response includes a list of currencies in the `available_currency_codes` attribute as well as a set of exchange rates.
@@ -60,28 +64,6 @@ query {
   }
 }
 ```
-
-## Output attributes
-
-The `currency` object provides the following attributes:
-
-Attribute | Data type | Description
---- | --- | ---
-`available_currency_codes` | [String] | An array of three-letter currency codes accepted by the store, such as `USD` and `EUR`
-`base_currency_code` | String | The base currency set for the store, such as USD
-`base_currency_symbol` | String | The symbol for the specified base currency, such as $
-`default_display_currency_code` | String | Specifies if the currency code is set as the store's default
-`default_display_currency_symbol` | String | Specifies if the currency symbol is set as the store's default
-`exchange_rates` | [[ExchangeRate]](#exchange-rate-attributes) | An array of exchange rates specified in the store
-
-## Exchange rate attributes
-
-The `ExchangeRate` object provides the following attributes:
-
-Attribute | Data type | Description
---- | --- | ---
-`currency_to` | String | Specifies the store's default currency to exchange to
-`rate` | Float | The exchange rate for the store's default currency
 
 ## Related topics
 

--- a/src/pages/graphql/schema/store/queries/currency.md
+++ b/src/pages/graphql/schema/store/queries/currency.md
@@ -12,7 +12,7 @@ Use the `currency` query to return information about the store's currency config
 
 ## Reference
 
-The [`currency`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-currency) reference provides detailed information about the types and fields defined in this query.
+The [`currency`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-currency) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/dynamic-blocks.md
+++ b/src/pages/graphql/schema/store/queries/dynamic-blocks.md
@@ -49,7 +49,7 @@ dynamicBlocks(
 
 ## Reference
 
-[`dynamic_blocks`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-dynamicBlocks) query
+The [`dynamic_blocks`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-dynamicBlocks) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/dynamic-blocks.md
+++ b/src/pages/graphql/schema/store/queries/dynamic-blocks.md
@@ -28,7 +28,7 @@ Field | Type | Description
 --- | --- | ---
 `audience_id` field | FilterEqualTypeInput | The Audience ID for this block. Available in the `magento/audiences` module only.
 `cart_id` | String | The unique ID that identifies the customer's cart. Available in the `magento2-pwa-commerce` module only.
-`product_uid` | ID | The unique ID of the product currently viewed. Available in the `magento2-pwa-commerce` module only.
+`product_uid` | ID | The unique ID of the currently viewed product. Available in the `magento2-pwa-commerce` module only.
 
 If the `magento/audiences` module is installed, the following field can be returned:
 

--- a/src/pages/graphql/schema/store/queries/dynamic-blocks.md
+++ b/src/pages/graphql/schema/store/queries/dynamic-blocks.md
@@ -30,7 +30,6 @@ Field | Type | Description
 `cart_id` | String | The unique ID that identifies the customer's cart. Available in the `magento2-pwa-commerce` module only.
 `product_uid` | ID | The unique ID of the product currently viewed. Available in the `magento2-pwa-commerce` module only.
 
-
 If the `magento/audiences` module is installed, the following field can be returned:
 
 Field | Type | Description

--- a/src/pages/graphql/schema/store/queries/dynamic-blocks.md
+++ b/src/pages/graphql/schema/store/queries/dynamic-blocks.md
@@ -22,15 +22,34 @@ Widgets defined with the **Specified Dynamic Blocks** option affect CMS page ren
 
 Adobe Commerce and Magento Open Source GraphQL supports the **Display all instead of rotating** rotation mode only.
 
+The following input fields are available only if specialized modules have been installed:
+
+Field | Type | Description
+--- | --- | ---
+`audience_id` field | FilterEqualTypeInput | Audience ID for this block. Available in the `magento/audiences` module only.
+`cart_id` | String | The unique ID that identifies the customer's cart. Available in the `magento2-pwa-commerce` module only.
+`product_uid` | ID | The unique ID of the product currently viewed. Available in the `magento2-pwa-commerce` module only.
+
+
+If the `magento/audiences` module is installed, the following field can be returned:
+
+Field | Type | Description
+--- | --- | ---
+`DynamicBlocks.audience_id` | [ID] | An array of of Audience IDs for this block. Available in the `magento/audiences` module only.
+
 ## Syntax
 
 ```graphql
-dynamic_blocks(
+dynamicBlocks(
     input: DynamicBlocksFilterInput
     pageSize: Int
     currentPage: Int
     ): DynamicBlocks!
 ```
+
+## Reference
+
+[`dynamic_blocks`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-dynamicBlocks) query
 
 ## Example usage
 
@@ -122,42 +141,3 @@ The following code illustrates the definition of the dynamic block with the `uid
   </ul>\n
 </div>
 ```
-
-## Input attributes
-
-Attribute | Data type | Description
---- | --- | ---
-`audience_id` | FilterEqualTypeInput | Audience ID for this block. Available in the `magento/audiences` module only.
-`cart_id` | String | The unique ID that identifies the customer's cart. Available in the `magento2-pwa-commerce` module only.
-`dynamic_block_uids` | [ID] | An array of dynamic block UIDs to filter on
-`locations` | [DynamicBlockLocationEnum] | An array indicating the locations the dynamic block can be placed. The possible values are CONTENT, HEADER, FOOTER, LEFT, and RIGHT. If this attribute is not specified, the query returns all locations
-`product_uid` | ID | The unique ID of the product currently viewed. Available in the `magento2-pwa-commerce` module only.
-`type` | DynamicBlockTypeEnum! | A value indicating the type of dynamic block to filter on. The possible values are CART_PRICE_RULE_RELATED, CATALOG_PRICE_RULE_RELATED, and SPECIFIED
-
-## Output attributes
-
-The `DynamicBlocks` output object contains the following attributes.
-
-Attribute | Data type | Description
---- | --- | ---
-`items` | [DynamicBlock]! | An array containing individual dynamic blocks
-`page_info` | SearchResultPageInfo | Metadata for pagination rendering
-`total_count` | Int! | The number of returned dynamic blocks
-
-### DynamicBlock attributes
-
-The `DynamicBlock` object contains the following attributes.
-
-Attribute | Data type | Description
---- | --- | ---
-`audience_id` | [ID] | An array of of Audience IDs for this block. Available in the `magento/audiences` module only.
-`content` | ComplexTextValue! | Contains the renderable HTML code of the dynamic block
-`uid` | ID! | The unique ID of a DynamicBlock object
-
-### ComplexTextValue attributes
-
-The `DynamicBlock` object contains the following attributes.
-
-Attribute | Data type | Description
---- | --- | ---
-`html` | String! | The HTML content of the dynamic block

--- a/src/pages/graphql/schema/store/queries/index.md
+++ b/src/pages/graphql/schema/store/queries/index.md
@@ -4,7 +4,7 @@ title: Store queries | Commerce Web APIs
 
 # Store queries
 
-The queries in the store schema fetch store configuration data and content blocks. 
+The queries in the store schema fetch store configuration data and content blocks.
 
 - Store configuration
   - [availableStores](available-stores.md)

--- a/src/pages/graphql/schema/store/queries/index.md
+++ b/src/pages/graphql/schema/store/queries/index.md
@@ -3,3 +3,17 @@ title: Store queries | Commerce Web APIs
 ---
 
 # Store queries
+
+The queries in the store schema fetch store configuration data and content blocks. 
+
+- Store configuration
+  - [availableStores](available-stores.md)
+  - [countries](countries.md)
+  - [country](country.md)
+  - [currency](currency.md)
+  - [recaptchaV3Config](recaptch-v3-config.md)
+  - [storeConfig](store-config.md)
+- Content blocks
+  - [cmsBlocks](cms-blocks.md)
+  - [cmsPage](cms-page.md)
+  - [dynamicBlocks](dynamic-blocks.md)

--- a/src/pages/graphql/schema/store/queries/store-config.md
+++ b/src/pages/graphql/schema/store/queries/store-config.md
@@ -12,7 +12,7 @@ The `storeConfig` query defines information about a store's configuration. You c
 
 ## Reference
 
-[`storeConfig`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-storeConfig) query
+The [`storeConfig`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-storeConfig) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/store-config.md
+++ b/src/pages/graphql/schema/store/queries/store-config.md
@@ -10,6 +10,10 @@ The `storeConfig` query defines information about a store's configuration. You c
 
 `storeConfig: StoreConfig`
 
+## Reference
+
+[`storeConfig`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-storeConfig) query
+
 ## Example usage
 
 ### Query a store's configuration
@@ -239,9 +243,3 @@ The following query returns enumeration values that indicate the store's fixed p
   }
 }
 ```
-
-## Output attributes
-
-import StoreConfig from '/src/pages/_includes/graphql/store-config.md'
-
-<StoreConfig />


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the manually maintained reference information from the topics in the `pages/graphql/schema/store`  directory.

The `reCaptchaV3Config` query and `contactUs` mutation are not included in this PR because I can't link to them in the 2.4.6 SpectaQLdocs. They will be addressed in COMDOX-727

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
