### PR TITLE
GraphQL: Remove reference info from Company section

### DIFF
--- a/src/pages/graphql/schema/b2b/company/index.md
+++ b/src/pages/graphql/schema/b2b/company/index.md
@@ -4,3 +4,5 @@ edition: b2b
 ---
 
 # Company (B2B)
+
+The Company component is the key entity within B2B on which all other features are in some way dependent. It allows joining multiple buyers that belong to the same company into a single company account (or corporate account). The company administrator is able to build the company structure (divisions, subdivisions, and users) in the appropriate hierarchy and provide different user roles and permissions to the company members. This hierarchy allows the company administrator to control user activity for the company account: ordering, quoting, purchasing, access to company credit information or profile, and so on. A seller can configure how the buying company operates on the website, including the payment methods, pricing levels, the ability to negotiate prices, and the ability to create requisition lists.

--- a/src/pages/graphql/schema/b2b/company/mutations/create-role.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create-role.md
@@ -15,6 +15,8 @@ import B2BRoles from '/src/_includes/graphql/b2b-roles.md'
 
 Also, you can get the list of all resources defined within the company using the [`company`](../queries/company.md) query.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -26,6 +28,10 @@ mutation {
     }
 }
 ```
+
+## Reference
+
+The [`createCompanyRole`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompanyRole) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -114,33 +120,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `CompanyRoleCreateInput` input object defines the company role data for creating.
-
-### CompanyRoleCreateInput attributes
-
-The `CompanyRoleCreateInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`name` | String! | The name of the role to create
-`permissions` | [String!]! | A list of resources the role can access
-
-## Output attributes
-
-The `CreateCompanyRoleOutput` output object contains the following attribute:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`role` | CompanyRole! | Contains company role data
-
-### CompanyRole attributes
-
-import CompanyRole from '/src/_includes/graphql/company-role.md'
-
-<CompanyRole />
 
 ## Errors
 

--- a/src/pages/graphql/schema/b2b/company/mutations/create-team.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create-team.md
@@ -13,6 +13,8 @@ The `target_id` input attribute allows you to specify which node in the company 
 
 You can get the `target_id` with the [`company`](../queries/company.md) query.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -24,6 +26,10 @@ mutation {
     }
 }
 ```
+
+## Reference
+
+The [`createCompanyTeam`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompanyTeam) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -100,31 +106,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `CompanyTeamCreateInput` input object defines the company team data.
-
-### CompanyTeamCreateInput attributes
-
-The `CompanyTeamCreateInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`description` | String | An optional description of the team
-`name` | String! | The display name of the team
-`target_id` | ID | The ID of a node within a company's structure. This ID will be the parent of the created team
-
-## Output attributes
-
-The `CreateCompanyTeamOutput` output object contains the following attribute:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`team` | CompanyTeam! | Contains company team data
-
-### CompanyTeam attributes
-
-import CompanyTeam from '/src/_includes/graphql/company-team.md'
-
-<CompanyTeam />

--- a/src/pages/graphql/schema/b2b/company/mutations/create-user.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create-user.md
@@ -19,6 +19,8 @@ The `target_id` input attribute allows you to specify which node in the company 
 
 You can get the `target_id` and the `role_id` with the [`company`](../queries/company.md) query.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -30,6 +32,10 @@ mutation {
     }
 }
 ```
+
+## Reference
+
+The [`createCompanyUser`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompanyUser) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -145,39 +151,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `CompanyUserCreateInput` input object defines the company user data.
-
-### CompanyUserCreateInput attributes
-
-The `CompanyUserCreateInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`email` | String! | The company user's email address
-`firstname` | String! | The company user's first name
-`job_title` | String! | The company user's job title or function
-`lastname` | String! | The company user's last name
-`role_id` | ID! | The role ID to assign to the company user
-`status` | CompanyUserStatusEnum! | Indicates whether the company user is ACTIVE or INACTIVE
-`target_id` | ID | The ID of a node within a company's structure. This ID will be the parent of the created company user
-`telephone` | String! | The company user's phone number
-
-## Output attributes
-
-The `CreateCompanyUserOutput` output object contains the following attribute:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`user` | Customer! | Contains company user data
-
-### Customer attributes
-
-import Customer from '/src/_includes/graphql/customer-output-24.md'
-
-<Customer />
 
 ## Errors
 

