### PR TITLE
GraphQL: Remove reference info from requisition list section

### DIFF
--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -1007,13 +1007,7 @@ module.exports = [
           },
           {
             title: "Interfaces",
-            path: "/graphql/schema/b2b/requisition-list/interfaces/",
-            pages: [
-              {
-                title: "RequisitionListItemInterface",
-                path: "/graphql/schema/b2b/requisition-list/interfaces/item/",
-              },
-            ],
+            path: "/graphql/schema/b2b/requisition-list/interfaces/"
           },
         ],
       },

--- a/src/pages/graphql/schema/b2b/requisition-list/index.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/index.md
@@ -4,3 +4,7 @@ description:
 ---
 
 # Requisition lists (B2B)
+
+Requisition lists are similar to wish lists, except they are used in the context of B2B transactions. Using a requisition list saves time for buyers who frequently purchase products on a continuing basis. Items are added to the shopping cart directly from the requisition list. Customers can maintain multiple lists that focus on products from different vendors, buyers, teams, campaigns, or anything else that streamlines their workflow. It is available for both logged-in users and guests.
+
+The [_B2B for Adobe Commerce_](https://experienceleague.adobe.com/docs/commerce-admin/b2b/requisition-lists/requisition-lists.html) guide describes requisition lists in detail.

--- a/src/pages/graphql/schema/b2b/requisition-list/index.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/index.md
@@ -5,6 +5,6 @@ description:
 
 # Requisition lists (B2B)
 
-Requisition lists are similar to wish lists, except they are used in the context of B2B transactions. Using a requisition list saves time for buyers who frequently purchase products on a continuing basis. Items are added to the shopping cart directly from the requisition list. Customers can maintain multiple lists that focus on products from different vendors, buyers, teams, campaigns, or anything else that streamlines their workflow. It is available for both logged-in users and guests.
+Requisition lists are similar to wish lists, except they are used in the context of B2B transactions. Using a requisition list saves time for buyers who frequently purchase products on a continuing basis. Items are added to the shopping cart directly from the requisition list. Customers can maintain multiple lists to streamline their workflow. For example, they can create lists that focus on products from different vendors, buyers, teams, or campaigns. Requisition lists are available for both logged-in users and guests.
 
 The [_B2B for Adobe Commerce_](https://experienceleague.adobe.com/docs/commerce-admin/b2b/requisition-lists/requisition-lists.html) guide describes requisition lists in detail.

--- a/src/pages/graphql/schema/b2b/requisition-list/interfaces/index.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/interfaces/index.md
@@ -1,6 +1,95 @@
 ---
-title: Requisition list (B2B) interfaces
-edition: b2b   
+title: RequisitionListItemInterface attributes and implementations
+edition: b2b
 ---
 
-# Requisition list (B2B) interfaces
+# RequisitionListItemInterface attributes and implementations
+
+[`RequisitionListItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-RequisitionListItemInterface) provides details about items in a requisition list. It has the following implementations:
+
+*  [`BundleRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-BundleRequisitionListItem)
+*  [`ConfigurableRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-ConfigurableRequisitionListItem)
+*  [`DownloadableRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-DownloadableRequisitionListItem)
+*  [`GiftCardRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-GiftCardRequisitionListItem)
+*  [`SimpleRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-SimpleRequisitionListItem)
+*  [`VirtualRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-VirtualRequisitionListItem)
+
+<InlineAlert variant="info" slots="text" />
+
+There is not an implementation for grouped products. The items within a grouped product are managed individually.
+
+## Example usage
+
+The following mutation adds a product to a requisition list and returns information about the products in the list.
+
+**Request:**
+
+```graphql
+mutation {
+  addProductsToRequisitionList(
+      requisitionListUid: "Mg=="
+      requisitionListItems: [
+        {
+            sku: "MS10"
+            quantity: 1
+            selected_options: ["Y29uZmlndXJhYmxlLzkzLzUw","Y29uZmlndXJhYmxlLzE2MC8xNjg"]
+        }
+      ]
+    ) {
+    requisition_list {
+      uid
+      items {
+        items {
+          ... on RequisitionListItemInterface {
+            uid
+            product {
+              uid
+              sku
+              name
+            }
+            quantity
+          }
+        }
+      }
+      items_count
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "addProductsToRequisitionList": {
+      "requisition_list": {
+        "uid": "Mg==",
+        "items": {
+          "items": [
+            {
+              "uid": "Mg==",
+              "product": {
+                "uid": "MTA=",
+                "sku": "24-WB05",
+                "name": "Savvy Shoulder Tote"
+              },
+              "quantity": 1
+            },
+            {
+              "uid": "Mw==",
+              "product": {
+                "uid": "NTk2",
+                "sku": "MS10",
+                "name": "Logan  HeatTec&reg; Tee"
+              },
+              "quantity": 1
+            }
+          ]
+        },
+        "items_count": 2
+      }
+    }
+  }
+}
+```

--- a/src/pages/graphql/schema/b2b/requisition-list/interfaces/item.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/interfaces/item.md
@@ -5,85 +5,18 @@ edition: b2b
 
 # RequisitionListItemInterface attributes and implementations
 
-`RequisitionListItemInterface` provides details about items in a requisition list. It has the following implementations:
+[`RequisitionListItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-RequisitionListItemInterface) provides details about items in a requisition list. It has the following implementations:
 
-*  [`BundleRequisitionListItem`](#bundlerequisitionlistitem-attributes)
-*  [`ConfigurableRequisitionListItem`](#configurablerequisitionlistitem-attributes)
-*  [`DownloadableRequisitionListItem`](#downloadablerequisitionlistitem-attributes)
-*  [`GiftCardRequisitionListItem`](#giftcardrequisitionlistitem-attributes)
-*  [`SimpleRequisitionListItem`](#simplerequisitionlistitem-attributes)
-*  [`VirtualRequisitionListItem`](#virtualrequisitionlistitem-attributes)
+*  [`BundleRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-BundleRequisitionListItem)
+*  [`ConfigurableRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-ConfigurableRequisitionListItem)
+*  [`DownloadableRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-DownloadableRequisitionListItem)
+*  [`GiftCardRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-GiftCardRequisitionListItem)
+*  [`SimpleRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-SimpleRequisitionListItem)
+*  [`VirtualRequisitionListItem`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#definition-VirtualRequisitionListItem)
 
 <InlineAlert variant="info" slots="text" />
 
 There is not an implementation for grouped products. The items within a grouped product are managed individually.
-
-## Attributes
-
-The `RequisitionListItemInterface` defines the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`customizable_options` | [SelectedCustomizableOption]! | Selected custom options for an item in the requisition list
-`product` | [ProductInterface!](../../../products/interfaces/index.md) | Contains details about an item added to a requisition list
-`quantity` | Float! | The amount added
-`uid` | ID! | The unique ID for the requisition list item
-
-## Implementations
-
-### BundleRequisitionListItem attributes
-
-The `BundleRequisitionListItem` implementation adds the following attribute.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`bundle_options`| [SelectedBundleOption]! | An array of selected options for a bundle product
-
-### ConfigurableRequisitionListItem attributes
-
-The `ConfigurableRequisitionListItem` implementation adds the following attribute.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`configurable_options`| [SelectedConfigurableOption] | Selected configurable options for an item in the requisition list
-
-### DownloadableRequisitionListItem attributes
-
-The `ConfigurableRequisitionListItem` implementation adds the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`links`| [DownloadableProductLinks] | An array of links for downloadable products in the requisition list
-`samples` | [DownloadableProductSamples] | An array of links to downloadable product samples
-
-### GiftCardRequisitionListItem attributes
-
-The `GiftCardRequisitionListItem` implementation adds the following attribute.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`gift_card_options` | GiftCardOptions! | An array that defines gift card properties
-
-#### GiftCardOptions attributes
-
-The GiftCardOptions object provides details about a gift card. All attributes are optional for a requisition list.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`amount`| Money | The amount and currency of the gift card
-`custom_giftcard_amount` | Money | The custom amount and currency of the gift card
-`message` | String | A message to the recipient
-`recipient_email` | String | The name of the person receiving the gift card
-`sender_email` | String | The email address of the person sending the gift card
-`sender_name` | String | The name of the person sending the gift card
-
-### SimpleRequisitionListItem attributes
-
-The SimpleRequisitionListItem data type does not provide additional attributes to the `RequisitionListItemInterface`.
-
-### VirtualRequisitionListItem attributes
-
-The VirtualRequisitionListItem data type does not provide additional attributes to the `RequisitionListItemInterface`.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/add-items-to-cart.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/add-items-to-cart.md
@@ -8,11 +8,11 @@ contributor_name: EY
 
 The `addRequisitionListItemsToCart` mutation adds requisition list items to the cart. The requisition list does not change after adding items to the cart.
 
-This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
-
 <InlineAlert variant="info" slots="text" />
 
 Use the [storeConfig query](../../../../schema/store/queries/store-config.md) with the `is_requisition_list_active` attribute to determine whether requisition lists are enabled.
+
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
 
 ## Syntax
 
@@ -26,6 +26,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`addRequisitionListItemsToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addRequisitionListItemsToCart) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -95,50 +99,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `addRequisitionListItemsToCart` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisitionListItemUids`| [ID!] | An array of UIDs presenting products to be added to the cart. If no UIDs are specified, all items in the requisition list will be added to the cart
-`requisitionListUid`| ID! | The unique ID of the requisition list
-
-## Output attributes
-
-The `addRequisitionListItemsToCart` object returns the status, cart and errors object.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`add_requisition_list_items_to_cart_user_errors` | [[AddRequisitionListItemToCartUserError!](#addrequisitionlistitemtocartusererror-attributes)] | Indicates why the attempt to add items to the requisition list was not successful
-`cart` | [Cart](#cart-object) | The cart after adding requisition list items
-`status` | Boolean! | Indicates whether the attempt to add items to the requisition list was successful
-
-### AddRequisitionListItemToCartUserError attributes
-
-The `AddRequisitionListItemToCartUserError` type contains the list of errors that describe why the attempt to add items to the requistion list was not successful.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`message` | String! | A description of the error
-`type` | [AddRequisitionListItemToCartUserErrorType!](#AddRequisitionListItemToCartUserErrorType) | The error type
-
-### AddRequisitionListItemToCartUserErrorType
-
-The AddRequisitionListItemToCartUserErrorType object can be one of the following values.
-
-Type | Description
---- | ---
-`LOW_QUANTITY` | The quantity of one of the items is low
-`OPTIONS_UPDATED` | The options have been updated
-`OUT_OF_STOCK` | One of the items is out of stock
-`UNAVAILABLE_SKU` | One of the items is unavailable
-
-### Cart object
-
-The `Cart` object can contain the following attributes.
-
-import CartObject from '/src/_includes/graphql/cart-object-24.md'
-
-<CartObject />

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/add-products.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/add-products.md
@@ -8,11 +8,11 @@ contributor_name: EY
 
 The `addProductsToRequisitionList` mutation adds products to a requisition list.
 
-This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
-
 <InlineAlert variant="info" slots="text" />
 
 Use the [storeConfig query](../../../../schema/store/queries/store-config.md) with the `is_requisition_list_active` attribute to determine whether requisition lists are enabled.
+
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
 
 ## Syntax
 
@@ -26,6 +26,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`addProductsToRequisitionList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addProductsToRequisitionList) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -93,38 +97,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `addProductsToRequisitionList` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisitionListItems`| [[RequisitionListItemsInput](#requisitionlistitemsinput-attributes)!]! | An array of products to be added to the requisition list
-`requisitionListUid`| ID! | The unique ID of the requisition list
-
-### RequisitionListItemsInput attributes
-
-The `RequisitionListItemsInput` type contains the list of products to add to a requisition list.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`entered_options` | [EnteredOptionInput!] | An array of customer entered option IDs
-`parent_sku` | String | For configurable products, the SKU of the parent product
-`quantity` | Float | The quantity of the product to add
-`selected_options` | [String!] | An array of selected option IDs
-`sku` | String! | The product SKU
-
-## Output attributes
-
-The `addProductsToRequisitionList` object returns the requisition list object.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisition_list` | [[RequisitionList](#requisitionlist-attributes)] | The requisition list after the items were added
-
-### RequisitionList attributes
-
-import RequisitionList from '/src/_includes/graphql/requisition-list.md'
-
-<RequisitionList />

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/clear-customer-cart.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/clear-customer-cart.md
@@ -6,13 +6,13 @@ contributor_name: EY
 
 # clearCustomerCart mutation
 
-The `clearCustomerCart` mutation clears the customer's cart.
-
-This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+The `clearCustomerCart` mutation clears the customer's cart. B2B requisition lists must be enabled to execute this mutation.
 
 <InlineAlert variant="info" slots="text" />
 
 Use the [storeConfig query](../../../../schema/store/queries/store-config.md) with the `is_requisition_list_active` attribute to determine whether requisition lists are enabled.
+
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
 
 ## Syntax
 
@@ -25,6 +25,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`clearCustomerCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-clearCustomerCart) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -53,28 +57,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `clearCustomerCart` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`cartUid`| String! | The masked ID of the cart.
-
-## Output attributes
-
-The `clearCustomerCart` object returns the status and cart object.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`cart` | [Cart](#cart-object) | The cart after clearing items.
-`status` | Boolean! | Indicates whether cart was cleared.
-
-### Cart object
-
-The `Cart` object can contain the following attributes.
-
-import CartObject from '/src/_includes/graphql/cart-object-24.md'
-
-<CartObject />

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/copy-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/copy-items.md
@@ -28,6 +28,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`copyItemsBetweenRequisitionLists`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-copyItemsBetweenRequisitionLists) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example copies an item from one requisition list to another.
@@ -69,38 +73,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `copyItemsBetweenRequisitionLists` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`destinationRequisitionListUid`| ID | The unique ID of the destination requisition list. If null, a new requisition list will be created
-`requisitionListItem`| [[CopyItemsBetweenRequisitionListsInput](#copyitemsbetweenrequisitionlistsinput-attributes)] | An array of selected requisition list items that are to be copied
-`sourceRequisitionListUid`| ID! | The unique ID of the source requisition list
-
-### CopyItemsBetweenRequisitionListsInput attributes
-
-The `CopyItemsBetweenRequisitionListsInput` type contains the list of products to copy from one requisition list to other.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisitionListItemUids` | [ID!]! | An array of IDs representing products copied from one requisition list to another
-
-## Output attributes
-
-The `copyItemsBetweenRequisitionLists` mutation returns the requisition list object to which the products were copied to.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisition_list` | [[RequisitionList](#requisitionlist-attributes)] | The destination requisition list after the items were copied
-
-### RequisitionList attributes
-
-import RequisitionList from '/src/_includes/graphql/requisition-list.md'
-
-<RequisitionList />
 
 ## Related topics
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/create.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/create.md
@@ -9,11 +9,11 @@ contributor_link: https://www.ztech.io/
 
 The `createRequisitionList` mutation creates a requisition list for the logged in customer.
 
-This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
-
 <InlineAlert variant="info" slots="text" />
 
 Use the [`storeConfig` query](../../../../schema/store/queries/store-config.md) with the `is_requisition_list_active` attribute to determine whether requisition lists are enabled.
+
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
 
 ## Syntax
 
@@ -27,6 +27,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`createRequisitionList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createRequisitionList) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -65,31 +69,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `createRequisitionList` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`description`| String | Description of the customer's requisition list
-`name` | String! | The name of the customer's requisition list
-
-## Output attributes
-
-The `createRequisitionList` mutation returns the new requisition list.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisition_list` | [[RequisitionList](#requisitionlist-attributes)] | The created requisition list
-
-### RequisitionList attributes
-
-import RequisitionList from '/src/_includes/graphql/requisition-list.md'
-
-<RequisitionList />
-
-## Related topics
-
-*  [updateRequisitionList mutation](update.md)
-*  [deleteRequisitionList mutation](delete.md)

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/delete-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/delete-items.md
@@ -6,13 +6,13 @@ contributor_name: EY
 
 # deleteRequisitionListItems mutation
 
-The `deleteRequisitionListItems` mutation removes items from the specified requisiton list for the logged in customer.
-
-This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
+The `deleteRequisitionListItems` mutation removes items from the specified requisition list for the logged in customer.
 
 <InlineAlert variant="info" slots="text" />
 
 Use the [storeConfig query](../../../../schema/store/queries/store-config.md) with the `is_requisition_list_active` attribute to determine whether requisition lists are enabled.
+
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
 
 ## Syntax
 
@@ -26,6 +26,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`deleteRequisitionListItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteRequisitionListItems) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -61,29 +65,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `deleteRequisitionListItems` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisitionListItemUids`| [ID!]! | An array of UIDs representing products to be removed from the requisition list
-`requisitionListUid`| ID! | The unique ID of the requisition list
-
-## Output attributes
-
-The `deleteRequisitionListItems` object returns the requisition list after the deletion of items.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisition_list` | [RequisitionList](#requisitionlist-attributes) | The requisition list after removing items
-
-### RequisitionList attributes
-
-import RequisitionList from '/src/_includes/graphql/requisition-list.md'
-
-<RequisitionList />
 
 ## Related topics
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/delete.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/delete.md
@@ -9,11 +9,11 @@ contributor_link: https://www.ztech.io/
 
 The `deleteRequisitionList` mutation deletes a requisition list of the logged in customer. The response can include any remaining requisition lists.
 
-This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
-
 <InlineAlert variant="info" slots="text" />
 
 Use the [storeConfig query](../../../../schema/store/queries/store-config.md) with the `is_requisition_list_active` attribute to determine whether requisition lists are enabled.
+
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
 
 ## Syntax
 
@@ -26,6 +26,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`deleteRequisitionList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteRequisitionList) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -70,39 +74,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `deleteRequisitionList` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisitionListUid` | ID! | The ID of the requisition list to delete
-
-## Output attributes
-
-The `deleteRequisitionList` mutation returns the status of the operation and any undeleted requisition lists.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisition_lists` | [[RequisitionLists](#requisitionlists-attributes)] | Contains the customer's remaining requisition lists
-`status` | Boolean | Indicates whether the request to delete the requisition list was successful
-
-### RequisitionLists attributes
-
-The RequisitionLists object contains array of requisition list items and pagination information.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`items` | [[RequisitionList](#requisitionlists-attributes)] | An array of requisition lists
-`page_info` | SearchResultPageInfo | Contains pagination metadata
-`total_count` | Int | The number of returned requisition lists
-
-### RequisitionList attributes
-
-import RequisitionList from '/src/_includes/graphql/requisition-list.md'
-
-<RequisitionList />
 
 ## Related topics
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/index.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/index.md
@@ -4,3 +4,22 @@ edition: b2b
 ---
 
 # Requisition list (B2B) mutations
+
+The B2B requisition list mutations allow you to perform the following operations:
+
+- Manage requisition lists
+  - [Create a requisition list](create.md)
+  - [Update a requisition list](update.md)
+  - [Delete a requistion list](delete.md)
+
+- Manage the contents of a requisition list
+  - [Add products to a requisition list](add-products.md)
+  - [Copy products from one requisition list to another](copy-items.md)
+  - [Move products from one requisition list to another](move-items.md)
+  - [Update items in a requisition list](update-items.md)
+  - [Delete items from a requistion list](delete-items.md)
+
+- Manage the cart
+  - [Add requisition list items to the cart](add-items-to-cart.md)
+  - [Clear the cart](clear-customer-cart.md)
+  

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/move-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/move-items.md
@@ -8,11 +8,11 @@ contributor_name: EY
 
 The `moveItemsBetweenRequisitionLists` mutation moves items from one requisition list to another.
 
-This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
-
 <InlineAlert variant="info" slots="text" />
 
 Use the [storeConfig query](../../../../schema/store/queries/store-config.md) with the `is_requisition_list_active` attribute to determine whether requisition lists are enabled.
+
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
 
 ## Syntax
 
@@ -27,6 +27,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`moveItemsBetweenRequisitionLists`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-moveItemsBetweenRequisitionLists) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -78,39 +82,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `moveItemsBetweenRequisitionLists` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`destinationRequisitionListUid`| ID! | The unique ID of the destination requisition list. If null, a new requisition list will be created
-`requisitionListItem`| [[MoveItemsBetweenRequisitionListsInput](#moveitemsbetweenrequisitionlistsinput-attributes)]  | An array of selected requisition list items that are to be moved from the source to the destination list
-`sourceRequisitionListUid`| ID! | The unique ID of the source requisition list
-
-### MoveItemsBetweenRequisitionListsInput attributes
-
-The `MoveItemsBetweenRequisitionListsInput` type contains the list of products to move from one requisition list to other.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisitionListItemUids` | [ID!]! | An array of IDs representing products moved from one requisition list to another
-
-## Output attributes
-
-The `moveItemsBetweenRequisitionLists` object returns the source requisition list and the destination requisition list object.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`destination_requisition_list` | [[RequisitionList](#requisitionlist-attributes)] | The destination requisition list after moving items
-`source_requisition_list` | [[RequisitionList](#requisitionlist-attributes)] | The source requisition list after moving items
-
-### RequisitionList attributes
-
-import RequisitionList from '/src/_includes/graphql/requisition-list.md'
-
-<RequisitionList />
 
 ## Related topics
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/update-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/update-items.md
@@ -8,11 +8,11 @@ contributor_name: EY
 
 The `updateRequisitionListItems` mutation updates products in a requisition list.
 
-This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
-
 <InlineAlert variant="info" slots="text" />
 
 Use the [storeConfig query](../../../../schema/store/queries/store-config.md) with the `is_requisition_list_active` attribute to determine whether requisition lists are enabled.
+
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
 
 ## Syntax
 
@@ -26,6 +26,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`updateRequisitionListItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateRequisitionListItems) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -68,7 +72,6 @@ mutation {
 
 ```json
 {
-{
   "data": {
     "updateRequisitionListItems": {
       "requisition_list": {
@@ -93,37 +96,3 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `updateRequisitionListItems` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisitionListItems`| [[UpdateRequisitionListItemsInput](#updaterequisitionlistitemsinput-attributes)!]! | An array of products to be updated in the requisition list
-`requisitionListUid`| ID! | The unique ID of the requisition list
-
-### UpdateRequisitionListItemsInput attributes
-
-The `UpdateRequisitionListItemsInput` type contains the list of products to be updated in the requisition list.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`entered_options` | [EnteredOptionInput!] | An array of customer entered option IDs
-`item_id` | ID! | The ID of the requisition list item to update
-`quantity` | Float | The new quantity of the item
-`selected_options` | [String!] | An array of selected option IDs
-
-## Output attributes
-
-The `updateRequisitionListItems` object returns the requisition list object.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisition_list` | [[RequisitionList](#requisitionlist-attributes)] | The requisition list after the items were updated
-
-### RequisitionList attributes
-
-import RequisitionList from '/src/_includes/graphql/requisition-list.md'
-
-<RequisitionList />

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/update.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/update.md
@@ -9,11 +9,11 @@ contributor_link: https://www.ztech.io/
 
 The `updateRequisitionList` mutation updates the name and, optionally, the description of a requisition list.
 
-This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
-
 <InlineAlert variant="info" slots="text" />
 
 Use the [storeConfig query](../../../../schema/store/queries/store-config.md) with the `is_requisition_list_active` attribute to determine whether requisition lists are enabled.
+
+This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
 
 ## Syntax
 
@@ -28,6 +28,10 @@ mutation {
   }
 }
 ```
+
+## Reference
+
+The [`updateRequisitionList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateRequisitionList) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -67,30 +71,6 @@ mutation {
   }
 }
 ```
-
-## Input attributes
-
-The `updateRequisitionList` mutation requires the following input.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`description`| String | Description of the customer's requisition list
-`name` | String! | The name of the customer's requisition list
-`requisitionListUid` | ID! | The ID of the new requisition list
-
-## Output attributes
-
-The `updateRequisitionList` mutation returns the new requisition list after updating a list.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`requisition_list` | [[RequisitionList](#requisitionlist-attributes)] | The updated requisition list
-
-### RequisitionList attributes
-
-import RequisitionList from '/src/_includes/graphql/requisition-list.md'
-
-<RequisitionList />
 
 ## Related topics
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes reference info from the requisition list section of the GraphQL schema docs.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
