### PR TITLE
Remove note that Authentification header is required. 

### DIFF
--- a/src/pages/graphql/schema/b2b/company/mutations/create.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create.md
@@ -9,8 +9,6 @@ The `createCompany` mutation creates a company at the request of either a custom
 
 The company administrator cannot log in or perform additional company-related tasks until an administrator approves the request to create a company.
 
-This mutation requires a valid [customer authentication token](../../../customer/mutations/generate-token.md).
-
 ## Syntax
 
 ```graphql


### PR DESCRIPTION
Remove note that Authentification header is required.  Cause you can create company without defining it.

## Purpose of this pull request

Remove confusion for developers. Cause its not true that you need an account to be able to create a company

## Affected pages

https://developer.adobe.com/commerce/webapi/graphql/schema/b2b/company/mutations/create/
