### PR TITLE
Add core versions to graphql API ref TOC

### DIFF
--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -1230,11 +1230,11 @@ module.exports = [
     ],
   },
   {
-    title: "Reference",
+    title: "Reference (2.4.6)",
     path: "/graphql/reference",
     pages: [
       {
-        title: "Reference (Beta)",
+        title: "Reference (2.4.7-beta)",
         path: "/graphql/reference/beta"
       }
     ]


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds version clarity to the TOC for GraphQL API reference pages.

According to PM, the current nav is confusing customers. They "think all of our APIs are in beta..."

PM agreed that this was an acceptable solution for now, but we should re-examine how we do this for future betas.

![Screenshot 2023-11-21 at 10 27 20 AM](https://github.com/AdobeDocs/commerce-webapi/assets/13662379/091ebb71-c466-492a-a35e-dbbca58b9543)
