### PR TITLE
Add EAV queries to list of cacheable queries

### DIFF
--- a/src/_includes/graphql/cache/queries-247beta.md
+++ b/src/_includes/graphql/cache/queries-247beta.md
@@ -1,5 +1,7 @@
 The application caches the following queries:
 
+* `attributesForm`
+* `attributesList`
 * `availableStores`
 * `categories`
 * `category` (deprecated)
@@ -10,6 +12,7 @@ The application caches the following queries:
 * `country`
 * `currency`
 * `customAttributeMetadata`
+* `customAttributeMetadataV2`
 * `products`
 * `route`
 * `storeConfig`


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the list of cacheable queries. The corresponding code updates were discovered while reviewing the 2.4.7 beta2 release notes.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
