### PR TITLE
LYNX-194: Add note to AttributesForm

### DIFF
--- a/src/pages/graphql/schema/attributes/queries/attributes-form.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-form.md
@@ -12,6 +12,8 @@ The `attributesForm` query retrieves EAV attributes associated with customer and
 
 These forms are visible when using the Admin to create or edit a customer or customer address address (**Stores** > Attributes > **Customer** or **Customer Address**).
 
+**Note:** For `region_id` and `country_id` attributes information use queries available in the `DirectoryGraphQl` module.
+
 The following table maps the display names of the applicable forms to values that you can specify as a `formCode` value.
 
 | Type | Display name | `formCode` value |


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates documentation for `AttributesForm` query, adding a note referencing `DirectoryGraphQl` as the right place with queries to retrieve information for regions and countries.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- src/pages/graphql/schema/attributes/queries/attributes-form.md
