### PR TITLE
GraphQL: Remove reference info from Attributes section

### DIFF
--- a/src/pages/graphql/schema/attributes/index.md
+++ b/src/pages/graphql/schema/attributes/index.md
@@ -4,4 +4,4 @@ title: Attributes
 
 # Attributes
 
-The attributes queries allow you to retrieve values stored as custom and [Entity-Attribute-Value (EAV)()] attributes. Custom attributes are those added on behalf of a merchant. For example, a merchant might need to add attributes to describe products, such as shape or volume. EAV attributes are defined by the system.
+The attributes queries allow you to retrieve values stored as custom and [Entity-Attribute-Value (EAV)](https://developer.adobe.com/commerce/php/development/components/attributes/) attributes. Custom attributes are those added on behalf of a merchant. For example, a merchant might need to add attributes to describe products, such as shape or volume. EAV attributes are defined by the system.

--- a/src/pages/graphql/schema/attributes/index.md
+++ b/src/pages/graphql/schema/attributes/index.md
@@ -3,3 +3,5 @@ title: Attributes
 ---
 
 # Attributes
+
+The attributes queries allow you to retrieve values stored as custom and [Entity-Attribute-Value (EAV)()] attributes. Custom attributes are those added on behalf of a merchant. For example, a merchant might need to add attributes to describe products, such as shape or volume. EAV attributes are defined by the system.

--- a/src/pages/graphql/schema/attributes/queries/attributes-form.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-form.md
@@ -14,7 +14,7 @@ These forms are visible when using the Admin to create or edit a customer or cus
 
 <InlineAlert variant="info" slots="text" />
 
-Use the [country](../../store/queries/country.md) and [countries](../../store/queries/countries.md) mutations to retrieve information about the region_id and country_id attributes.
+Use the [country](../../store/queries/country.md) and [countries](../../store/queries/countries.md) mutations to retrieve information about the `region_id` and `country_id` attributes.
 
 The following table maps the display names of the applicable forms to values that you can specify as a `formCode` value.
 
@@ -24,6 +24,7 @@ The following table maps the display names of the applicable forms to values tha
 | Customer | Customer Registration | `customer_account_create` |
 | Customer address |  Customer Address Registration |  `customer_register_address` |
 | Customer address | Customer Account Address | `customer_address_edit` |
+
 <InlineAlert slots="text" />
 
 You cannot query on the Admin Checkout form.
@@ -31,6 +32,10 @@ You cannot query on the Admin Checkout form.
 ## Syntax
 
 `{attributesForm(formCode: String!): {AttributesFormOutput!}}`
+
+## Reference
+
+The [`attributesForm`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-attributesForm) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 
@@ -139,57 +144,3 @@ The following query returns the list of attributes metadata associated to the fo
   }
 }
 ```
-
-## Input attributes
-
-Attribute | Data Type | Description
---- |-----------| ---
-`formCode` | String!   | Form code
-
-## Output attributes
-
-The `AttributesFormOutput` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`items` | [CustomAttributeMetadataInterface!]! | Requested attributes metadata
-`errors` | [AttributeMetadataError!]! | Errors of retrieving certain attributes metadata
-
-The `CustomAttributeMetadataInterface` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`code` | ID! | The unique identifier for an attribute code. This value should be in lowercase letters without spaces
-`default_value` | String | Default attribute value
-`entity_type` | AttributeEntityTypeEnum! | The type of entity that defines the attribute
-`frontend_input` | AttributeFrontendInputEnum | The frontend input type of the attribute
-`is_comparable` | Boolean | Whether a product or category attribute can be compared against another or not
-`is_filterable` | Boolean | Whether a product or category attribute can be filtered or not
-`is_filterable_in_search` | Boolean | Whether a product or category attribute can be filtered in search or not
-`is_html_allowed_on_front` | Boolean | Whether a product or category attribute can use HTML on front or not
-`is_required` | Boolean! | Whether the attribute value is required
-`is_searchable` | Boolean | Whether a product or category attribute can be searched or not
-`is_unique` | Boolean! | Whether the attribute value must be unique
-`is_used_for_price_rules` | Boolean | Whether a product or category attribute can be used for price rules or not
-`is_used_for_promo_rules` | Boolean | Whether a product or category attribute is used for promo rules or not
-`is_visible_in_advanced_search` | Boolean | Whether a product or category attribute is visible in advanced search or not
-`is_visible_on_front` | Boolean | Whether a product or category attribute is visible on front or not
-`is_wysiwyg_enabled` | Boolean | Whether a product or category attribute has WYSIWYG enabled or not
-`label` | String | The label assigned to the attribute
-`options` | [CustomAttributeOptionInterface!]! | Attribute options
-`used_in_product_listing` | Boolean | Whether a product or category attribute is used in product listing or not
-
-The `CustomAttributeOptionInterface` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`is_default` | Boolean | Is the option value default
-`label` | String! | The label assigned to the attribute option
-`value` | String! | The attribute option value
-
-The `AttributeMetadataError` object contains the following attributes:
-
-Attribute | Data Type | Description
---- | --- | ---
-`message` | String! | Attribute metadata retrieval error message
-`type` | AttributeMetadataErrorType! | Attribute metadata retrieval error type

--- a/src/pages/graphql/schema/attributes/queries/attributes-form.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-form.md
@@ -35,7 +35,7 @@ You cannot query on the Admin Checkout form.
 
 ## Reference
 
-The [`attributesForm`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-attributesForm) reference provides detailed information about the types and fields defined in this query.
+The [`attributesForm`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-attributesForm) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/queries/attributes-list.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-list.md
@@ -18,7 +18,7 @@ The possible values for this attribute are populated by the modules introducing 
 
 ## Reference
 
-The [`attributesList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-attributesList) reference provides detailed information about the types and fields defined in this query.
+The [`attributesList`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-attributesList) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/queries/attributes-list.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-list.md
@@ -16,6 +16,10 @@ The possible values for this attribute are populated by the modules introducing 
 
 `{attributesList(entityType: AttributeEntityTypeEnum!): {AttributesMetadataOutput}}`
 