--- a/src/pages/graphql/schema/b2b/company/mutations/create.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create.md
@@ -9,6 +9,8 @@ The `createCompany` mutation creates a company at the request of either a custom
 
 The company administrator cannot log in or perform additional company-related tasks until an administrator approves the request to create a company.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -20,6 +22,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`createCompany`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompany) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -105,53 +111,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The CompanyCreateInput object defines the schema for creating an entity.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`company_admin` | [CompanyAdminInput!](#companyadmininput-attributes) | Defines the company administrator
-`company_email` | String! | The email address of the company contact
-`company_name` | String! | The company name
-`legal_address` | [CompanyLegalAddressCreateInput!](#companylegaladdresscreateinput-attributes) | Defines legal address data of the company
-`legal_name` | String | The full legal name of the company
-`reseller_id` | String | The resale number that is assigned to the company for tax reporting purposes
-`vat_tax_id` | String | The value-added tax number that is assigned to the company by some jurisdictions for tax reporting purposes
-
-### CompanyAdminInput attributes
-
-The `CompanyAdminInput` object can contain the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`email` | String! | The email address of the company administrator
-`firstname` | String! | The company administrator's first name
-`gender` | Int | The company administrator's gender (Male - 1, Female - 2, Not Specified - 3)
-`job_title` | String | The job title of the company administrator
-`lastname` | String! | The company administrator's last name
-
-### CompanyLegalAddressCreateInput attributes
-
-The `CompanyLegalAddressCreateInput` object can contain the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`city` | String! | The city where the company is registered to conduct business
-`country_id` | CountryCodeEnum! | The company's country ID. See the [`countries` query](../../../store/queries/countries.md)
-`postcode` | String! | The postal code of the company
-`region` | CustomerAddressRegionInput! | An object containing the region name and/or region ID where the company is registered to conduct business
-`street` | [String!]! | An array of strings that define the street address where the company is registered to conduct business
-`telephone` | String! | The primary phone number of the company
-
-## Output attributes
-
-The `CreateCompanyOutput` object contains the `Company` object.
-
-import Company from '/src/_includes/graphql/company.md'
-
-<Company />
 
 ## Related topics
 

--- a/src/pages/graphql/schema/b2b/company/mutations/delete-role.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/delete-role.md
@@ -11,6 +11,8 @@ Use the `deleteCompanyRole` mutation to delete a company role by ID.
 
 You can get the role ID with the [`company`](../queries/company.md) query.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -22,6 +24,10 @@ mutation {
     }
 }
 ```
+
+## Reference
+
+The [`deleteCompanyRole`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCompanyRole) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -50,19 +56,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `deleteCompanyRole` mutation requires the following input:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`id` | ID! | The encoded role ID to delete
-
-## Output attributes
-
-The `deleteCompanyRole` mutation returns a Boolean value that indicates whether the operation was successful.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`success` | Boolean | Indicates whether the company role has been deleted successfully (`true` or `false`)

--- a/src/pages/graphql/schema/b2b/company/mutations/delete-team.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/delete-team.md
@@ -9,6 +9,8 @@ edition: b2b
 
 Use the `deleteCompanyTeam` mutation to delete a company team by ID. You can get the team ID with the [`company`](../queries/company.md) query.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -20,6 +22,10 @@ mutation {
     }
 }
 ```
+
+## Reference
+
+The [`deleteCompanyTeam`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCompanyTeam) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -48,19 +54,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `deleteCompanyTeam` mutation requires the following input:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`id` | ID! | The encoded team ID to delete
-
-## Output attributes
-
-The `deleteCompanyTeam` mutation returns a Boolean value that indicates whether the operation was successful.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`success` | Boolean | Indicates whether the company team has been deleted successfully (`true` or `false`)

--- a/src/pages/graphql/schema/b2b/company/mutations/delete-user.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/delete-user.md
@@ -11,6 +11,8 @@ Use the `deleteCompanyUser` mutation to deactivate the specified company user.
 
 You can get the user ID with the [`company`](../queries/company.md) query.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -22,6 +24,10 @@ mutation {
     }
 }
 ```
+
+## Reference
+
+The [`deleteCompanyUser`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCompanyUser) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -50,22 +56,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `deleteCompanyUser` mutation requires the following input:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`id` | ID! | The encoded user ID to deactivate
-
-## Output attributes
-
-The `deleteCompanyUser` mutation returns a Boolean value that indicates whether the operation was successful.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`success` | Boolean! | Indicates whether the company user has been deactivated successfully (`true` or `false`)
 
 ## Errors
 

--- a/src/pages/graphql/schema/b2b/company/mutations/index.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/index.md
@@ -1,5 +1,14 @@
 ---
 title: Company (B2B) mutations
+edition: b2b
 ---
 
 # Company (B2B) mutations
+
+The B2B company mutations allow you to perform the management operations:
+
+* Create and update a company.
+* Create, update, and delete company users.
+* Create, update, and delete company teams.
+* Move the position of a company team in the company hierarchy.
+* Create, update, and delete company roles.

--- a/src/pages/graphql/schema/b2b/company/mutations/update-role.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-role.md
@@ -15,6 +15,14 @@ import B2BRoles from '/src/_includes/graphql/b2b-roles.md'
 
 <B2BRoles />
 
+You can change or add permissions to the company role using the `permissions` attribute.
+
+<InlineAlert variant="warning" slots="text" />
+
+Any time you use the `permissions` object to update role capabilities, you must include the entire hierarchy of permissions. The `updateCompanyRole` mutation rewrites all role permissions based on the specified payload.
+
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -26,6 +34,10 @@ mutation {
     }
 }
 ```
