### PR TITLE
COMDOX-570: Adding intro to `2.4.6` schemas

### DIFF
--- a/src/openapi/admin-schema-2.4.6.yaml
+++ b/src/openapi/admin-schema-2.4.6.yaml
@@ -7,6 +7,8 @@ swagger: "2.0"
 info:
   version: 2.4.6
   title: Commerce Admin REST endpoints - All inclusive
+  description: 
+    $ref: https://raw.githubusercontent.com/AdobeDocs/commerce-webapi/main/src/_includes/redocly-intro.md
 host: example.com
 basePath: /rest/default
 schemes:

--- a/src/openapi/customer-schema-2.4.6.yaml
+++ b/src/openapi/customer-schema-2.4.6.yaml
@@ -7,6 +7,8 @@ swagger: "2.0"
 info:
   version: 2.4.6
   title: Commerce Customer REST endpoints - All inclusive
+  description: 
+    $ref: https://raw.githubusercontent.com/AdobeDocs/commerce-webapi/main/src/_includes/redocly-intro.md
 host: example.com
 basePath: /rest/default
 schemes:

--- a/src/openapi/guest-schema-2.4.6.yaml
+++ b/src/openapi/guest-schema-2.4.6.yaml
@@ -3,7 +3,7 @@ securityDefinitions:
     type: apiKey
     name: api_key
     in: header
-swagger: "2.0"
+swagger: "3.0"
 info:
   version: 2.4.6
   title: Commerce Guest REST endpoints - All inclusive

--- a/src/openapi/guest-schema-2.4.6.yaml
+++ b/src/openapi/guest-schema-2.4.6.yaml
@@ -7,6 +7,8 @@ swagger: "2.0"
 info:
   version: 2.4.6
   title: Commerce Guest REST endpoints - All inclusive
+  description: 
+    $ref: ../_includes/redocly-intro.md
 host: example.com
 basePath: /rest/default
 schemes:

--- a/src/openapi/guest-schema-2.4.6.yaml
+++ b/src/openapi/guest-schema-2.4.6.yaml
@@ -3,12 +3,12 @@ securityDefinitions:
     type: apiKey
     name: api_key
     in: header
-swagger: "3.0"
+swagger: "2.0"
 info:
   version: 2.4.6
   title: Commerce Guest REST endpoints - All inclusive
   description: 
-    $ref: ../_includes/redocly-intro.md
+    $ref: https://raw.githubusercontent.com/AdobeDocs/commerce-webapi/main/src/_includes/redocly-intro.md
 host: example.com
 basePath: /rest/default
 schemes:


### PR DESCRIPTION
This PR builds on the work done in PR #200 and adds links to the `2.4.6` schemas.

Example preview: https://preview.redoc.ly/warm-baboon-65/jh_redocly_intro_2/

This affects the Redocly site embedded on the [REST page](https://developer.adobe.com/commerce/webapi/rest/quick-reference/). 