+## Reference
+
+The [`attributesList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-attributesList) reference provides detailed information about the types and fields defined in this query.
+
 ## Example usage
 
 ### Attributes list for `customer`
@@ -341,78 +345,3 @@ The following call returns the list of attributes metadata for a `catalog_produc
   }
 }
 ```
-
-## Input attributes
-
-The `AttributeEntityTypeEnum` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`entityType` | String | The type of entity that defines the attribute
-`filters` | AttributeFilterInput | Identifies which filter inputs to search for and return
-
-## Attribute Filter Input
-
-The `AttributeFilterInput` object specifies the filters used for attributes. It contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`is_comparable` | Boolean | Whether a product or category attribute can be compared against another or not
-`is_filterable` | Boolean | Whether a product or category attribute can be filtered or not
-`is_filterable_in_search` | Boolean | Whether a product or category attribute can be filtered in search or not
-`is_html_allowed_on_front` | Boolean | Whether a product or category attribute can use HTML on front or not
-`is_searchable` | Boolean | Whether a product or category attribute can be searched or not
-`is_used_for_price_rules` | Boolean | Whether a product or category attribute can be used for price rules or not
-`is_used_for_promo_rules` | Boolean | Whether a product or category attribute is used for promo rules or not
-`is_visible_in_advanced_search` | Boolean | Whether a product or category attribute is visible in advanced search or not
-`is_visible_on_front` | Boolean | Whether a product or category attribute is visible on front or not
-`is_wysiwyg_enabled` | Boolean | Whether a product or category attribute has WYSIWYG enabled or not
-`used_in_product_listing` | Boolean | Whether a product or category attribute is used in product listing or not
-
-## Output attributes
-
-The `AttributesMetadataOutput` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`errors` | [AttributeMetadataError!]! | Errors of retrieving certain attributes metadata
-`items` | [CustomAttributeMetadataInterface!]! | Requested attributes metadata
-
-The `CustomAttributeMetadataInterface` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`code` | ID! | The unique identifier for an attribute code. This value should be in lowercase letters without spaces
-`default_value` | String | Default attribute value
-`entity_type` | AttributeEntityTypeEnum! | The type of entity that defines the attribute
-`frontend_input` | AttributeFrontendInputEnum | The frontend input type of the attribute
-`is_comparable` | Boolean | Whether a product or category attribute can be compared against another or not
-`is_filterable` | Boolean | Whether a product or category attribute can be filtered or not
-`is_filterable_in_search` | Boolean | Whether a product or category attribute can be filtered in search or not
-`is_html_allowed_on_front` | Boolean | Whether a product or category attribute can use HTML on front or not
-`is_required` | Boolean! | Whether the attribute value is required
-`is_searchable` | Boolean | Whether a product or category attribute can be searched or not
-`is_unique` | Boolean! | Whether the attribute value must be unique
-`is_used_for_price_rules` | Boolean | Whether a product or category attribute can be used for price rules or not
-`is_used_for_promo_rules` | Boolean | Whether a product or category attribute is used for promo rules or not
-`is_visible_in_advanced_search` | Boolean | Whether a product or category attribute is visible in advanced search or not
-`is_visible_on_front` | Boolean | Whether a product or category attribute is visible on front or not
-`is_wysiwyg_enabled` | Boolean | Whether a product or category attribute has WYSIWYG enabled or not
-`label` | String | The label assigned to the attribute
-`options` | [CustomAttributeOptionInterface!]! | Attribute options
-`used_in_product_listing` | Boolean | Whether a product or category attribute is used in product listing or not
-
-The `CustomAttributeOptionInterface` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`is_default` | Boolean | Is the option value default
-`label` | String! | The label assigned to the attribute option
-`value` | String! | The attribute option value
-
-The `AttributeMetadataError` object contains the following attributes:
-
-Attribute | Data Type | Description
---- | --- | ---
-`message` | String! | Attribute metadata retrieval error message
-`type` | AttributeMetadataErrorType! | Attribute metadata retrieval error type

--- a/src/pages/graphql/schema/attributes/queries/attributes-metadata.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-metadata.md
@@ -22,10 +22,6 @@ The `attributesMetadata` query returns everything available in [`customAttribute
 }
 ```
 
-## Reference
-
-The [`attributesMetadata`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-attributesMetadata) reference provides detailed information about the types and fields defined in this query.
-
 ## Example usage
 
 **Request:**
@@ -107,3 +103,17 @@ attributesMetadata(
           }
         }
 ```