+
+## Reference
+
+The [`updateCompanyRole`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyRole) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -148,40 +160,6 @@ mutation {
   }
 }
 ```
-
-You can change or add permissions to the company role using "permissions" attribute.
-
-<InlineAlert variant="warning" slots="text" />
-
-To add new or change current permissions, you also must send all the current permissions every time you use the "permissions" attribute. The company role permissions are rewritten completely from the "permissions" attribute.
-
-## Input attributes
-
-The `CompanyRoleUpdateInput` input object defines the company role data.
-
-### CompanyRoleUpdateInput attributes
-
-The `CompanyRoleUpdateInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`id` | ID! | The encoded company role ID for updating
-`name` | String | Role name.
-`permissions` | [String!] | A list of role permission resources.
-
-## Output attributes
-
-The `UpdateCompanyRoleOutput` output object contains the following attribute:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`role` | CompanyRole! | Contains company role data
-
-### CompanyRole attributes
-
-import CompanyRole from '/src/_includes/graphql/company-role.md'
-
-<CompanyRole />
 
 ## Errors
 

--- a/src/pages/graphql/schema/b2b/company/mutations/update-structure.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-structure.md
@@ -9,6 +9,8 @@ contributor_link: https://www.atwix.com/
 
 Use the `updateCompanyStructure` mutation to change the parent node of a company team.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -20,6 +22,10 @@ mutation {
     }
 }
 ```
+
+## Reference
+
+The [`updateCompanyStructure`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyStructure) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -95,30 +101,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `CompanyStructureUpdateInput` input object defines the company team data.
-
-### CompanyStructureUpdateInput attributes
-
-The `CompanyStructureUpdateInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`parent_tree_id` | ID! | The ID of a company that will be the new parent
-`tree_id` | ID! | The ID of the company team that is being moved to another parent
-
-You can get the `parent_tree_id` and `tree_id` with the [`company`](../queries/company.md) query.
-
-## Output attributes
-
-The `UpdateCompanyStructureOutput` output object contains the following attribute:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`company` | Company! | Contains company data
-
-import Company from '/src/_includes/graphql/company.md'
-
-<Company />.md %}

