### PR TITLE
GraphQL: Remove reference info from Wishlist entities

### DIFF
--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -1130,7 +1130,7 @@ module.exports = [
         ],
       },
       {
-        title: "Wishlist",
+        title: "Wish list",
         path: "/graphql/schema/wishlist/",
         pages: [
           {
@@ -1138,7 +1138,7 @@ module.exports = [
             path: "/graphql/schema/wishlist/queries/",
             pages: [
               {
-                title: "Wishlist",
+                title: "wishlist",
                 path: "/graphql/schema/wishlist/queries/wishlist/",
               },
             ],
@@ -1190,7 +1190,7 @@ module.exports = [
             path: "/graphql/schema/wishlist/interfaces/",
             pages: [
               {
-                title: "Wishlist",
+                title: "WishlistItemInterface",
                 path: "/graphql/schema/wishlist/interfaces/wishlist/",
               },
             ],

--- a/src/pages/graphql/schema/wishlist/index.md
+++ b/src/pages/graphql/schema/wishlist/index.md
@@ -1,5 +1,11 @@
 ---
-title: Wishlist | Commerce Web APIs
+title: Wish list | Commerce Web APIs
 ---
 
-# Wishlist
+# Wish list
+
+Use the wish list mutations to manage wish lists and their contents. `WishlistItemInterface` and its implementations return details about individual items in a wish list.
+
+<InlineAlert variant="info" slots="text" />
+
+The `wishlist` query has been deprecated. Wish list information is now provided by the [customer](../customer/queries/customer.md) query.

--- a/src/pages/graphql/schema/wishlist/interfaces/index.md
+++ b/src/pages/graphql/schema/wishlist/interfaces/index.md
@@ -1,5 +1,7 @@
 ---
-title: Wishlist interfaces | Commerce Web APIs
+title: Wish list interfaces | Commerce Web APIs
 ---
 
-# Wishlist interfaces
+# Wish list interfaces
+
+`WishlistItemInterface` provides details about items in a wish list.

--- a/src/pages/graphql/schema/wishlist/interfaces/wishlist.md
+++ b/src/pages/graphql/schema/wishlist/interfaces/wishlist.md
@@ -6,13 +6,13 @@ title: WishlistItemInterface attributes and implementations | Commerce Web APIs
 
 `WishlistItemInterface` provides details about items in a wish list. It has the following implementations:
 
-*  [`BundleWishlistItem`]
-*  [`ConfigurableWishlistItem`]
-*  [`DownloadableWishlistItem`]
-*  [`GiftCardWishlistItem`]
-*  [`GroupedProductWishlistItem`]
-*  [`SimpleWishlistItem`]
-*  [`VirtualWishlistItem`]
+*  `BundleWishlistItem`
+*  `ConfigurableWishlistItem`
+*  `DownloadableWishlistItem`
+*  `GiftCardWishlistItem`
+*  `GroupedProductWishlistItem`
+*  `SimpleWishlistItem`
+*  `VirtualWishlistItem`
 
 ## Reference
 

--- a/src/pages/graphql/schema/wishlist/interfaces/wishlist.md
+++ b/src/pages/graphql/schema/wishlist/interfaces/wishlist.md
@@ -6,82 +6,17 @@ title: WishlistItemInterface attributes and implementations | Commerce Web APIs
 
 `WishlistItemInterface` provides details about items in a wish list. It has the following implementations:
 
-*  [`BundleWishlistItem`](#bundlewishlistitem-attributes)
-*  [`ConfigurableWishlistItem`](#configurablewishlistitem-attributes)
-*  [`DownloadableWishlistItem`](#downloadablewishlistitem-attributes)
-*  [`GiftCardWishlistItem`](#giftcardwishlistitem-attributes)
-*  [`GroupedProductWishlistItem`](#groupedproductwishlistitem-attributes)
-*  [`SimpleWishlistItem`](#simplewishlistitem-attributes)
-*  [`VirtualWishlistItem`](#virtualwishlistitem-attributes)
+*  [`BundleWishlistItem`]
+*  [`ConfigurableWishlistItem`]
+*  [`DownloadableWishlistItem`]
+*  [`GiftCardWishlistItem`]
+*  [`GroupedProductWishlistItem`]
+*  [`SimpleWishlistItem`]
+*  [`VirtualWishlistItem`]
 
-## Attributes
+## Reference
 
-import WishlistItemInterface from '/src/pages/_includes/graphql/wishlist-item-interface.md'
-
-<WishlistItemInterface />
-
-## Implementations
-
-### BundleWishlistItem attributes
-
-The `BundleWishlistItem` object defines the following bundle-product specific attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`bundle_options` | [SelectedBundleOption!]| An array containing information about the selected bundle items
-
-### ConfigurableWishlistItem attributes
-
-The `ConfigurableWishlistItem` object defines the following attributes that are specific to configurable products:
-
-Attribute | Data type | Description
---- | --- | ---
-`child_sku` | String! | Deprecated. Use `configured_variant` instead. The SKU of the simple product corresponding to a set of selected configurable options
-`configurable_options` | [SelectedConfigurableOption!] | An array of selected configurable options
-`configured_variant` | [ProductInterface](../../products/interfaces/index.md) | Returns details about the selected variant. The value is null if some options are not configured
-
-### DownloadableWishlistItem attributes
-
-The `DownloadableWishlistItem` object defines the following attributes that are specific to downloadable products:
-
-Attribute | Data type | Description
---- | --- | ---
-`links_v2` | [DownloadableProductLinks] | An array containing information about the selected links
-`samples` | [DownloadableProductSamples] | An array containing information about the selected samples
-
-### GiftCardWishlistItem attributes
-
-The `GiftCardWishlistItem` object defines the following gift card-specific attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`gift_card_options` | GiftCardOptions! | Contains details about a gift card product
-
-#### GiftCardOptions attributes
-
-The GiftCardOptions object provides details about a gift card. All attributes are optional for a wish list.
-
-Attribute | Data type | Description
---- | --- | ---
-`amount` | Money | The amount and currency of the gift card
-`custom_giftcard_amount` | Money | The custom amount and currency of the gift card
-`message` | String | A message to the recipient
-`recipient_email` | String | The email of the person receiving the gift card
-`recipient_name` | String | The name of the person receiving the gift card
-`sender_email` | String | The email of the sender
-`sender_name` | String | The name of the sender
-
-### GroupedProductWishlistItem attributes
-
-The GroupedProductWishlistItem data type does not provide additional attributes to the `WishlistItemInterface`.
-
-### SimpleWishlistItem attributes
-
-The SimpleWishlistItem data type does not provide additional attributes to the `WishlistItemInterface`.
-
-### VirtualWishlistItem attributes
-
-The VirtualWishlistItem data type does not provide additional attributes to the `WishlistItemInterface`.
+The [`WishlistItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-WishlistItemInterface) reference provides detailed information about the types and fields defined in this interface.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/mutations/add-items-to-cart.md
+++ b/src/pages/graphql/schema/wishlist/mutations/add-items-to-cart.md
@@ -21,6 +21,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`addWishlistItemsToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-wishlist) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example moves two items from a wishlist to the cart.
@@ -115,41 +119,9 @@ mutation {
 }
 ```
 
-## Input attributes
+## Errors
 
-The `addWishlistItemsToCart` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`wishlistItemIds`| [ID!] | An array of IDs presenting products to be added to the cart. If no IDs are specified, all items in the wish list will be added to the cart
-`wishlistId`| ID! | The unique ID of the wish list
-
-## Output attributes
-
-The `addWishlistItemsToCart` mutation returns the status of the operation as well an array of any errors that occurred.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`add_wishlist_items_to_cart_user_errors` | [[WishlistCartUserInputError!](#wishlistcartuserinputerror-attributes)] | Indicates why the attempt to add items to the wish list was not successful
-`status` | Boolean! | Indicates whether the attempt to add items to the cart was successful
-`wishlist` | [Wishlist!](#wishlist-attributes) | The wish list after moving items to the cart
-
-### Wishlist attributes
-
-import Wishlist from '/src/pages/_includes/graphql/wishlist.md'
-
-<Wishlist />
-
-### WishlistCartUserInputError attributes
-
-The `WishlistCartUserInputError` type contains a list of errors that indicate why the attempt to add items to the cart was not successful.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`code` | [WishlistCartUserInputErrorType!](#WishlistCartUserInputErrorType) | An error code that describes the error encountered.
-`message` | String! | A localized error message
-
-### WishlistCartUserInputErrorType!
+The `WishlistCartUserInputErrorType` field can contain the following values:
 
 Type | Description
 --- | ---

--- a/src/pages/graphql/schema/wishlist/mutations/add-products.md
+++ b/src/pages/graphql/schema/wishlist/mutations/add-products.md
@@ -31,6 +31,10 @@ To determine whether wish lists are enabled, specify the `magento_wishlist_gener
 }
 ```
 
+## Reference
+
+The [`addProductsToWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addProductsToWishlist) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example adds a simple product (`24-MB01`), a configurable product (`WJ01-M-Red`), and a bundle product (`24-WG080`) to the customer's wish list. The SKU `WG-09` is invalid, and error information is returned in the `user_errors` object.
@@ -246,54 +250,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `addProductsToWishlist` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`wishlistId` | ID! | The ID of the customer's wish list
-`wishlistItems`| [[WishlistItemInput(#WishlistItemInput)]!]! | An array containing each product to be added to the wish list
-
-### WishlistItemInput attributes
-
-The `WishlistItemInput` object defines each item to add to the wish list.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`entered_options`| [EnteredOptionInput!] | An array of options that the customer entered
-`parent_sku` | String | For complex product types, the SKU of the parent product
-`quantity` | Float! | The amount or number of items to add
-`selected_options` | [ID] | An array of strings corresponding to options the customer selected
-`sku` | String! | The SKU of the product to add. For complex product types, specify the child product SKU
-
-### EnteredOptionInput attributes
-
-import EnteredOptionInput from '/src/pages/_includes/graphql/entered-option-input.md'
-
-<EnteredOptionInput />
-
-## Output attributes
-
-The `AddProductsToWishlistOutput` object contains the customer's wish list and error message information.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`user_errors` | [[WishListUserInputError!](#wishlistuserinputerror-attributes)] | An array of errors encountered while adding products to a wish list
-`wishlist` | [Wishlist!](#wishlist-attributes) | Contains the wish list with all items that were successfully added
-
-### Wishlist attributes
-
-import Wishlist from '/src/pages/_includes/graphql/wishlist.md'
-
-<Wishlist />
-
-### WishListUserInputError attributes
-
-import WishlistUserInputErrors from '/src/pages/_includes/graphql/wishlist-user-input-errors.md'
-
-<WishlistUserInputErrors />
 
 ## Errors
 

--- a/src/pages/graphql/schema/wishlist/mutations/copy-products.md
+++ b/src/pages/graphql/schema/wishlist/mutations/copy-products.md
@@ -25,6 +25,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`copyProductsBetweenWishlists`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-copyProductsBetweenWishlists) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example copies two items to another wish list.
@@ -146,44 +150,3 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `copyProductsBetweenWishlists` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`destinationWishlistUid` | ID! | The ID of the wishlist to copy products to
-`sourceWishlistUid` | ID! | The ID of the origin wishlist
-`wishlistItems` | [WishlistItemCopyInput!]! | A list of items to be copied
-
-### WishlistItemCopyInput attributes
-
-The WishlistItemCopyInput object contains the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`quantity` | Float | The quantity of this item to move to the destination wish list. This value cannot be greater than the quantity in the source wish list
-`wishlist_item_id` | ID! | The unique ID of the `WishlistItemInterface` object to be copied
-
-## Output attributes
-
-The `CopyProductsBetweenWishlistsOutput` object can contain the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`destination_wishlist` | [Wishlist!](#wishlist-attributes) | The destination wish list containing the copied products
-`source_wishlist` | [Wishlist!](#wishlist-attributes) | The wish list that the products were copied from
-`user_errors` | [[WishListUserInputError!](#wishlistuserinputerror-attributes)] | An array of errors encountered while copying products to a wish list
-
-### Wishlist attributes
-
-import Wishlist from '/src/pages/_includes/graphql/wishlist.md'
-
-<Wishlist />
-
-### WishListUserInputError attributes
-
-import WishlistUserInputErrors from '/src/pages/_includes/graphql/wishlist-user-input-errors.md'
-
-<WishlistUserInputErrors />

--- a/src/pages/graphql/schema/wishlist/mutations/create.md
+++ b/src/pages/graphql/schema/wishlist/mutations/create.md
@@ -27,6 +27,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`createWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createWishlist) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example creates the `My favorites` public wish list.
@@ -64,20 +68,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `CreateWishlistInput` object requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`name` | String! | The ID of the customer's wish list
-`visibility`| WishlistVisibilityEnum! | Describes the visibility of the wish list. Possible values are `PRIVATE` and `PUBLIC`
-
-## Output attributes
-
-The `createWishlist` mutation returns the Wishlist object.
-
-import Wishlist from '/src/pages/_includes/graphql/wishlist.md'
-
-<Wishlist />

--- a/src/pages/graphql/schema/wishlist/mutations/delete.md
+++ b/src/pages/graphql/schema/wishlist/mutations/delete.md
@@ -17,6 +17,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`deleteWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteWishlist) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example deletes a wish list.
@@ -59,26 +63,3 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `deleteWishlist` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`wishlistId` | ID! | The ID of the wish list to delete
-
-## Output attributes
-
-The DeleteWishlistOutput object can contain the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`status` | Boolean! | Indicates whether the wish list was deleted
-`wishlists` | [Wishlist]! | An array of wish lists that have not been deleted
-
-### Wishlist attributes
-
-import Wishlist from '/src/pages/_includes/graphql/wishlist.md'
-
-<Wishlist />

--- a/src/pages/graphql/schema/wishlist/mutations/index.md
+++ b/src/pages/graphql/schema/wishlist/mutations/index.md
@@ -4,4 +4,4 @@ title: Wish list mutations | Commerce Web APIs
 
 # Wish list mutations
 
-The wish list mutations allow you to manage wish lists and their contents. Adobe Commerce allows customers to create multiple wishlists.
+The wish list mutations allow you to manage wish lists and their contents. Adobe Commerce allows customers to create multiple wish lists.

--- a/src/pages/graphql/schema/wishlist/mutations/index.md
+++ b/src/pages/graphql/schema/wishlist/mutations/index.md
@@ -1,5 +1,7 @@
 ---
-title: Wishlist mutations | Commerce Web APIs
+title: Wish list mutations | Commerce Web APIs
 ---
 
-# Wishlist mutations
+# Wish list mutations
+
+The wish list mutations allow you to manage wish lists and their contents. Adobe Commerce allows customers to create multiple wishlists.

--- a/src/pages/graphql/schema/wishlist/mutations/move-products.md
+++ b/src/pages/graphql/schema/wishlist/mutations/move-products.md
@@ -27,6 +27,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`moveProductsBetweenWishlists`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-moveProductsBetweenWishlists) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example moves an item to another wish list. The ID of the moved product changes.
@@ -220,44 +224,3 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `moveProductsBetweenWishlists` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`destinationWishlistUid` | ID! | The ID of the wishlist to move products to
-`sourceWishlistUid` | ID! | The ID of the origin wishlist
-`wishlistItems` | [WishlistItemMoveInput!]! | A list of items to be moved
-
-### WishlistItemMoveInput attributes
-
-The WishlistItemMoveInput object contains the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`quantity` | Float | The quantity of this item to move to the destination wish list. This value cannot be greater than the quantity in the source wish list
-`wishlist_item_id` | ID! | The unique ID of the `WishlistItemInterface` item to be moved
-
-## Output attributes
-
-The `MoveProductsBetweenWishlistsOutput` object can contain the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`destination_wishlist` | [Wishlist!](#wishlist-attributes) | The destination wish list containing the moved products
-`source_wishlist` | [Wishlist!](#wishlist-attributes) | The wish list that the products were moved from
-`user_errors` | [[WishListUserInputError!](#wishlistuserinputerror-attributes)] | An array of errors encountered while copying products in a wish list
-
-### Wishlist attributes
-
-import Wishlist from '/src/pages/_includes/graphql/wishlist.md'
-
-<Wishlist />
-
-### WishListUserInputError attributes
-
-import WishlistUserInputError from '/src/pages/_includes/graphql/wishlist-user-input-errors.md'
-
-<WishlistUserInputError />

--- a/src/pages/graphql/schema/wishlist/mutations/remove-products.md
+++ b/src/pages/graphql/schema/wishlist/mutations/remove-products.md
@@ -21,6 +21,10 @@ mutation {
 }
   ```
 
+## Reference
+
+The [`removeProductsFromWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeProductsFromWishlist) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example removes an item that was added in the [`addProductsToWishlist` mutation](add-products.md) example.
@@ -136,36 +140,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `removeProductsFromWishlist` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`wishlistId` | ID! | The ID of the customer's wish list
-`wishlistItemsIds`| [ID!]! | An array of wish list item IDs to be removed
-
-## Output attributes
-
-The `RemoveProductsFromWishlistOutput` object contains the customer's wish list and error message information.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`user_errors` | [WishListUserInputError!]! | An array of errors encountered while adding products to a wish list
-`wishlist` | Wishlist! | Contains the wish list with all items that were successfully added
-
-### Wishlist attributes
-
-import Wishlist from '/src/pages/_includes/graphql/wishlist.md'
-
-<Wishlist />
-
-### WishListUserInputError attributes
-
-import WishlistUserInputErrors from '/src/pages/_includes/graphql/wishlist-user-input-errors.md'
-
-<WishlistUserInputErrors />
 
 ## Errors
 

--- a/src/pages/graphql/schema/wishlist/mutations/update-products.md
+++ b/src/pages/graphql/schema/wishlist/mutations/update-products.md
@@ -25,6 +25,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`updateProductsInWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateProductsInWishlist) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example changes the quantity of the product represented by wish list item `16` to `2` and adds a description for item `17`.
@@ -286,57 +290,9 @@ mutation {
 }
 ```
 
-## Input attributes
-
-The `updateProductsInWishlist` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`wishlistId` | ID! | The ID of the customer's wish list
-`wishlistItems`| [[WishlistItemUpdateInput!](#wishlistitemupdateinput-attributes)]! | An array containing products to be updated
-
-### WishlistItemUpdateInput attributes
-
-The `WishlistItemUpdateInput` object defines each item to add to the wish list.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`description` | String | Customer-entered comments about the item
-`entered_options`| [EnteredOptionInput] | An array of options that the customer entered
-`quantity` | Float | The amount or number of items to add
-`selected_options` | [ID!] | An array of strings corresponding to options the customer selected
-`wishlist_item_id` | ID! | The ID of the wishlist item to update
-
-### EnteredOptionInput attributes
-
-import EnteredOptionInput from '/src/pages/_includes/graphql/entered-option-input.md'
-
-<EnteredOptionInput />
-
-## Output attributes
-
-The `UpdateProductsInWishlistOutput` object contains the customer's wish list and error message information.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`user_errors` | [WishListUserInputError!]! | An array of errors encountered while adding products to a wish list
-`wishlist` | Wishlist! | Contains the wish list with all items that were successfully added
-
-### Wishlist attributes
-
-import Wishlist from '/src/pages/_includes/graphql/wishlist.md'
-
-<Wishlist />
-
-### WishListUserInputError attributes
-
-import WishlistUserInputErrors from '/src/pages/_includes/graphql/wishlist-user-input-errors.md'
-
-<WishlistUserInputErrors />
-
 ## Errors
 
 Error | Description
 --- | ---
 `The current user cannot perform operations on wishlist` | An unauthorized user (guest) tried to add an item to a wishlist, or an authorized user (customer) tried to add an item to a wishlist of another customer.
-`The wishlist was not found.` | The value provifed in the `wishlistId` field is invalid or does not exist for the customer.
+`The wishlist was not found.` | The value provided in the `wishlistId` field is invalid or does not exist for the customer.

--- a/src/pages/graphql/schema/wishlist/mutations/update.md
+++ b/src/pages/graphql/schema/wishlist/mutations/update.md
@@ -27,6 +27,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`updateWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateWishlist) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example changes the name of an existing wish list.
@@ -60,23 +64,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `updateWishlist` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`name` | String! | The unique ID of `Wishlist` object
-`visibility`| WishlistVisibilityEnum! | Describes the visibility of the wish list. Possible values are `PRIVATE` and `PUBLIC`
-`wishlistUid` | ID! | The ID of the wish list to update
-
-## Output attributes
-
-The `UpdateWishlistOutput` object can contain the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`name` | String! | The wish list name
-`uid` | ID! | The ID of the updated wish list
-`visibility` | WishlistVisibilityEnum! | The wish list visibility. Possible values are `PRIVATE` and `PUBLIC`

--- a/src/pages/graphql/schema/wishlist/queries/index.md
+++ b/src/pages/graphql/schema/wishlist/queries/index.md
@@ -2,4 +2,6 @@
 title: Wishlist | Commerce Web APIs
 ---
 
-# Wishlist
+# Wish list
+
+The `wishlist` query has been deprecated. Wish list information is now provided by the [customer](../../customer/queries/customer.md) query.

--- a/src/pages/graphql/schema/wishlist/queries/wishlist.md
+++ b/src/pages/graphql/schema/wishlist/queries/wishlist.md
@@ -14,6 +14,10 @@ Use the `wishlist` query to retrieve information about a customer's wish list. [
 
 `wishlist: WishlistOutput`
 
+## Reference
+
+The [`wishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-wishlist) reference provides detailed information about the types and fields defined in this query.
+
 ## Example usage
 
 The following query returns the customer's wish list:
@@ -77,23 +81,3 @@ The following query returns the customer's wish list:
   }
 }
 ```
-
-## Output attributes
-
-Attribute | Data type | Description
---- | --- | ---
-`items` | [WishlistItem](#wish-list-item-attributes) | An array of items in the customer's wish list
-`items_count` | Int | The number of items in the wish list
-`name` | String | When multiple wish lists are enabled, the name the customer assigns to the wish list
-`sharing_code` | String | An encrypted code that the application uses to link to the wish list
-`updated_at` | String | The time of the last modification to the wish list
-
-### Wish list item attributes
-
-Attribute | Data type | Description
---- | --- | ---
-`added_at` | String | The time when the customer added the item to the wish list
-`description` | String | The customer's comment about this item
-`id` | Int | The wish list item ID
-`product` | [ProductInterface](../../products/interfaces/index.md) | The ProductInterface contains attributes that are common to all types of products. Note that descriptions may not be available for custom and EAV attributes
-`qty` | Float | The quantity of this wish list item


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the manually maintained reference information from the topics in the pages/graphql/schema/wishlist directory.

Staging build: https://developer-stage.adobe.com/commerce/webapi/graphql/schema/wishlist/

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