+
+## Input attributes
+
+Attribute | Data type | Description
+--- | --- | ---
+`attributeUids` | [ID!] | An array of attribute IDs to search
+`entityType` | AttributeEntityTypeEnum! | The type of entity to search
+`showSystemAttributes` | Boolean | Indicates whether to also return matching system attributes
+
+## Output attributes
+
+import AttributeMetadata from '/src/_includes/graphql/attribute-metadata.md'
+
+<AttributeMetadata />

--- a/src/pages/graphql/schema/attributes/queries/attributes-metadata.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-metadata.md
@@ -22,6 +22,10 @@ The `attributesMetadata` query returns everything available in [`customAttribute
 }
 ```
 
+## Reference
+
+The [`attributesMetadata`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-attributesMetadata) reference provides detailed information about the types and fields defined in this query.
+
 ## Example usage
 
 **Request:**
@@ -103,17 +107,3 @@ attributesMetadata(
           }
         }
 ```
-
-## Input attributes
-
-Attribute | Data type | Description
---- | --- | ---
-`attributeUids` | [ID!] | An array of attribute IDs to search
-`entityType` | AttributeEntityTypeEnum! | The type of entity to search
-`showSystemAttributes` | Boolean | Indicates whether to also return matching system attributes
-
-## Output attributes
-
-import AttributeMetadata from '/src/_includes/graphql/attribute-metadata.md'
-
-<AttributeMetadata />

--- a/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata-v2.md
+++ b/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata-v2.md
@@ -21,6 +21,10 @@ This new query has several features that were not available in the deprecated qu
 
 `{customAttributeMetadataV2(attributes: [AttributeInput!]): {AttributesMetadataOutput!}}`
 
+## Reference
+
+The [`customAttributeMetadataV2`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customAttributeMetadataV2) reference provides detailed information about the types and fields defined in this query.
+
 ## Example usage
 
 ### Custom attribute metadata for a `customer` attribute
@@ -260,83 +264,3 @@ The `swatch options` are the possible values of the attribute.
   }
 }
 ```
