### PR TITLE
GraphQL: Remove reference info from Orders section

### DIFF
--- a/src/pages/graphql/schema/orders/index.md
+++ b/src/pages/graphql/schema/orders/index.md
@@ -4,3 +4,5 @@ description:
 ---
 
 # Orders
+
+The Orders mutations primarily manage returns, although the [`reorderItems` mutation](mutations/reorder-items.md) enables a customer to place the contents of a previous order into their cart. The interfaces allow you to access details about a customer's order history.

--- a/src/pages/graphql/schema/orders/interfaces/credit-memo-item.md
+++ b/src/pages/graphql/schema/orders/interfaces/credit-memo-item.md
@@ -6,60 +6,14 @@ title: CreditMemoItemInterface attributes and implementations | Commerce Web API
 
 `CreditMemoItemInterface` provides details about items in a customer's order history that were refunded. It has the following implementations:
 
-*  [`BundleCreditMemoItem`](#bundlecreditmemoitem-attributes)
-*  [`CreditMemoItem`](#creditmemoitem-attributes)
-*  [`DownloadableCreditMemoItem`](#downloadablecreditmemoitem-attributes)
-*  [`GiftCardCreditMemoItem`](#giftcardcreditmemoitem-attributes)
+*  `BundleCreditMemoItem`
+*  `CreditMemoItem`
+*  `DownloadableCreditMemoItem`
+*  `GiftCardCreditMemoItem`
 
-## Attributes
+## Reference
 
-The `CreditMemoItemInterface` describes a specific credit memo.
-
-import CreditMemoItemInterface from '/src/pages/_includes/graphql/credit-memo-item-interface.md'
-
-<CreditMemoItemInterface />
-
-## Implementations
-
-### BundleCreditMemoItem attributes
-
-The `BundleCreditMemoItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`bundle_options` | [[ItemSelectedBundleOption]](#itemselectedbundleoption-attributes) | A list of bundle options that are assigned to the bundle product
-
-import ItemSelectedBundleOption from '/src/pages/_includes/graphql/item-selected-bundle-option.md'
-
-<ItemSelectedBundleOption />
-
-### CreditMemoItem attributes
-
-The `CreditMemoItem` object does not introduce any additional attributes to `CreditMemoItemInterface`.
-
-### DownloadableCreditMemoItem attributes
-
-The `DownloadableCreditMemoItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`downloadable_links` | [[DownloadableItemsLinks]](#downloadableitemslinks-attributes) | A list of downloadable links that were refunded from the downloadable product
-
-import DownloadableItemsLinks from '/src/pages/_includes/graphql/downloadable-items-links.md'
-
-<DownloadableItemsLinks />
-
-### GiftCardCreditMemoItem attributes
-
-The `GiftCardCreditMemoItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`gift_card` | [GiftCardItem](#giftcarditem-attributes) | Selected gift card properties for an order item
-
-import GiftCardItem from '/src/pages/_includes/graphql/gift-card-item.md'
-
-<GiftCardItem />
+The [`CreditMemoItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CreditMemoItemInterface) reference provides detailed information about the types and fields defined in this interface.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/interfaces/index.md
+++ b/src/pages/graphql/schema/orders/interfaces/index.md
@@ -3,3 +3,10 @@ title: Order interfaces | Commerce Web APIs
 ---
 
 # Orders interfaces
+
+Use the following interfaces to return details about customer orders:
+
+* [CreditMemoItemInterface](credit-memo-item.md)
+* [InvoiceItemInterface](invoice-item.md)
+* [OrderItemInterface](order-item.md)
+* [ShipmentItemInterface](shipment-item.md)

--- a/src/pages/graphql/schema/orders/interfaces/invoice-item.md
+++ b/src/pages/graphql/schema/orders/interfaces/invoice-item.md
@@ -6,60 +6,14 @@ title: InvoiceItemInterface attributes and implementations | Commerce Web APIs
 
 `InvoiceItemInterface` provides details about items in a customer's order history that were invoiced. It has the following implementations:
 
-*  [`BundleInvoiceItem`](#bundleinvoiceitem-attributes)
-*  [`DownloadableInvoiceItem`](#downloadableinvoiceitem-attributes)
-*  [`GiftCardInvoiceItem`](#giftcardinvoiceitem-attributes)
-*  [`InvoiceItem`](#invoiceitem-attributes)
+*  `BundleInvoiceItem`
+*  `DownloadableInvoiceItem`
+*  `GiftCardInvoiceItem`
+*  `InvoiceItem`
 
-## Attributes
+## Reference
 
-The `InvoiceItemInterface` describes a specific invoice.
-
-import InvoiceItemInterface from '/src/pages/_includes/graphql/invoice-item-interface.md'
-
-<InvoiceItemInterface />
-
-## Implementations
-
-### BundleInvoiceItem attributes
-
-The `BundleInvoiceItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`bundle_options` | [[ItemSelectedBundleOption]](#itemselectedbundleoption-attributes) | A list of bundle options that are assigned to the bundle product
-
-import ItemSelectedBundleOption from '/src/pages/_includes/graphql/item-selected-bundle-option.md'
-
-<ItemSelectedBundleOption />
-
-### DownloadableInvoiceItem attributes
-
-The `DownloadableInvoiceItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`downloadable_links` | [[DownloadableItemsLinks]](#downloadableitemslinks-attributes) | A list of downloadable links from the invoiced downloadable product
-
-import DownloadableItemsLinks from '/src/pages/_includes/graphql/downloadable-items-links.md'
-
-<DownloadableItemsLinks />
-
-### GiftCardInvoiceItem attributes
-
-The `GiftCardInvoiceItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`gift_card` | [GiftCardItem](#giftcarditem-attributes) | Selected gift card properties for an invoiced item
-
-import GiftCardItem from '/src/pages/_includes/graphql/gift-card-item.md'
-
-<GiftCardItem />
-
-### InvoiceItem attributes
-
-The `InvoiceItem` object does not introduce any additional attributes to `InvoiceItemInterface`.
+The [`InvoiceItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-InvoiceItemInterface) reference provides detailed information about the types and fields defined in this interface.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/interfaces/order-item.md
+++ b/src/pages/graphql/schema/orders/interfaces/order-item.md
@@ -6,58 +6,14 @@ title: OrderItemInterface attributes and implementations | Commerce Web APIs
 
 `OrderItemInterface` provides details about items in a customer's order history. It has the following implementations:
 
-*  [`OrderItem`](#orderitem-attributes)
-*  [`BundleOrderItem`](#bundleorderitem-attributes)
-*  [`DownloadableOrderItem`](#downloadableorderitem-attributes)
-*  [`GiftCardOrderItem`](#giftcardorderitem-attributes)
+*  `OrderItem`
+*  `BundleOrderItem`
+*  `DownloadableOrderItem`
+*  `GiftCardOrderItem`
 
-## Attributes
+## Reference
 
-import OrderItemInterface from '/src/pages/_includes/graphql/order-item-interface.md'
-
-<OrderItemInterface />
-
-## Implementations
-
-### OrderItem attributes
-
-The `OrderItem` object does not introduce any additional attributes to `OrderItemInterface`.
-
-### BundleOrderItem attributes
-
-The `BundleOrderItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`bundle_options` | [[ItemSelectedBundleOption]](#itemselectedbundleoption-attributes) | A list of bundle options that are assigned to the bundle product
-
-import ItemSelectedBundleOption from '/src/pages/_includes/graphql/item-selected-bundle-option.md'
-
-<ItemSelectedBundleOption />
-
-### DownloadableOrderItem attributes
-
-The `DownloadableOrderItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`downloadable_links` | [[DownloadableItemsLinks]](#downloadableorderitem-attributes) | A list of downloadable links that were ordered from the downloadable product
-
-import DownloadableItemsLinks from '/src/pages/_includes/graphql/downloadable-items-links.md'
-
-<DownloadableItemsLinks />
-
-### GiftCardOrderItem attributes
-
-The `GiftCardOrderItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`gift_card` | [GiftCardItem](#giftcardorderitem-attributes) | Selected gift card properties for an order item
-
-import GiftCardItem from '/src/pages/_includes/graphql/gift-card-item.md'
-
-<GiftCardItem />
+The [`OrderItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-OrderItemInterface) reference provides detailed information about the types and fields defined in this interface.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/interfaces/shipment-item.md
+++ b/src/pages/graphql/schema/orders/interfaces/shipment-item.md
@@ -6,47 +6,13 @@ title: ShipmentItemInterface attributes and implementations | Commerce Web APIs
 
 `ShipmentItemInterface` provides details about items in a customer's order history that were shipped. It has the following implementations:
 
-*  [`BundleShipmentItem`](#bundleshipmentitem-attributes)
-*  [`GiftCardShipmentItem`](#giftcardshipmentitem-attributes)
-*  [`ShipmentItem`](#shipmentitem-attributes)
+*  `BundleShipmentItem`
+*  `GiftCardShipmentItem`
+*  `ShipmentItem`
 
-## Attributes
+## Reference
 
-The `ShipmentItemInterface` describes a specific shipmemt.
-
-import ShipmentItemInterface from '/src/pages/_includes/graphql/shipment-item-interface.md'
-
-<ShipmentItemInterface />
-
-## Implementations
-
-### BundleShipmentItem attributes
-
-The `BundleShipmentItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`bundle_options` | [[ItemSelectedBundleOption]](#itemselectedbundleoption-attributes) | A list of bundle options that are assigned to the bundle product
-
-import ItemSelectedBundleOption from '/src/pages/_includes/graphql/item-selected-bundle-option.md'
-
-<ItemSelectedBundleOption />
-
-### GiftCardShipmentItem attributes
-
-The `GiftCardShipmentItem` object defines the following attribute:
-
-Attribute | Data type | Description
---- | --- | ---
-`gift_card` | [GiftCardItem](#giftcardshipmentitem-attributes) | Selected properties for a shipped gift card
-
-import GiftCardItem from '/src/pages/_includes/graphql/gift-card-item.md'
-
-<GiftCardItem />
-
-### ShipmentItem attributes
-
-The `ShipmentItem` object does not introduce any additional attributes to `ShipmentItemInterface`.
+The [`ShipmentItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-ShipmentItemInterface) reference provides detailed information about the types and fields defined in this interface.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/mutations/add-return-comment.md
+++ b/src/pages/graphql/schema/orders/mutations/add-return-comment.md
@@ -14,6 +14,10 @@ mutation: {
 }
 ```
 
+## Reference
+
+The [`addReturnComment`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addReturnComment) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example adds a comment in response to the merchant.
@@ -75,29 +79,6 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `AddReturnCommentInput` object must contain the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`comment_text` | String! | The text added to the return request
-`return_uid` | ID! | The unique ID of a `Return` object
-
-## Output attributes
-
-The `AddReturnCommentOutput` object contains the `Return` object.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`return` | Return | Contains details about the modified return
-
-### Return object
-
-import Return from '/src/pages/_includes/graphql/return.md'
-
-<Return />
 
 ## Related topics
 

--- a/src/pages/graphql/schema/orders/mutations/add-return-tracking.md
+++ b/src/pages/graphql/schema/orders/mutations/add-return-tracking.md
@@ -14,6 +14,10 @@ mutation: {
 }
 ```
 
+## Reference
+
+The [`addReturnTracking`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addReturnTracking) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example adds the shipping carrier and a tracking number for the specified return request.
@@ -57,31 +61,6 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `AddReturnTrackingInput` object must contain the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`carrier_uid`| ID! | The unique ID of a `ReturnShippingCarrier` object
-`return_uid` | ID! | The unique ID of a `Return` object
-`tracking_number` | String! | The shipping tracking number for this return request
-
-## Output attributes
-
-The `AddReturnTrackingOutput` object contains the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`return` | [Return](#return-object) | Contains details about the modified return
-`return_shipping_tracking` | [ReturnShippingTracking](#returnshippingtracking-attributes) | Contains details about shipping for a return
-
-### Return object
-
-import Return from '/src/pages/_includes/graphql/return.md'
-
-<Return />
 
 ## Related topics
 

--- a/src/pages/graphql/schema/orders/mutations/index.md
+++ b/src/pages/graphql/schema/orders/mutations/index.md
@@ -3,3 +3,5 @@ title: Order mutations | Commerce Web APIs
 ---
 
 # Orders mutations
+
+With the exception of the [`reorderItems` mutation](reorder-items.md), the Orders mutations create and manage returns (RMAs). Use the [`requestReturn` mutation](request-return.md) to initiate an RMA. You can subsequently add or remove shipment tracking information or add a comment to the RMA.

--- a/src/pages/graphql/schema/orders/mutations/remove-return-tracking.md
+++ b/src/pages/graphql/schema/orders/mutations/remove-return-tracking.md
@@ -14,6 +14,10 @@ mutation: {
 }
 ```
 
+## Reference
+
+The [`removeReturnTracking`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeReturnTracking) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example removes customer-entered tracking information for the specified return request. In the response, the `shipping` object is empty because the tracking information has been deleted.
@@ -76,28 +80,6 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `RemoveReturnTrackingInput` object must contain the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`return_shipping_tracking_uid` | ID! | The encoded ID of the tracking item to delete
-
-## Output attributes
-
-The `RemoveReturnTrackingOutput` object contains the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`return` | [Return](#return-object) | Contains details about the modified return
-
-### Return object
-
-import Return from '/src/pages/_includes/graphql/return.md'
-
-<Return />
 
 ## Related topics
 

--- a/src/pages/graphql/schema/orders/mutations/reorder-items.md
+++ b/src/pages/graphql/schema/orders/mutations/reorder-items.md
@@ -4,7 +4,7 @@ title: reorderItems mutation | Commerce Web APIs
 
 # reorderItems mutation
 
-The `reorderItems` mutation allows a logged-in user to add all the products from a previous order into their cart. The **Stores** > Settings > **Sales** > **Sales** > **Reorder** > **Allow Reorder** field must be set to **Yes** to enable reorders. You must provide a customer authorization token with the call.
+The `reorderItems` mutation allows a logged-in user to add all the products from a previous order into their cart. The **Stores** > Settings > **Sales** > **Sales** > **Reorder** > **Allow Reorder** field must be set to **Yes** to enable reorders. You must provide a customer authorization token with the call. The customer associated with the authorization token must match the customer who placed the specified order.
 
 The mutation returns an error if it cannot add a product to the customer's cart:
 
@@ -21,6 +21,10 @@ The `reorderItems` mutation will not add any products to the cart if it encounte
 ## Syntax
 
 `mutation: {reorderItems(orderNumber: String!) {ReorderItemsOutput}}`
+
+## Reference
+
+The [`reorderItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-reorderItems) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -124,46 +128,6 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `reorderItems` mutation requires a valid order number. The customer associated with the authorization token must match the customer who placed the specified order.
-
-Attribute | Type | Description
---- | --- | ---
-`orderNumber` | String! | The ID of the order to be used as the source for reordering products
-
-## Output attributes
-
-The `ReorderItemsOutput` object contains the following objects:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`cart` |[Cart!](#cart-object) | Describes the contents of the specified shopping cart
-`userInputErrors` | [CheckoutUserInputError!](#checkoutuserinputerror-object) | An array of reordering errors
-
-### Cart object
-
-import CartObject from '/src/pages/_includes/graphql/cart-object-24.md'
-
-<CartObject />
-
-[Cart query output](../../cart/queries/cart.md#output-attributes) provides more information about the `Cart` object.
-
-### userInputErrors object
-
-The `userInputErrors` object contains an array of errors encountered while attempting to reorder products.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`userInputErrors` |[CheckoutUserInputError]!| An array of reordering errors
-
-### CheckoutUserInputError object
-
-Attribute |  Data Type | Description
---- | --- | ---
-`message` | String! | A localized error message
-`path` | [String]! | The value for this mutation is `orderNumber`
 
 ## Related topics
 

--- a/src/pages/graphql/schema/orders/mutations/request-return.md
+++ b/src/pages/graphql/schema/orders/mutations/request-return.md
@@ -24,6 +24,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`requestReturn`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestReturn) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example requests a product return. At this point, the merchant hasn't taken action, but the response acknowledges the request was received.
@@ -126,61 +130,6 @@ mutation{
   }
 }
 ```
-
-## Input attributes
-
-The `requestReturn` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`comment_text` | String | Text the buyer entered that describes the reason for the refund request
-`contact_email` | String | An email address the buyer enters to receive notifications about the status of the return
-`items`| [RequestReturnItemInput!]! |An array of items to be returned
-`order_uid` | ID! | The unique ID for an `Order` object
-
-### RequestReturnItemInput attributes
-
-The RequestReturnItemInput object can contain the following fields:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`entered_custom_attributes`| [EnteredCustomAttributeInput!] | Contains details about a custom attribute that was entered, such as text or a file
-`order_item_uid` | ID! | The unique ID for an `OrderItemInterface` object
-`quantity_to_return` | Float! | The quantity of the item to be returned
-`selected_custom_attributes` | [SelectedCustomAttributeInput!] | An array of selected custom option IDs associated with the item to be returned. For example, the IDs for the selected color and size of a configurable product
-
-### EnteredCustomAttributeInput attributes
-
-The EnteredCustomAttributeInput object must contained the following fields:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`attribute_code` | String! | A string that identifies the entered custom attribute
-`value` | String! | The text or other entered value
-
-### SelectedCustomAttributeInput attributes
-
-The SelectedCustomAttributeInput object must contain the following fields:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`attribute_code` | String! | A string that identifies the selected attribute
-`value` | ID! | The unique ID for a `CustomAttribute` object
-
-## Output attributes
-
-The `RequestReturnOutput` object can contain the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`return` | Return | Contains details about a single return request")
-`returns(pageSize, currentPage)` | Returns | Contains an array of return requests
-
-### Return attributes
-
-import Return from '/src/pages/_includes/graphql/return.md'
-
-<Return />
 
 ### Returns attributes
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the manually maintained reference information from the topics in the pages/graphql/schema/orders directory.

Staging build: https://developer-stage.adobe.com/commerce/webapi/graphql/schema/orders/

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
