### PR TITLE
GraphQL: Remove reference info from purchase order/po rules sections

### DIFF
--- a/src/pages/graphql/schema/b2b/purchase-order-rule/interfaces/index.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/interfaces/index.md
@@ -5,37 +5,10 @@ edition: b2b
 
 # PurchaseOrderApprovalRuleConditionInterface attributes and implementations
 
-`PurchaseOrderApprovalRuleConditionInterface` provides details about the approval rule conditions. It has the following implementations:
+[`PurchaseOrderApprovalRuleConditionInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-PurchaseOrderApprovalRuleConditionInterface) provides details about the approval rule conditions. It has the following implementations:
 
-*  [`PurchaseOrderApprovalRuleConditionAmount`](#purchaseorderapprovalruleconditionamount-attributes)
-*  [`PurchaseOrderApprovalRuleConditionQuantity`](#purchaseorderapprovalruleconditionquantity-attributes)
-
-## Attributes
-
-The `PurchaseOrderApprovalRuleConditionInterface` defines the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`attribute` | `PurchaseOrderApprovalRuleType` | GRAND_TOTAL, NUMBER_OF_SKUS, or SHIPPING_INCL_TAX
-`operator` | `PurchaseOrderApprovalRuleConditionOperator` | MORE_THAN, LESS_THAN, MORE_THAN_OR_EQUAL_TO, or LESS_THAN_OR_EQUAL_TO
-
-## Implementations
-
-### PurchaseOrderApprovalRuleConditionAmount attributes
-
-The `PurchaseOrderApprovalRuleConditionAmount` implementation adds the following attribute.
-
-Attribute |  Data Type | Description
---- | -- | ---
-`amount`| `Money!` | An amount used for evaluation of the approval rule condition.
-
-### PurchaseOrderApprovalRuleConditionQuantity attributes
-
-The `PurchaseOrderApprovalRuleConditionQuantity` implementation adds the following attribute.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`quantity`| `Int` | The quantity used for evaluation of the approval rule condition.
+*  [`PurchaseOrderApprovalRuleConditionAmount`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-PurchaseOrderApprovalRuleConditionAmount)
+*  [`PurchaseOrderApprovalRuleConditionQuantity`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-PurchaseOrderApprovalRuleConditionQuantity)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/create.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/create.md
@@ -31,6 +31,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`createPurchaseOrderApprovalRule`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createPurchaseOrderApprovalRule) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Headers
 
 A valid [customer authentication token](../../../customer/mutations/generate-token.md) is required.

--- a/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/delete.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/delete.md
@@ -23,6 +23,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`deletePurchaseOrderApprovalRule`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deletePurchaseOrderApprovalRule) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Headers
 
 A valid [customer authentication token](../../../customer/mutations/generate-token.md) is required.

--- a/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/index.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/index.md
@@ -4,3 +4,11 @@ edition: b2b
 ---
 
 # Purchase order approval rule (B2B) mutations
+
+B2B for Adobe Commerce provides mutations to manage purchase order approval rules:
+
+* `createPurchaseOrderApprovalRule`
+* `deletePurchaseOrderApprovalRule`
+* `updatePurchaseOrderApprovalRule`
+
+The `validatePurchaseOrders` mutation allows an approver to manually validate purchase orders when automatic validation fails unexpectedly.

--- a/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/update.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/update.md
@@ -23,6 +23,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`updatePurchaseOrderApprovalRule`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updatePurchaseOrderApprovalRule) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Headers
 
 A valid [customer authentication token](../../../customer/mutations/generate-token.md) is required.

--- a/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/validate.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/validate.md
@@ -21,6 +21,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`validatePurchaseOrders`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-validatePurchaseOrders) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Headers
 
 A valid [customer authentication token](../../../customer/mutations/generate-token.md) is required.

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/add-comment.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/add-comment.md
@@ -19,6 +19,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`addPurchaseOrderComment`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addPurchaseOrderComment) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example adds a comment to the purchase order.

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/add-items-to-cart.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/add-items-to-cart.md
@@ -19,6 +19,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`addPurchaseOrderItemsToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addPurchaseOrderItemsToCart) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example adds all purchase order items to the shopping cart.

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/approve.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/approve.md
@@ -19,6 +19,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`approvePurchaseOrders`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-approvePurchaseOrders) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example approves a purchase order.

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/cancel.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/cancel.md
@@ -19,6 +19,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`cancelPurchaseOrders`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-cancelPurchaseOrders) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example cancels purchase orders.

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/index.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/index.md
@@ -4,3 +4,14 @@ edition: b2b
 ---
 
 # Purchase order (B2B) mutations
+
+Adobe Commerce for B2B provides the following mutations for processing and managing purchase orders:
+
+* [`addPurchaseOrderComment`](./add-comment.md)
+* [`addPurchaseOrderItemsToCart`](./add-items-to-cart.md)
+* [`approvePurchaseOrders`](./approve.md)
+* [`cancelPurchaseOrders`](./cancel.md)
+* [`placeOrderForPurchaseOrder`](./place-purchase-order.md)
+* [`placePurchaseOrder`](./place-order.md)
+* [`rejectPurchaseOrders`](./reject.md)
+* [`validatePurchaseOrders`](../../purchase-order-rule/mutations/validate.md)

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/place-order.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/place-order.md
@@ -21,6 +21,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`placeOrderForPurchaseOrder`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-placeOrderForPurchaseOrder) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example places an order based on the approved purchase order.

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/place-purchase-order.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/place-purchase-order.md
@@ -21,6 +21,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`placePurchaseOrder`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-placePurchaseOrder) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example places a purchase order.

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/reject.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/reject.md
@@ -19,6 +19,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`rejectPurchaseOrders`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-rejectPurchaseOrders) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example rejects a purchase order.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes reference information from the B2B purchase order/purchase order rules queries/mutations/interface and adds links to SpectaQL. Also added content to index pages.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