-
-## Input attributes
-
-The `AttributeInput` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`attribute_code` | String | The unique identifier for an attribute. This value should be in lowercase letters without spaces
-`entity_type` | String | The type of entity that defines the attribute
-
-## Output attributes
-
-The `AttributesMetadataOutput` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`errors` | [AttributeMetadataError!]! | Errors of retrieving certain attributes metadata
-`items` | [CustomAttributeMetadataInterface!]! | Requested attributes metadata
-
-The `CustomAttributeMetadataInterface` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`code` | ID! | The unique identifier for an attribute. This value should be in lowercase letters without spaces
-`default_value` | String | Default attribute value
-`entity_type` | AttributeEntityTypeEnum! | The type of entity that defines the attribute. Possible values are CATALOG_CATEGORY and CATALOG_PRODUCT
-`frontend_input` | AttributeFrontendInputEnum | The frontend input type of the attribute. Possible values are BOOLEAN, DATE, DATETIME, FILE, GALLERY, HIDDEN, IMAGE, MEDIA_IMAGE, MULTILINE, MULTISELECT, PRICE, SELECT, TEXT, TEXTAREA, WEIGHT and UNDEFINED
-`is_comparable` | Boolean | Whether a product or category attribute can be compared against another or not
-`is_filterable` | Boolean | Whether a product or category attribute can be filtered or not
-`is_filterable_in_search` | Boolean | Whether a product or category attribute can be filtered in search or not
-`is_html_allowed_on_front` | Boolean | Whether a product or category attribute can use HTML on front or not
-`is_required` | Boolean! | Whether the attribute value is required
-`is_searchable` | Boolean | Whether a product or category attribute can be searched or not
-`is_unique` | Boolean! | Whether the attribute value must be unique
-`is_used_for_price_rules` | Boolean | Whether a product or category attribute can be used for price rules or not
-`is_used_for_promo_rules` | Boolean | Whether a product or category attribute is used for promo rules or not
-`is_visible_in_advanced_search` | Boolean | Whether a product or category attribute is visible in advanced search or not
-`is_visible_on_front` | Boolean | Whether a product or category attribute is visible on front or not
-`is_wysiwyg_enabled` | Boolean | Whether a product or category attribute has WYSIWYG enabled or not
-`label` | String | The label assigned to the attribute
-`options` | [CustomAttributeOptionInterface!]! | Attribute options
-`used_in_product_listing` | Boolean | Whether a product or category attribute is used in product listing or not
-
-The `CustomAttributeOptionInterface` object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`is_default` | Boolean | Is the option value default
-`label` | String! | The label assigned to the attribute option
-`value` | String! | The attribute option value
-
-The `AttributeMetadataError` object contains the following attributes:
-
-Attribute | Data Type | Description
---- | --- | ---
-`message` | String! | Attribute metadata retrieval error message
-`type` | AttributeMetadataErrorType! | Attribute metadata retrieval error type
-
-The `CatalogAttributeMetadata` is an implementation of the `CustomAttributeMetadataInterface`. This object contains the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`apply_to` | [CatalogAttributeApplyToEnum] | To which catalog types an attribute can be applied. Possible values are SIMPLE, VIRTUAL, BUNDLE, DOWNLOADABLE, CONFIGURABLE, GROUPED and CATEGORY
-`is_comparable` | Boolean! | Whether a product or category attribute can be compared against another or not
-`is_filterable` | Boolean! | Whether a product or category attribute can be filtered or not
-`is_filterable_in_search` | Boolean! | Whether a product or category attribute can be filtered in search or not
-`is_html_allowed_on_front` | Boolean! | Whether a product or category attribute can use HTML on front or not
-`is_used_for_price_rules` | Boolean! | Whether a product or category attribute can be used for price rules or not
-`is_searchable` | Boolean! | Whether a product or category attribute can be searched or not
-`is_used_for_promo_rules` | Boolean! | Whether a product or category attribute is used for promo rules or not
-`is_wysiwyg_enabled` | Boolean! | Whether a product or category attribute has WYSIWYG enabled or not
-`used_in_product_listing` | Boolean! | Whether a product or category attribute is used in product listing or not
-
-Additionally, if the attribute manages `swatch options` (values of the attribute), this object will contain the following attributes:
-
-Attribute | Data Type | Description
---- |---| ---
-`swatch_input_type` | SwatchInputTypeEnum | Input type of the swatch attribute option. Possible values are BOOLEAN, DATE, DATETIME, DROPDOWN, FILE, GALLERY, HIDDEN, IMAGE, MEDIA_IMAGE, MULTILINE, MULTISELECT, PRICE, SELECT, TEXT, TEXTAREA, UNDEFINED, VISUAL and WEIGHT
-`update_product_preview_image` | Boolean | Whether update product preview image or not
-`use_product_image_for_swatch` | Boolean | Whether use product image for swatch or not

