### PR TITLE
Fix indexing workflow

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -29,19 +29,19 @@ jobs:
         run: corepack enable
 
       - name: Install Yarn v3
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         with:
           cmd: set version stable
 
       - name: Install dependencies
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         with:
           cmd: install
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Build site
-        uses: borales/actions-yarn@v4
+        uses: borales/actions-yarn@v3
         with:
           cmd: build
         env:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a potential indexing workflow [failure](https://github.com/AdobeDocs/commerce-extensibility/actions/runs/6724894582/job/18278143476). Downgrading yarn to v3 in the workflow like in other workflows.
yarn v4 doesn't support node v16.

## Test run

https://github.com/commerce-docs/commerce-extensibility/actions/runs/6725364432/job/18279583045
