### PR TITLE
GraphQL: Remove reference info from Gift Registry section

### DIFF
--- a/src/pages/graphql/schema/gift-registry/index.md
+++ b/src/pages/graphql/schema/gift-registry/index.md
@@ -4,3 +4,11 @@ edition: ee
 ---
 
 # Gift registry
+
+Once gift registry functionality is enabled and configured from the Admin, customers use the following workflow to create registries:
+
+1. The customer creates a gift registry from their account for an upcoming occasion and completes the required fields in each section of the gift registry. After adding items to the registry, it can be shared with friends and family.
+
+1. The customer shares their registry. A link to the gift registry is included in each invitation. If Gift Registry Search is enabled in the store, shoppers can search for specific gift registries by name, email address, or gift registry ID.
+
+1. Invitation recipients place orders. Those who receive an invitation or information about the registry can place an order for any item directly from the gift registry. As items are sold, Adobe Commerce updates the gift registry item counts, and notifies the gift registry owner.

--- a/src/pages/graphql/schema/gift-registry/mutations/add-registrants.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/add-registrants.md
@@ -22,6 +22,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`addGiftRegistryRegistrants`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addGiftRegistryRegistrants) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example adds a registrant to the specified gift registry.
@@ -77,37 +81,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `addGiftRegistryRegistrants` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`dynamic_attributes` | [[GiftRegistryDynamicAttributeInput](#giftregistrydynamicattributeinput-attributes)] | An array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair
-`email` | String! | The email address of the registrant
-`firstname` | String! | The first name of the registrant
-`lastname` | String! | The last name of the registrant
-
-### GiftRegistryDynamicAttributeInput attributes
-
-The `GiftRegistryDynamicAttributeInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`code` | ID! | A unique key for an additional attribute of the event
-`value` | String! | A corresponding value for the code
-
-## Output attributes
-
-The `AddGiftRegistryRegistrantsOutput` output object contains the following attribute.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`gift_registry` | [GiftRegistry](#giftregistry-attributes) | The gift registry after adding registrants
-
-### GiftRegistry attributes
-
-import GiftRegistry from '/src/pages/_includes/graphql/gift-registry.md'
-
-<GiftRegistry />

--- a/src/pages/graphql/schema/gift-registry/mutations/create.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/create.md
@@ -12,7 +12,7 @@ This mutation requires a valid [customer authentication token](../../customer/mu
 
 The `id` input attribute is optional. If a value is not specified, the application creates one. If you specify a value, then you can create a gift registry and make multiple updates in a single call.
 
-The `dynamic_attributes` input field contains an array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair
+The `dynamic_attributes` input field contains an array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair.
 
 When assigning a shipping address, you must specify only one of `address_data` or `address_id`.
 

--- a/src/pages/graphql/schema/gift-registry/mutations/create.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/create.md
@@ -12,6 +12,8 @@ This mutation requires a valid [customer authentication token](../../customer/mu
 
 The `id` input attribute is optional. If a value is not specified, the application creates one. If you specify a value, then you can create a gift registry and make multiple updates in a single call.
 
+The `dynamic_attributes` input field contains an array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair
+
 When assigning a shipping address, you must specify only one of `address_data` or `address_id`.
 
 Only the gift registry owner can view the following output attributes:
@@ -32,6 +34,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`createGiftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createGiftRegistry) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -199,65 +205,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `CreateGiftRegistryInput` input object defines the gift registry.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`dynamic_attributes` | [[GiftRegistryDynamicAttributeInput](#giftregistrydynamicattributeinput-attributes)] | An array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair
-`event_name` | String! | The name of the event
-`gift_registry_type_uid` | ID! | The ID of the selected event type
-`message` | String! | A message describing the event
-`privacy_settings` | GiftRegistryPrivacySettings! | Indicates whether the registry is PRIVATE or PUBLIC
-`registrants` | [[AddGiftRegistryRegistrantInput!](#addgiftregistryregistrantinput-attributes)]! | The list of people who receive notifications about the registry
-`shipping_address` | [GiftRegistryShippingAddressInput](#giftregistryshippingaddressinput-attributes) | The address for shipping the gift registry. Specify either the `address_data` object or the `address_id` attribute. Validation fails if both are provided
-`status` | GiftRegistryStatus! | An enum that states whether the gift registry is ACTIVE or INACTIVE. Only the registry owner can access this attribute
-
-### AddGiftRegistryRegistrantInput attributes
-
-The `AddGiftRegistryRegistrantInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`dynamic_attributes` | [[GiftRegistryDynamicAttributeInput](#giftregistrydynamicattributeinput-attributes)] | An array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair
-`email` | String! | The email address of the registrant
-`firstname` | String! | The first name of the registrant
-`lastname` | String! | The last name of the registrant
-
-### GiftRegistryDynamicAttributeInput attributes
-
-The `GiftRegistryDynamicAttributeInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`code` | ID! | A unique key for an additional attribute of the event
-`value` | String! | A corresponding value for the code
-
-### GiftRegistryShippingAddressInput attributes
-
-The `GiftRegistryShippingAddressInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`address_data` | CustomerAddressInput | The complete details of the shipping address
-`address_id` | ID | The ID of predefined customer address
-
-import CustomerAddressInput from '/src/pages/_includes/graphql/customer-address-input-24.md'
-
-<CustomerAddressInput />
-
-## Output attributes
-
-The `CreateGiftRegistryOutput` output object contains the following attribute:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`gift_registry` | [GiftRegistry](#giftregistry-attributes) | Contains the created gift registry
-
-### GiftRegistry attributes
-
-import GiftRegistry from '/src/pages/_includes/graphql/gift-registry.md'
-
-<GiftRegistry />

--- a/src/pages/graphql/schema/gift-registry/mutations/index.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/index.md
@@ -4,4 +4,4 @@ title: Gift registry mutations | Commerce Web APIs
 
 # Gift registry mutations
 
-Use the gift registry mutations to create and manage gift registries and their contents. The `shareGiftRegistry` mutation sends an invitation to a list email addresses to shop from the customer's gift registry. All mutations require a customer authentication token.
+Use the gift registry mutations to create and manage gift registries and their contents. The `shareGiftRegistry` mutation sends an invitation to a list of email addresses to shop from the customer's gift registry. All mutations require a customer authentication token.

--- a/src/pages/graphql/schema/gift-registry/mutations/index.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/index.md
@@ -3,3 +3,5 @@ title: Gift registry mutations | Commerce Web APIs
 ---
 
 # Gift registry mutations
+
+Use the gift registry mutations to create and manage gift registries and their contents. The `shareGiftRegistry` mutation sends an invitation to a list email addresses to shop from the customer's gift registry. All mutations require a customer authentication token.

--- a/src/pages/graphql/schema/gift-registry/mutations/move-cart-items.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/move-cart-items.md
@@ -24,6 +24,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`moveCartItemsToGiftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-moveCartItemsToGiftRegistry) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example moves all items from the cart to a gift registry.
@@ -93,34 +97,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `moveCartItemsToGiftRegistry` mutation requires the following input:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`cartUid` | ID! | The unique ID that identifies the customer's cart
-`giftRegistryUid` | ID! | The unique ID of a `GiftRegistry` object
-
-## Output attributes
-
-The `MoveCartItemsToGiftRegistryOutput` object can contain the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`gift_registry` | [GiftRegistry!](#giftregistry-attributes) | The gift registry containing the moved items
-`status` | Boolean! | Indicates whether the attempt to move the cart items to the gift registry was successful
-`user_errors` | [[GiftRegistryItemsUserError!](#giftregistryitemsusererror-attributes)] | An array of errors encountered while moving items from the cart to the gift registry
-
-### GiftRegistry attributes
-
-import GiftRegistry from '/src/pages/_includes/graphql/gift-registry.md'
-
-<GiftRegistry />
-
-### GiftRegistryItemsUserError attributes
-
-import GiftRegistryItemsUserError from '/src/pages/_includes/graphql/gift-registry-items-user-error.md'
-
-<GiftRegistryItemsUserError />

--- a/src/pages/graphql/schema/gift-registry/mutations/remove-items.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/remove-items.md
@@ -22,6 +22,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`removeGiftRegistryItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftRegistryItems) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example removes an item from the specified gift registry.
@@ -74,26 +78,3 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `removeGiftRegistryItems` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`giftRegistryUid` | ID! | The unique ID of a `GiftRegistry` object
-`itemsUid` | [ID!]! | An array of item IDs to remove
-
-## Output attributes
-
-The `RemoveGiftRegistryItemsOutput` output object contains the following attribute.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`gift_registry` | [GiftRegistry](#giftregistry-attributes) | The gift registry after removing items
-
-### GiftRegistry attributes
-
-import GiftRegistry from '/src/pages/_includes/graphql/gift-registry.md'
-
-<GiftRegistry />

--- a/src/pages/graphql/schema/gift-registry/mutations/remove-registrants.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/remove-registrants.md
@@ -22,6 +22,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`removeGiftRegistryRegistrants`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftRegistryRegistrants) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example removes a registrant from the specified gift registry.
@@ -68,26 +72,3 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `removeGiftRegistryRegistrants` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`giftRegistryRegistrantUid` | ID! | The unique ID of a `giftRegistryRegistrant` object
-`registrantsUid` | [ID!]! | An array of registrant IDs to remove
-
-## Output attributes
-
-The `RemoveGiftRegistryRegistrantsOutput` output object contains the following attribute.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`gift_registry` | [GiftRegistry](#giftregistry-attributes) | The gift registry after adding registrants
-
-### GiftRegistry attributes
-
-import GiftRegistry from '/src/pages/_includes/graphql/gift-registry.md'
-
-<GiftRegistry />

--- a/src/pages/graphql/schema/gift-registry/mutations/remove.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/remove.md
@@ -15,6 +15,10 @@ This mutation requires a valid [customer authentication token](../../customer/mu
 removeGiftRegistry ( giftRegistryUid ID! ) RemoveGiftRegistryOutput
 ```
 
+## Reference
+
+The [`removeGiftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftRegistry) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example deletes the specified gift registry.
@@ -40,19 +44,3 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `removeGiftRegistry` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`giftRegistryUid` | ID! | The unique ID of the gift registry to update
-
-## Output attributes
-
-The `RemoveGiftRegistryOutput` output object contains the following attribute:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`success` | Boolean! | Indicates whether the gift registry was successfully deleted

--- a/src/pages/graphql/schema/gift-registry/mutations/share.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/share.md
@@ -24,6 +24,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`shareGiftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-shareGiftRegistry) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example creates a gift registry.
@@ -64,39 +68,3 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `shareGiftRegistry` mutation requires the following input attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`giftRegistryUid`| ID! | The unique ID of the gift registry to be shared
-`invitees`| [[ShareGiftRegistryInviteeInput!](#sharegiftregistryinviteeinput-attributes)]! | A list of people invited to participate in the event
-`sender`| [ShareGiftRegistrySenderInput!](#sharegiftregistrysenderinput-attributes) | Information about the invitation sender
-
-### ShareGiftRegistrySenderInput attributes
-
-The `ShareGiftRegistrySenderInput` object contains the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`message` | String! | A brief message from the sender
-`name`| String! | The name of the sender
-
-### ShareGiftRegistryInviteeInput attributes
-
-The `ShareGiftRegistryInviteeInput` object contains the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`email` | String! | The email address of the invitee
-`name`| String! | Name of the invitee
-
-## Output attributes
-
-The `ShareGiftRegistryOutput` object contains the following attribute.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`is_shared` | Boolean! | Indicates whether the gift registry was successfully shared

--- a/src/pages/graphql/schema/gift-registry/mutations/update-items.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/update-items.md
@@ -22,6 +22,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`updateGiftRegistryItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateGiftRegistryItems) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example changes the quantity and description of an item in a gift registry
@@ -84,34 +88,3 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `updateGiftRegistryItems` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`giftRegistryUid` | ID! | The unique ID of a `GiftRegistry` object
-`items`| [[UpdateGiftRegistryItemInput!]!](#updategiftregistryiteminput-attributes) | An array of items to update
-
-### UpdateGiftRegistryItemInput attributes
-
-Attribute |  Data Type | Description
---- | --- | ---
-`gift_registry_item_uid` | ID! | The unique ID of a `giftRegistryItem` object
-`note` |String | The updated description of the item
-`quantity` | Float! | The updated quantity of the gift registry item
-
-## Output attributes
-
-The `UpdateGiftRegistryItemsOutput` output object contains the following attribute.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`gift_registry` | [GiftRegistry](#giftregistry-attributes) | The gift registry after updating items
-
-### GiftRegistry attributes
-
-import GiftRegistry from '/src/pages/_includes/graphql/gift-registry.md'
-
-<GiftRegistry />

--- a/src/pages/graphql/schema/gift-registry/mutations/update-registrants.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/update-registrants.md
@@ -22,6 +22,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`updateGiftRegistryRegistrants`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateGiftRegistryRegistrants) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example updates a registrant's e-mail address.
@@ -78,47 +82,3 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `updateGiftRegistryRegistrants` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`giftRegistryRegistrantUid` | ID! | The unique ID of a `giftRegistryRegistrant` object
-`registrants` | [UpdateGiftRegistryRegistrantInput!]! | An array of registrants to update
-
-### UpdateGiftRegistryRegistrantInput attributes
-
-The `UpdateGiftRegistryRegistrantInput` object can contain the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`dynamic_attributes` | [[GiftRegistryDynamicAttributeInput](#giftregistrydynamicattributeinput-attributes)] | As a result of the update, only the values of provided attributes will be affected. If the attribute is missing in the request, its value will not be changed
-`email` | String | The updated email address of the registrant
-`firstname` | String | The updated first name of the registrant
-`giftRegistryRegistrantUid` | ID! | The unique ID of a `giftRegistryRegistrant` object
-`lastname` | String | The updated last name of the registrant
-
-### GiftRegistryDynamicAttributeInput attributes
-
-The `GiftRegistryDynamicAttributeInput` object can contain the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`code` | ID! | A unique key for an additional attribute of the event
-`value` | String! | A corresponding value for the code
-
-## Output attributes
-
-The `UpdateGiftRegistryRegistrantsOutput` output object contains the following attribute.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`gift_registry` | [GiftRegistry](#giftregistry-attributes) | The gift registry after updating registrants
-
-### GiftRegistry attributes
-
-import GiftRegistry from '/src/pages/_includes/graphql/gift-registry.md'
-
-<GiftRegistry />

--- a/src/pages/graphql/schema/gift-registry/mutations/update.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/update.md
@@ -9,6 +9,8 @@ The `updateGiftRegistry` mutation modifies properties of specified gift registry
 
 This mutation requires a valid [customer authentication token](../../customer/mutations/generate-token.md).
 
+The `dynamic_attributes` input field contains an array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair
+
 ## Syntax
 
 ```graphql
@@ -21,6 +23,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`updateGiftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateGiftRegistry) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -96,63 +102,3 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `updateGiftRegistry` mutation requires the following input objects.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`giftRegistryUid` | ID! | The unique ID of the gift registry to update
-`giftRegistry` | [UpdateGiftRegistryInput!](#updategiftregistryinput-attributes) | Defines the attributes to be updated.
-
-### UpdateGiftRegistryInput attributes
-
-The `UpdateGiftRegistryInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`dynamic_attributes` | [[GiftRegistryDynamicAttributeInput](#giftregistrydynamicattributeinput-attributes)] | An array of attributes that define elements of the gift registry. Each attribute is specified as a code-value pair
-`event_name` | String | The name of the event
-`message` | String | A message describing the event
-`privacy_settings` | GiftRegistryPrivacySettings! | Indicates whether the registry is PRIVATE or PUBLIC
-`shipping_address` | [GiftRegistryShippingAddressInput](#giftregistryshippingaddressinput-attributes) | The address for shipping the gift registry. Specify either the `address_data` object or the `address_id` attribute. Validation fails if both are provided
-`status` | GiftRegistryStatus | An enum that states whether the gift registry is ACTIVE or INACTIVE. Only the registry owner can access this attribute
-
-### GiftRegistryDynamicAttributeInput attributes
-
-The `GiftRegistryDynamicAttributeInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`code` | ID! | A unique key for an additional attribute of the event
-`value` | String! | A corresponding value for the code
-
-### GiftRegistryShippingAddressInput attributes
-
-The `GiftRegistryShippingAddressInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`address_data` | [CustomerAddressInput](#customeraddressinput-attributes) | The complete details of the shipping address
-`address_id` | ID | The ID of a pre-defined customer address
-
-### CustomerAddressInput attributes
-
-import CustomerAddressInput from '/src/pages/_includes/graphql/customer-address-input-24.md'
-
-<CustomerAddressInput />
-
-## Output attributes
-
-The `UpdateGiftRegistryOutput` output object contains the following attribute:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`gift_registry` | [GiftRegistry](#giftregistry-attributes) | Contains the updated gift registry
-
-### GiftRegistry attributes
-
-import GiftRegistry from '/src/pages/_includes/graphql/gift-registry.md'
-
-<GiftRegistry />

--- a/src/pages/graphql/schema/gift-registry/queries/email-search.md
+++ b/src/pages/graphql/schema/gift-registry/queries/email-search.md
@@ -13,6 +13,10 @@ The `giftRegistryEmailSearch` query returns a list of gift registries that match
 giftRegistryEmailSearch(email: String!): [GiftRegistrySearchResult]
 ```
 
+## Reference
+
+The [`giftRegistryEmailSearch`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryEmailSearch) reference provides detailed information about the types and fields defined in this query.
+
 ## Example usage
 
 The following example returns details about gift registries in which `staceyg@example.com` is a registrant.
@@ -48,17 +52,3 @@ query{
   }
 }
 ```
-
-## Input attributes
-
-The `giftRegistryEmailSearch` query requires the `email` attribute as input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`email` | String | The registrant's email address
-
-## Output attributes
-
-import GiftRegistrySearchResult from '/src/pages/_includes/graphql/gift-registry-search-result.md'
-
-<GiftRegistrySearchResult />

--- a/src/pages/graphql/schema/gift-registry/queries/gift-registry.md
+++ b/src/pages/graphql/schema/gift-registry/queries/gift-registry.md
@@ -16,6 +16,10 @@ This query requires a valid [customer authentication token](../../customer/mutat
 giftRegistry(uid: ID!): GiftRegistry
 ```
 
+## Reference
+
+The [`giftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistry) reference provides detailed information about the types and fields defined in this query.
+
 ## Example usage
 
 The following example returns information about the gift registry with the ID of 1.
@@ -194,17 +198,3 @@ query{
   }
 }
 ```
-
-## Input attributes
-
-The `giftRegistry` query requires the gift registry ID.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`uid` | ID! | The unique ID assigned to the gift registry
-
-## Output attributes
-
-import GiftRegistry from '/src/pages/_includes/graphql/gift-registry.md'
-
-<GiftRegistry />

--- a/src/pages/graphql/schema/gift-registry/queries/id-search.md
+++ b/src/pages/graphql/schema/gift-registry/queries/id-search.md
@@ -13,6 +13,10 @@ The `giftRegistryIdSearch` query returns a list of gift registries that match th
 giftRegistryIdSearch(giftRegistryUid: String!): [GiftRegistrySearchResult]
 ```
 
+## Reference
+
+The [`giftRegistryIdSearch`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryIdSearch) reference provides detailed information about the types and fields defined in this query.
+
 ## Example usage
 
 The following example returns details about the specified gift registry.
@@ -48,17 +52,3 @@ query{
   }
 }
 ```
-
-## Input attributes
-
-The `giftRegistryIdSearch` query requires the `giftRegistryUid` attribute as input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`giftRegistryUid` | ID! | The unique ID of the gift registry to search for
-
-## Output attributes
-
-import GiftRegistrySearchResult from '/src/pages/_includes/graphql/gift-registry-search-result.md'
-
-<GiftRegistrySearchResult />

--- a/src/pages/graphql/schema/gift-registry/queries/index.md
+++ b/src/pages/graphql/schema/gift-registry/queries/index.md
@@ -3,3 +3,5 @@ title: Gift registry queries | Commerce Web APIs
 ---
 
 # Gift registry queries
+
+The `giftRegistry` query retrieves details about the specified gift registry and requires a customer authentication token. All other queries in this category can be used by guests and customers to find gift registries.

--- a/src/pages/graphql/schema/gift-registry/queries/type-search.md
+++ b/src/pages/graphql/schema/gift-registry/queries/type-search.md
@@ -17,6 +17,10 @@ giftRegistryTypeSearch(
 ): [GiftRegistrySearchResult]
 ```
 
+## Reference
+
+The [`giftRegistryTypeSearch`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryTypeSearch) reference provides detailed information about the types and fields defined in this query.
+
 ## Example usage
 
 The following example returns all gift registries in which the specified person is a registrant.
@@ -52,19 +56,3 @@ query{
   }
 }
 ```
-
-## Input attributes
-
-The `giftRegistryTypeSearch` query accepts the following input attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`firstName` | String! | The first name of the registrant
-`lastName` | String! | The last name of the registrant
-`giftRegistryTypeUid` | String | The type UID of the registry
-
-## Output attributes
-
-import GiftRegistrySearchResult from '/src/pages/_includes/graphql/gift-registry-search-result.md'
-
-<GiftRegistrySearchResult />

--- a/src/pages/graphql/schema/gift-registry/queries/types.md
+++ b/src/pages/graphql/schema/gift-registry/queries/types.md
@@ -15,6 +15,10 @@ The `giftRegistryTypes` query returns a list of available gift registry types.
 giftRegistryTypes: [GiftRegistryType]
 ```
 
+## Reference
+
+The [`giftRegistryTypes`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryTypes) reference provides detailed information about the types and fields defined in this query.
+
 ## Example usage
 
 The following example returns information about the list of available gift registry types.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the manually maintained reference information from the topics in the `pages/graphql/schema/gift-registry` directory.

Staging build: https://developer-stage.adobe.com/commerce/webapi/graphql/schema/gift-registry/

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
