### PR TITLE
Rename the test:links task

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "test:links": "remark src/pages --ignore-pattern src/pages/graphql/schema,src/_includes --quiet --frail",
+    "test": "remark src/pages --ignore-pattern src/pages/graphql/schema,src/_includes --quiet --frail",
     "build:spectaql": "spectaql --target-dir static/graphql-api/ --target-file index.html spectaql/config.yml",
     "build:spectaql:beta": "spectaql --target-dir static/graphql-api/beta/ --target-file index.html spectaql/config_beta.yml",
     "dev:spectaql": "spectaql --development-mode-live spectaql/config.yml",


### PR DESCRIPTION
## Purpose of this pull request 
This pull request renames the `test:links` script to `test` after the functionality of the script was extended.

## Affected pages

none

## Additional information

Internal ref: COMDOX-783
