### PR TITLE
update link in CreateGuestCart

### DIFF
--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -186,6 +186,10 @@ module.exports = [
                 path: "/graphql/schema/cart/mutations/create-empty-cart/",
               },
               {
+                title: "createGuestCart",
+                path: "/graphql/schema/cart/mutations/create-guest-cart/",
+              },
+              {
                 title: "mergeCarts",
                 path: "/graphql/schema/cart/mutations/merge/",
               },

--- a/src/pages/graphql/schema/cart/mutations/create-guest-cart.md
+++ b/src/pages/graphql/schema/cart/mutations/create-guest-cart.md
@@ -18,7 +18,7 @@ mutation {
 
 ## Reference
 
-The `createGuestCart` reference provides detailed information about the types and fields defined in this mutation.
+The [`createGuestCart`](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#mutation-createGuestCart) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -83,20 +83,6 @@ The mutation returns a cart using the same `cart_id`.
   }
 }
 ```
-
-## Input attributes
-
-### CreateGuestCartInput object
-
-The `CreateGuestCartInput` object contains the following attributes:
-
-Attribute | Type | Description
---- |----| ---
-`cart_uid` | ID | Optional client-generated ID
-
-## Output attributes
-
-The `createGuestCart` mutation returns the newly created cart.
 
 ## Errors
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the [CreateGuestCart](https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/create-guest-cart/) page to include a direct link to the [SpectaQL listing](https://developer.adobe.com/commerce/webapi/graphql-api/beta/index.html#mutation-createGuestCart) and removes information that the link makes redundant. As requested by @keharper.