### PR TITLE
Fixed typo in a URL

### DIFF
--- a/src/pages/graphql/schema/checkout/index.md
+++ b/src/pages/graphql/schema/checkout/index.md
@@ -10,7 +10,7 @@ The checkout workflow differs for each online payment time. See the following to
 
 *  [Braintree](../../payment-methods/braintree.md)
 *  [Braintree vault](../../payment-methods/braintree-vault.md)
-*  [Payment Services checkout](../../payment-services/checkout.md
+*  [Payment Services checkout](../../payment-services/checkout.md)
 *  [Payment Services minicart](../../payment-services/minicart.md)
 *  [Klarna](../../payment-methods/klarna.md) (no longer supported)
 *  [PayPal Express Checkout](../../payment-methods/paypal-express-checkout.md)


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a small typo in a URL.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi/graphql/schema/checkout/