--- a/src/pages/graphql/schema/b2b/company/mutations/update-team.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-team.md
@@ -9,6 +9,8 @@ contributor_link: https://www.atwix.com/
 
 Use the `updateCompanyTeam` mutation to update the company team data.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -20,6 +22,10 @@ mutation {
     }
 }
 ```
+
+## Reference
+
+The [`updateCompanyTeam`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyTeam) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -60,33 +66,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `CompanyTeamUpdateInput` input object defines the company team data.
-
-### CompanyTeamUpdateInput attributes
-
-The `CompanyTeamUpdateInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`description` | String | An optional description of the team
-`id` | ID! | The unique ID for a `CompanyTeam` object
-`name` | String | The display name of the team
-
-You can get the team ID with the [`company`](../queries/company.md) query.
-
-## Output attributes
-
-The `UpdateCompanyTeamOutput` output object contains the following attribute:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`team` | CompanyTeam! | Contains company team data
-
-### CompanyTeam attributes
-
-import CompanyTeam from '/src/_includes/graphql/company-team.md'
-
-<CompanyTeam />

--- a/src/pages/graphql/schema/b2b/company/mutations/update-user.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-user.md
@@ -11,6 +11,8 @@ Use the `updateCompanyUser` mutation to update an existing company user.
 
 You can get the user ID and role ID with the [`company`](../queries/company.md) query.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -22,6 +24,10 @@ mutation {
     }
 }
 ```
+
+## Reference
+
+The [`updateCompanyUser`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyUser) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -131,39 +137,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `CompanyUserUpdateInput` input object defines the company user data.
-
-### CompanyUserUpdateInput attributes
-
-The `CompanyUserUpdateInput` object contains the following attributes:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`email` | String | The company user's email address
-`firstname` | String | The company user's first name
-`id` | ID! | The encoded user ID of the company user to be updated
-`job_title` | String | The company user's job title or function
-`lastname` | String | The company user's last name
-`role_id` | ID | The ID of the role assigned to the company user
-`status` | CompanyUserStatusEnum | Indicates whether the company user is ACTIVE or INACTIVE
-`telephone` | String | The company user's phone number
-
-## Output attributes
-
-The `UpdateCompanyUserOutput` output object contains the following attribute:
-
-Attribute |  Data Type | Description
---- | --- | ---
-`user` | Customer! | Contains company user data
-
-### Customer attributes
-
-import Customer from '/src/_includes/graphql/customer-output-24.md'
-
-<Customer />
 
 ## Errors
 

--- a/src/pages/graphql/schema/b2b/company/mutations/update.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update.md
@@ -7,6 +7,8 @@ edition: b2b
 
 The `updateCompany` mutation allows you to update a company's address as well as top-level string attributes such as the name, legal name, and email. You cannot update the administrator or other objects such as teams, roles, or resources with this mutation.
 
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -18,6 +20,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`updateCompany`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompany) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -76,40 +82,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The CompanyUpdateInput object defines the schema for updating a company.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`company_email` | String | The email address of the company contact
-`company_name` | String | The name of the company to update
-`legal_address` | [CompanyLegalAddressUpdateInput](#companylegaladdressupdateinput-attributes) | Defines the legal address data of the company
-`legal_name` | String | The full legal name of the company
-`reseller_id` | String | The resale number that is assigned to the company for tax reporting purposes
-`vat_tax_id` | String | The value-added tax number that is assigned to the company by some jurisdictions for tax reporting purposes
-
-### CompanyLegalAddressUpdateInput attributes
-
-The `CompanyLegalAddressUpdateInput` object can contain the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`city` | String | The city where the company is registered to conduct business
-`country_id` | CountryCodeEnum | Company's country ID. See the [`countries` query](../../../store/queries/countries.md)
-`postcode` | String | The ZIP/postal code of the company
-`region` | CustomerAddressRegionInput! | An object containing the region name and/or region ID where the company is registered to conduct business
-`street` | [String!] | An array of strings that define the street address where the company is registered to conduct business
-`telephone` | String | The primary phone number of the company
-
-## Output attributes
-
-The `UpdateCompanyOutput` object contains the `Company` object.
-
-import Company from '/src/_includes/graphql/company.md'
-
-<Company />.md %}
 
 ## Related topics
 

--- a/src/pages/graphql/schema/b2b/company/queries/company.md
+++ b/src/pages/graphql/schema/b2b/company/queries/company.md
@@ -9,9 +9,17 @@ The `company` query returns details about the user's company. The request must i
 
 A company structure can contain multiple levels of teams, with company users assigned at each level. To query on a company structure, specify fragments on the `Customer` and `CompanyTeam` objects. The application returns a [union](https://graphql.org/learn/schema/#union-types) of these objects. Specify the `__typename` attribute to distinguish the object types in the response.
 
+The `CompanyCredit` output object contains the company's `available_credit` and `outstanding_balance` values. These values cannot be changed with a mutation.  The `available_credit` amount is the sum of the credit limit and the outstanding balance. If the company has exceeded the credit limit, the amount is as a negative value. The `outstanding_balance` amount is the amount reimbursed, less the total due from all orders placed using the Payment on Account payment method. The amount can be a positive or negative value.
+
+This query requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 `{company: {Company}}`
+
+## Reference
+
+The [`company`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-company) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 
@@ -363,11 +371,3 @@ query{
   }
 }
 ```
