### PR TITLE
Redoc search results improvement

### DIFF
--- a/src/openapi/.redocly.yaml
+++ b/src/openapi/.redocly.yaml
@@ -28,3 +28,5 @@ features.openapi:
   nativeScrollbars: true
   ctrlFHijack: true
   scrollYOffset: .site-nav
+theme.openapi:
+  searchFieldLevelBoost: .5


### PR DESCRIPTION
Search results for [REST](https://developer.adobe.com/commerce/webapi/rest/quick-reference/) do not currently weight routes over the searched term appearing in the description.

I've added `searchFieldLevelBoost` which is described [here](https://redocly.com/docs/api-reference-docs/configuration/functionality/) as: 

> number <float> Default: 0.95 Specifies the boost factor for search terms found in fields at a specific level. If this value is lower than 1, search results found on deeper levels will rank lower.

alternatively `searchMode` could be set to `path-only`.

> searchMode | string Default: "default" Controls the search indexing mode. Supported values: 'default'; 'path-only' (will index and search only the operation paths). Enum: "default" "path-only"

And we could boost operation titles:

>  searchOperationTitleBoost | number Default: 4 Specifies the boost factor for search terms found in operation titles. The bigger the value, the higher searches will rank.







