### PR TITLE
Update links to Klarna docs

### DIFF
--- a/src/pages/graphql/payment-methods/klarna.md
+++ b/src/pages/graphql/payment-methods/klarna.md
@@ -40,9 +40,9 @@ Klarna payments require cart information to initiate the session. For this reaso
 
 1. The PWA client renders the Klarna payment widget.
 
-   The PWA client uses the `client_token` and `payment_categories` to initialize the [Klarna Payments JS SDK](https://developers.klarna.com/documentation/klarna-payments/javascript-sdk/).
+   The PWA client uses the `client_token` and `payment_categories` to initialize the [Klarna Payments JS SDK](https://docs.klarna.com/klarna-payments/in-depth-knowledge/klarna-payments-sdk-reference/).
 
-1. The PWA client sends the [authorization](https://developers.klarna.com/documentation/klarna-payments/single-call-descriptions/authorize-the-purchase/) directly to Klarna.
+1. The PWA client sends the [authorization](https://docs.klarna.com/klarna-payments/integrate-with-klarna-payments/step-2-check-out/22-get-authorization/) directly to Klarna.
 
    On the checkout page, the shopper selects Klarna as the payment method and clicks **Place Order**. When this happens, the PWA client must send the `authorize()` call to Klarna. Then the shopper follows the authorization steps on the Klarna inline modal. During this phase, the communication between the PWA client and Klarna is handled directly by the Klarna Payments JS SDK.
 

--- a/src/pages/graphql/payment-methods/klarna.md
+++ b/src/pages/graphql/payment-methods/klarna.md
@@ -80,7 +80,7 @@ In order to always present shoppers with the latest available payment options pr
 
 1. The application returns an updated `cart` object.
 
-1. [Reload the widget](https://developers.klarna.com/documentation/klarna-payments/single-call-descriptions/load-klarna-payments/) on the client side.
+1. [Reload the widget](https://docs.klarna.com/klarna-payments/integration-best-practices/purchase-experience/payment-widget/?q=widget) on the client side.
 
 The following diagram describes the workflow:
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes broken links to the Klarna developer documentation.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