-
-## Output attributes
-
-The `company` object returns the `Company` object.
-
-import Company from '/src/_includes/graphql/company.md'
-
-<Company />

--- a/src/pages/graphql/schema/b2b/company/queries/index.md
+++ b/src/pages/graphql/schema/b2b/company/queries/index.md
@@ -1,5 +1,8 @@
 ---
 title: Company (B2B) queries
+edition: b2b
 ---
 
 # Company (B2B) queries
+
+The [`company`](company.md) query returns full details about the specified company. The [`isCompanyAdminEmailAvailable`](is-company-admin-email-available.md), [`isCompanyEmailAvailable`](is-company-email-available.md), [`isCompanyRoleNameAvailable`](is-company-role-name-available.md), and [`isCompanyUserEmailAvailable`](is-company-user-email-available.md) queries allow you to determine whether company entities already exist.

--- a/src/pages/graphql/schema/b2b/company/queries/is-company-admin-email-available.md
+++ b/src/pages/graphql/schema/b2b/company/queries/is-company-admin-email-available.md
@@ -7,9 +7,15 @@ edition: b2b
 
 The `isCompanyAdminEmailAvailable` query checks whether the specified email can be used to create a company administrator account. If the email matches an existing customer or another company administrator account, the query returns a `false` value. A value of `true` indicates the email address can be used to create a company administrator account.
 
