### PR TITLE
COMDOX-345: Remove duplicate remark config

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,5 @@
     "dev:spectaql:beta": "spectaql --development-mode-live spectaql/config_beta.yml",
     "lint": "docker run --rm -e RUN_LOCAL=true --env-file '.github/super-linter.env' -v \"$PWD\":/tmp/lint github/super-linter:slim-v4.10.1"
   },
-  "remarkConfig": {
-    "plugins": [
-      "remark-validate-links"
-    ]
-  },
   "packageManager": "yarn@3.2.4"
 }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes a duplicate `remark` config that I overlooked in #201. The config was moved [here](https://github.com/AdobeDocs/commerce-webapi/blob/main/.remarkrc.mjs#L7). 