--- a/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata-v2.md
+++ b/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata-v2.md
@@ -23,7 +23,7 @@ This new query has several features that were not available in the deprecated qu
 
 ## Reference
 
-The [`customAttributeMetadataV2`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customAttributeMetadataV2) reference provides detailed information about the types and fields defined in this query.
+The [`customAttributeMetadataV2`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#query-customAttributeMetadataV2) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata.md
+++ b/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata.md
@@ -10,9 +10,15 @@ The `customAttributeMetadata` query has been deprecated. Use the [`customAttribu
 
 The `customAttributeMetadata` query returns the attribute type, given an attribute code and entity type. All entity attributes can be added to an equivalent GraphQL type, including custom, extension, and EAV (which have precedence set in that order for collisions). The GraphQL query consumer does not have the ability to know a field's attribute type.
 
+The `StorefrontProperties` output object returns information about a product attribute. Storefront properties are configured in the Admin at **Stores** > Attributes > **Product** > `Attribute Name` > **Storefront Properties**.
+
 ## Syntax
 
 `customAttributeMetadata(attributes: [AttributeInput!]!): CustomAttributeMetadata`
+
+## Reference
+
+The [`customAttributeMetadata`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customAttributeMetadata) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 
@@ -225,49 +231,6 @@ The following query returns the attribute type for various custom and EAV attrib
   }
 }
 ```
-
-## Input attributes
-
-The `AttributeInput` input object requires the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`attribute_code` | String | The unique identifier for an attribute code. This value should be in lowercase letters without spaces
-`entity_type` | String | The type of entity that defines the attribute, such as `catalog_product`, `catalog_category`, or `customer`
-
-## Output attributes
-
-The `CustomAttributeMetadata` object contains the `items` attribute field, which returns an array of `Attribute` objects. The `Attribute` object can contain the following attributes.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`attribute_code` | String | The unique identifier for an attribute code. This value should be in lowercase letters without spaces
-`attribute_options` | [`AttributeOption`] | An array of attribute options
-`attribute_type` | String | The data type of the attribute
-`entity_type` | String | The type of entity that defines the attribute, such as `catalog_product`, `catalog_category`, or `customer`
-`input_type` | String | The frontend input type of the attribute
-`storefront_properties` | [StorefrontProperties](#storefrontproperties-object) | Contains details about the storefront properties configured for the attribute
-
-### AttributeOption object
-
-The `AttributeOption` object contains the name and value of the option.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`label` | String | The name of an attribute option
-`value` | String | The value assigned to an attribute option
-
-### StorefrontProperties object
-
-The `StorefrontProperties` object returns information about a product attribute. Storefront properties are configured in the Admin at **Stores** > Attributes > **Product** > `Attribute Name` > **Storefront Properties**.
-
-Attribute |  Data Type | Description
---- | --- | ---
-`position`| Int | The relative position of the attribute in the layered navigation block
-`use_in_layered_navigation` | UseInLayeredNavigationOptions | Indicates whether the attribute is filterable with results, without results, or not at all
-`use_in_product_listing` | Boolean | Indicates whether the attribute is displayed in product listings
-`use_in_search_results_layered_navigation`| Boolean | Indicates whether the attribute can be used in layered navigation on search results pages
-`visible_on_catalog_pages`| Boolean | Indicates whether the attribute is displayed on product pages
 
 ## Errors
 

--- a/src/pages/graphql/schema/attributes/queries/index.md
+++ b/src/pages/graphql/schema/attributes/queries/index.md
@@ -3,3 +3,11 @@ title: Attributes queries
 ---
 
 # Attributes queries
+
+The following queries allow you to retrieve details about custom and EAV attributes:
+
+* [`attributesForm`](attributes-form.md)
+* [`attributesList`](attributes-list.md)
+* [`attributesMetadata`](attributes-metadata.md) (Deprecated)
+* [`customAttributeMetadata`](custom-attribute-metadata.md) (Deprecated)
+* [`customAttributeMetadataV2`](custom-attribute-metadata-v2.md)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the manually maintained reference information from the topics in the pages/graphql/schema/attributes directory.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