+This query requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 `isCompanyAdminEmailAvailable ( email String! ) IsCompanyAdminEmailAvailableOutput`
+
+## Reference
+
+The [`isCompanyAdminEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyAdminEmailAvailable) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 
@@ -36,18 +42,6 @@ query{
   }
 }
 ```
-
-## Input attribute
-
-Attribute |  Data Type | Description
---- | --- | ---
-`email` | String! | The email address to check
-
-## Output attribute
-
-Attribute |  Data Type | Description
---- | --- | ---
-`is_email_available` | Boolean! | A value of `true` indicates the email address is available
 
 ## Related topics
 

--- a/src/pages/graphql/schema/b2b/company/queries/is-company-email-available.md
+++ b/src/pages/graphql/schema/b2b/company/queries/is-company-email-available.md
@@ -7,9 +7,15 @@ edition: b2b
 
 The `isCompanyEmailAvailable` query checks whether the specified email is valid for company registration. The specified email can be the same as an existing customer or company administrator. If the email matches an existing company email, the query returns a `false` value.
 
+This query requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 `isCompanyEmailAvailable ( email String! ) IsCompanyEmailAvailableOutput`
+
+## Reference
+
+The [`isCompanyEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyEmailAvailable) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 
@@ -36,18 +42,6 @@ query{
   }
 }
 ```
-
-## Input attribute
-
-Attribute |  Data Type | Description
---- | --- | ---
-`email` | String! | The email address to check
-
-## Output attribute
-
-Attribute |  Data Type | Description
---- | --- | ---
-`is_email_available` | Boolean! | A value of `true` indicates the email address is available
 
 ## Related topics
 

--- a/src/pages/graphql/schema/b2b/company/queries/is-company-role-name-available.md
+++ b/src/pages/graphql/schema/b2b/company/queries/is-company-role-name-available.md
@@ -11,6 +11,8 @@ The `isCompanyRoleNameAvailable` query checks whether a company role name is val
 
 The query returns a `false` value if the specified role name has already found in a company.
 
+This query requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 ```graphql
@@ -22,6 +24,10 @@ The query returns a `false` value if the specified role name has already found i
     }
 }
 ```
+
+## Reference
+
+The [`isCompanyRoleNameAvailable`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyRoleNameAvailable) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 
@@ -48,15 +54,3 @@ query {
   }
 }
 ```
-
-## Input attribute
-
-Attribute |  Data Type | Description
---- | --- | ---
-`name` | String! | The company role name to check
-
-## Output attribute
-
-Attribute |  Data Type | Description
---- | --- | ---
-`is_role_name_available` | Boolean | A value of `true` indicates the company role name is available

--- a/src/pages/graphql/schema/b2b/company/queries/is-company-user-email-available.md
+++ b/src/pages/graphql/schema/b2b/company/queries/is-company-user-email-available.md
@@ -7,9 +7,15 @@ edition: b2b
 
 The `isCompanyUserEmailAvailable` query checks whether an email is valid for registering a company user. The query returns a `false` value if the specified email matches the email of an existing customer or a company administrator.
 
+This query requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+
 ## Syntax
 
 `isCompanyUserEmailAvailable ( email String! ) IsCompanyUserEmailAvailableOutput`
+
+## Reference
+
+The [`isCompanyUserEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyUserEmailAvailable) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 
@@ -36,18 +42,6 @@ query{
   }
 }
 ```
-
-## Input attribute
-
-Attribute |  Data Type | Description
---- | --- | ---
-`email` | String! | The email address to check
-
-## Output attribute
-
-Attribute |  Data Type | Description
---- | --- | ---
-`is_email_available` | Boolean! | A value of `true` indicates the email address is available
 
 ## Related topics
 

--- a/src/pages/graphql/schema/b2b/company/unions/index.md
+++ b/src/pages/graphql/schema/b2b/company/unions/index.md
@@ -4,3 +4,5 @@ edition: b2b
 ---
 
 # Company (B2B) unions
+
+The `CompanyStructureEntity` union provides details about a node in a company structure.

--- a/src/pages/graphql/schema/b2b/company/unions/structure-entity.md
+++ b/src/pages/graphql/schema/b2b/company/unions/structure-entity.md
@@ -1,5 +1,6 @@
 ---
 title: CompanyStructureEntity union
+edition: b2b
 ---
 
 # CompanyStructureEntity union


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes reference information from the B2B Company queries/mutations/union and adds links to SpectaQL. Also added content to index pages and added missing token information.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
