### PR TITLE
LYNX-329: Updated examples returning cart items field to use itemsV2

### DIFF
--- a/src/pages/graphql/schema/cart/interfaces/index.md
+++ b/src/pages/graphql/schema/cart/interfaces/index.md
@@ -42,33 +42,41 @@ mutation {
     ]
   ) {
     cart {
-      items {
-        uid
-        product {
-          name
-          sku
-        }
-        quantity
-        ... on ConfigurableCartItem {
-          configurable_options {
-            configurable_product_option_uid
-            configurable_product_option_value_uid
-            option_label
-            value_label
+      itemsV2 {
+        items {
+          uid
+          product {
+            name
+            sku
           }
-        }
-        ... on BundleCartItem {
-          bundle_options {
-            uid
-            label
-            type
-            values {
-              id
-              label
-              price
-              quantity
+          quantity
+          ... on ConfigurableCartItem {
+            configurable_options {
+              configurable_product_option_uid
+              configurable_product_option_value_uid
+              option_label
+              value_label
             }
           }
+          ... on BundleCartItem {
+              bundle_options {
+              uid
+              label
+              type
+              values {
+                id
+                label
+                price
+                quantity
+              }
+            }
+          }
+        }
+        total_count
+        page_info {
+            page_size
+            current_page
+            total_pages
         }
       }
     }
@@ -83,92 +91,100 @@ mutation {
   "data": {
     "addProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "uid": "MjU=",
-            "product": {
-              "name": "Erika Running Short",
-              "sku": "WSH12"
+        "itemsV2": {
+          "items": [
+            {
+              "uid": "MjU=",
+              "product": {
+                "name": "Erika Running Short",
+                "sku": "WSH12"
+              },
+              "quantity": 1,
+              "configurable_options": [
+                {
+                  "configurable_product_option_uid": "Y29uZmlndXJhYmxlLzIwNDgvOTM=",
+                  "configurable_product_option_value_uid": "Y29uZmlndXJhYmxlLzkzLzUz",
+                  "option_label": "Color",
+                  "value_label": "Green"
+                },
+                {
+                  "configurable_product_option_uid": "Y29uZmlndXJhYmxlLzIwNDgvMTYx",
+                  "configurable_product_option_value_uid": "Y29uZmlndXJhYmxlLzE2MS8xNzQ=",
+                  "option_label": "Size",
+                  "value_label": "28"
+                }
+              ]
             },
-            "quantity": 1,
-            "configurable_options": [
-              {
-                "configurable_product_option_uid": "Y29uZmlndXJhYmxlLzIwNDgvOTM=",
-                "configurable_product_option_value_uid": "Y29uZmlndXJhYmxlLzkzLzUz",
-                "option_label": "Color",
-                "value_label": "Green"
+            {
+              "uid": "Mjc=",
+              "product": {
+                "name": "Sprite Yoga Companion Kit",
+                "sku": "24-WG080"
               },
-              {
-                "configurable_product_option_uid": "Y29uZmlndXJhYmxlLzIwNDgvMTYx",
-                "configurable_product_option_value_uid": "Y29uZmlndXJhYmxlLzE2MS8xNzQ=",
-                "option_label": "Size",
-                "value_label": "28"
-              }
-            ]
-          },
-          {
-            "uid": "Mjc=",
-            "product": {
-              "name": "Sprite Yoga Companion Kit",
-              "sku": "24-WG080"
-            },
-            "quantity": 1,
-            "bundle_options": [
-              {
-                "uid": "YnVuZGxlLzE=",
-                "label": "Sprite Stasis Ball",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 1,
-                    "label": "Sprite Stasis Ball 55 cm",
-                    "price": 23,
-                    "quantity": 1
-                  }
-                ]
-              },
-              {
-                "uid": "YnVuZGxlLzI=",
-                "label": "Sprite Foam Yoga Brick",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 4,
-                    "label": "Sprite Foam Yoga Brick",
-                    "price": 5,
-                    "quantity": 1
-                  }
-                ]
-              },
-              {
-                "uid": "YnVuZGxlLzM=",
-                "label": "Sprite Yoga Strap",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 5,
-                    "label": "Sprite Yoga Strap 6 foot",
-                    "price": 14,
-                    "quantity": 1
-                  }
-                ]
-              },
-              {
-                "uid": "YnVuZGxlLzQ=",
-                "label": "Sprite Foam Roller",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 8,
-                    "label": "Sprite Foam Roller",
-                    "price": 19,
-                    "quantity": 1
-                  }
-                ]
-              }
-            ]
+              "quantity": 1,
+              "bundle_options": [
+                {
+                  "uid": "YnVuZGxlLzE=",
+                  "label": "Sprite Stasis Ball",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 1,
+                      "label": "Sprite Stasis Ball 55 cm",
+                      "price": 23,
+                      "quantity": 1
+                    }
+                  ]
+                },
+                {
+                  "uid": "YnVuZGxlLzI=",
+                  "label": "Sprite Foam Yoga Brick",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 4,
+                      "label": "Sprite Foam Yoga Brick",
+                      "price": 5,
+                      "quantity": 1
+                    }
+                  ]
+                },
+                {
+                  "uid": "YnVuZGxlLzM=",
+                  "label": "Sprite Yoga Strap",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 5,
+                      "label": "Sprite Yoga Strap 6 foot",
+                      "price": 14,
+                      "quantity": 1
+                    }
+                  ]
+                },
+                {
+                  "uid": "YnVuZGxlLzQ=",
+                  "label": "Sprite Foam Roller",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 8,
+                      "label": "Sprite Foam Roller",
+                      "price": 19,
+                      "quantity": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "total_count": 2,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       }
     }
   }

--- a/src/pages/graphql/schema/cart/mutations/add-bundle-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-bundle-products.md
@@ -81,25 +81,33 @@ mutation {
     ]
   }) {
     cart {
-      items {
-        uid
-        quantity
-        product {
-          sku
-        }
-        ... on BundleCartItem {
-          bundle_options {
-            uid
-            label
-            type
-            values {
-              id
+      itemsV2 {
+        items {
+          uid
+          quantity
+          product {
+            sku
+          }
+          ... on BundleCartItem {
+            bundle_options {
+              uid
               label
-              price
-              quantity
+              type
+              values {
+                id
+                label
+                price
+                quantity
+              }
             }
           }
         }
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }          
       }
     }
   }
@@ -113,83 +121,91 @@ mutation {
   "data": {
     "addBundleProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "uid": "MjI=",
-            "quantity": 1,
-            "product": {
-              "sku": "WSH12"
-            }
-          },
-          {
-            "uid": "MjQ=",
-            "quantity": 3,
-            "product": {
-              "sku": "24-WB01"
-            }
-          },
-          {
-            "uid": "MzI=",
-            "quantity": 1,
-            "product": {
-              "sku": "24-WG080"
-            },
-            "bundle_options": [
-              {
-                "uid": "YnVuZGxlLzE=",
-                "label": "Sprite Stasis Ball",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 2,
-                    "label": "Sprite Stasis Ball 65 cm",
-                    "price": 27,
-                    "quantity": 1
-                  }
-                ]
-              },
-              {
-                "uid": "YnVuZGxlLzI=",
-                "label": "Sprite Foam Yoga Brick",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 4,
-                    "label": "Sprite Foam Yoga Brick",
-                    "price": 5,
-                    "quantity": 2
-                  }
-                ]
-              },
-              {
-                "uid": "YnVuZGxlLzM=",
-                "label": "Sprite Yoga Strap",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 7,
-                    "label": "Sprite Yoga Strap 10 foot",
-                    "price": 21,
-                    "quantity": 1
-                  }
-                ]
-              },
-              {
-                "uid": "YnVuZGxlLzQ=",
-                "label": "Sprite Foam Roller",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 8,
-                    "label": "Sprite Foam Roller",
-                    "price": 19,
-                    "quantity": 1
-                  }
-                ]
+        "itemsV2": {
+          "items": [
+            {
+              "uid": "MjI=",
+              "quantity": 1,
+              "product": {
+                "sku": "WSH12"
               }
-            ]
+            },
+            {
+              "uid": "MjQ=",
+              "quantity": 3,
+              "product": {
+                "sku": "24-WB01"
+              }
+            },
+            {
+              "uid": "MzI=",
+              "quantity": 1,
+              "product": {
+                "sku": "24-WG080"
+              },
+              "bundle_options": [
+                {
+                  "uid": "YnVuZGxlLzE=",
+                  "label": "Sprite Stasis Ball",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 2,
+                      "label": "Sprite Stasis Ball 65 cm",
+                      "price": 27,
+                      "quantity": 1
+                    }
+                  ]
+                },
+                {
+                  "uid": "YnVuZGxlLzI=",
+                  "label": "Sprite Foam Yoga Brick",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 4,
+                      "label": "Sprite Foam Yoga Brick",
+                      "price": 5,
+                      "quantity": 2
+                    }
+                  ]
+                },
+                {
+                  "uid": "YnVuZGxlLzM=",
+                  "label": "Sprite Yoga Strap",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 7,
+                      "label": "Sprite Yoga Strap 10 foot",
+                      "price": 21,
+                      "quantity": 1
+                    }
+                  ]
+                },
+                {
+                  "uid": "YnVuZGxlLzQ=",
+                  "label": "Sprite Foam Roller",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 8,
+                      "label": "Sprite Foam Roller",
+                      "price": 19,
+                      "quantity": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "total_count": 3,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       }
     }
   }

--- a/src/pages/graphql/schema/cart/mutations/add-configurable-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-configurable-products.md
@@ -41,17 +41,25 @@ mutation {
     }
   ) {
     cart {
-      items {
-        uid
-        quantity
-        product {
-          name
-          sku
-        }
-        ... on ConfigurableCartItem {
-          configurable_options {
-            option_label
+      itemsV2 {
+        items {
+          uid
+          quantity
+          product {
+            name
+            sku
           }
+          ... on ConfigurableCartItem {
+            configurable_options {
+              option_label
+            }
+          }
+        }
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
         }
       }
     }
@@ -66,24 +74,32 @@ mutation {
   "data": {
     "addConfigurableProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "uid": "Mzc=",
-            "quantity": 2,
-            "product": {
-              "name": "Teton Pullover Hoodie",
-              "sku": "MH02"
-            },
-            "configurable_options": [
-              {
-                "option_label": "Color"
+        "itemsV2": {
+          "items": [
+            {
+              "uid": "Mzc=",
+              "quantity": 2,
+              "product": {
+                "name": "Teton Pullover Hoodie",
+                "sku": "MH02"
               },
-              {
-                "option_label": "Size"
-              }
-            ]
+              "configurable_options": [
+                {
+                  "option_label": "Color"
+                },
+                {
+                  "option_label": "Size"
+                }
+              ]
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       }
     }
   }

--- a/src/pages/graphql/schema/cart/mutations/add-downloadable-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-downloadable-products.md
@@ -60,20 +60,28 @@ mutation {
     }
   ) {
     cart {
-      items {
-        product {
-          sku
+      itemsV2 {
+        items {
+          product {
+            sku
+          }
+          quantity
+          ... on DownloadableCartItem {
+            links {
+              title
+              price
+            }
+            samples {
+              title
+              sample_url
+            }
+          }
         }
-        quantity
-        ... on DownloadableCartItem {
-          links {
-            title
-            price
-          }
-          samples {
-            title
-            sample_url
-          }
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
         }
       }
     }
@@ -83,43 +91,51 @@ mutation {
 
 **Response:**
 
-```text
+```json
 {
   "data": {
     "addDownloadableProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "product": {
-              "sku": "240-LV09"
-            },
-            "quantity": 1,
-            "links": [
-              {
-                "title": "Episode 2",
-                "price": 9
+        "itemsV2": {
+          "items": [
+            {
+              "product": {
+                "sku": "240-LV09"
               },
-              {
-                "title": "Episode 3",
-                "price": 9
-              }
-            ],
-            "samples": [
-              {
-                "title": "Trailer #1",
-                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/16/"
-              },
-              {
-                "title": "Trailer #2",
-                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/17/"
-              },
-              {
-                "title": "Trailer #3",
-                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/18/"
-              }
-            ]
+              "quantity": 1,
+              "links": [
+                {
+                  "title": "Episode 2",
+                  "price": 9
+                },
+                {
+                  "title": "Episode 3",
+                  "price": 9
+                }
+              ],
+              "samples": [
+                {
+                  "title": "Trailer #1",
+                  "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/16/"
+                },
+                {
+                  "title": "Trailer #2",
+                  "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/17/"
+                },
+                {
+                  "title": "Trailer #3",
+                  "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/18/"
+                }
+              ]
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       }
     }
   }
@@ -146,20 +162,28 @@ mutation {
     }
   ) {
     cart {
-      items {
-        product {
-          sku
+      itemsV2 {
+        items {
+          product {
+            sku
+          }
+          quantity
+          ... on DownloadableCartItem {
+            links {
+              title
+              price
+            }
+            samples {
+              title
+              sample_url
+            }
+          }
         }
-        quantity
-        ... on DownloadableCartItem {
-          links {
-            title
-            price
-          }
-          samples {
-            title
-            sample_url
-          }
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
         }
       }
     }
@@ -169,39 +193,47 @@ mutation {
 
 **Response:**
 
-```text
+```json
 {
   "data": {
     "addDownloadableProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "product": {
-              "sku": "240-LV07"
-            },
-            "quantity": 2,
-            "links": [
-              {
-                "title": "Solo Power Circuit",
-                "price": 14
-              }
-            ],
-            "samples": [
-              {
-                "title": "Trailer #1",
-                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/10/"
+        "itemsV2": {
+          "items": [
+            {
+              "product": {
+                "sku": "240-LV07"
               },
-              {
-                "title": "Trailer #2",
-                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/11/"
-              },
-              {
-                "title": "Trailer #3",
-                "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/12/"
-              }
-            ]
-          }
-        ]
+              "quantity": 2,
+              "links": [
+                {
+                  "title": "Solo Power Circuit",
+                  "price": 14
+                }
+              ],
+              "samples": [
+                {
+                  "title": "Trailer #1",
+                  "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/10/"
+                },
+                {
+                  "title": "Trailer #2",
+                  "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/11/"
+                },
+                {
+                  "title": "Trailer #3",
+                  "sample_url": "https://<M2_INSTANCE>/downloadable/download/sample/sample_id/12/"
+                }
+              ]
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
+          }          
+        }
       }
     }
   }

--- a/src/pages/graphql/schema/cart/mutations/add-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-products.md
@@ -73,12 +73,20 @@ mutation {
     ]
   ) {
     cart {
-      items {
-        product {
-          name
-          sku
+      itemsV2 {
+        items {
+          product {
+            name
+            sku
+          }
+          quantity
         }
-        quantity
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }
       }
     }
     user_errors {
@@ -96,15 +104,23 @@ mutation {
   "data": {
     "addProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "product": {
-              "name": "Strive Shoulder Pack",
-              "sku": "24-MB04"
-            },
-            "quantity": 1
+        "itemsV2": {
+          "items": [
+            {
+              "product": {
+                "name": "Strive Shoulder Pack",
+                "sku": "24-MB04"
+              },
+              "quantity": 1
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       },
       "user_errors": []
     }
@@ -135,13 +151,21 @@ mutation {
     ]
   ) {
     cart {
-      items {
-        id
-        product {
-          name
-          sku
+      itemsV2 {
+        items {
+          id
+          product {
+            name
+            sku
+          }
+          quantity
         }
-        quantity
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }
       }
     }
     user_errors {
@@ -159,24 +183,32 @@ mutation {
   "data": {
     "addProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "id": "24",
-            "product": {
-              "name": "Erika Running Short",
-              "sku": "WSH12"
+        "itemsV2": {
+          "items": [
+            {
+              "id": "24",
+              "product": {
+                "name": "Erika Running Short",
+                "sku": "WSH12"
+              },
+              "quantity": 1
             },
-            "quantity": 1
-          },
-          {
-            "id": "26",
-            "product": {
-              "name": "Erika Running Short-28-Green",
-              "sku": "WSH12-28-Green"
-            },
-            "quantity": 1
+            {
+              "id": "26",
+              "product": {
+                "name": "Erika Running Short-28-Green",
+                "sku": "WSH12-28-Green"
+              },
+              "quantity": 1
+            }
+          ],
+          "total_count": 2,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       },
       "user_errors": []
     }
@@ -203,20 +235,28 @@ mutation {
     ]
   ) {
     cart {
-      items {
-        product {
-          name
-          sku
-        }
-        ... on ConfigurableCartItem {
-          configurable_options {
-            configurable_product_option_uid
-            option_label
-            configurable_product_option_value_uid
-            value_label
+      itemsV2 {
+        items {
+          product {
+            name
+            sku
           }
+          ... on ConfigurableCartItem {
+            configurable_options {
+              configurable_product_option_uid
+              option_label
+              configurable_product_option_value_uid
+              value_label
+            }
+          }
+          quantity
         }
-        quantity
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }
       }
     }
     user_errors {
@@ -234,29 +274,37 @@ mutation {
   "data": {
     "addProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "product": {
-              "name": "Erika Running Short",
-              "sku": "WSH12"
-            },
-            "configurable_options": [
-              {
-                "configurable_product_option_uid": "Y29uZmlndXJhYmxlLzIwNDgvOTM=",
-                "option_label": "Color",
-                "configurable_product_option_value_uid": "Y29uZmlndXJhYmxlLzkzLzUz",
-                "value_label": "Green"
+        "itemsV2": {
+          "items": [
+            {
+              "product": {
+                "name": "Erika Running Short",
+                "sku": "WSH12"
               },
-              {
-                "configurable_product_option_uid": "Y29uZmlndXJhYmxlLzIwNDgvMTYx",
-                "option_label": "Size",
-                "configurable_product_option_value_uid": "Y29uZmlndXJhYmxlLzE2MS8xNzQ=",
-                "value_label": "28"
-              }
-            ],
-            "quantity": 1
+              "configurable_options": [
+                {
+                  "configurable_product_option_uid": "Y29uZmlndXJhYmxlLzIwNDgvOTM=",
+                  "option_label": "Color",
+                  "configurable_product_option_value_uid": "Y29uZmlndXJhYmxlLzkzLzUz",
+                  "value_label": "Green"
+                },
+                {
+                  "configurable_product_option_uid": "Y29uZmlndXJhYmxlLzIwNDgvMTYx",
+                  "option_label": "Size",
+                  "configurable_product_option_value_uid": "Y29uZmlndXJhYmxlLzE2MS8xNzQ=",
+                  "value_label": "28"
+                }
+              ],
+              "quantity": 1
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       },
       "user_errors": []
     }
@@ -290,22 +338,30 @@ mutation {
     ]
   ) {
     cart {
-      items {
-        product {
-          name
-          sku
-        }
-        ... on SimpleCartItem {
-          customizable_options {
-            customizable_option_uid
-            label
-            values {
-              customizable_option_value_uid
-              value
+      itemsV2 {
+        items {
+          product {
+            name
+            sku
+          }
+          ... on SimpleCartItem {
+            customizable_options {
+              customizable_option_uid
+              label
+              values {
+                customizable_option_value_uid
+                value
+              }
             }
           }
+          quantity
         }
-        quantity
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }
       }
     }
     user_errors {
@@ -323,28 +379,36 @@ mutation {
   "data": {
     "addProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "id": "19",
-            "product": {
-              "name": "Clamber Watch",
-              "sku": "24-WG03"
-            },
-            "customizable_options": [
-              {
-                "customizable_option_uid": "Y3VzdG9tLW9wdGlvbi8x",
-                "label": "Engraving",
-                "values": [
-                  {
-                    "customizable_option_value_uid": "Y3VzdG9tLW9wdGlvbi8x",
-                    "value": "Congrats, Julie!"
-                  }
-                ]
-              }
-            ],
-            "quantity": 1
+        "itemsV2": {
+          "items": [
+            {
+              "id": "19",
+              "product": {
+                "name": "Clamber Watch",
+                "sku": "24-WG03"
+              },
+              "customizable_options": [
+                {
+                  "customizable_option_uid": "Y3VzdG9tLW9wdGlvbi8x",
+                  "label": "Engraving",
+                  "values": [
+                    {
+                      "customizable_option_value_uid": "Y3VzdG9tLW9wdGlvbi8x",
+                      "value": "Congrats, Julie!"
+                    }
+                  ]
+                }
+              ],
+              "quantity": 1
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       },
       "user_errors": []
     }
@@ -389,25 +453,33 @@ mutation {
     ]
   ) {
     cart {
-      items {
-        uid
-        product {
-          name
-          sku
-        }
-        quantity
-        ... on BundleCartItem {
-          bundle_options {
-            uid
-            label
-            type
-            values {
-              id
+      itemsV2 {
+        items {
+          uid
+          product {
+            name
+            sku
+          }
+          quantity
+          ... on BundleCartItem {
+            bundle_options {
+              uid
               label
-              price
-              quantity
+              type
+              values {
+                id
+                label
+                price
+                quantity
+              }
             }
           }
+        }
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
         }
       }
     }
@@ -426,70 +498,78 @@ mutation {
   "data": {
     "addProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "uid": "MTQ=",
-            "product": {
-              "name": "Sprite Yoga Companion Kit",
-              "sku": "24-WG080"
-            },
-            "quantity": 1,
-            "bundle_options": [
-              {
-                "uid": "YnVuZGxlLzE=",
-                "label": "Sprite Stasis Ball",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 1,
-                    "label": "Sprite Stasis Ball 55 cm",
-                    "price": 23,
-                    "quantity": 1
-                  }
-                ]
+        "itemsV2": {
+          "items": [
+            {
+              "uid": "MTQ=",
+              "product": {
+                "name": "Sprite Yoga Companion Kit",
+                "sku": "24-WG080"
               },
-              {
-                "uid": "YnVuZGxlLzI=",
-                "label": "Sprite Foam Yoga Brick",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 4,
-                    "label": "Sprite Foam Yoga Brick",
-                    "price": 5,
-                    "quantity": 1
-                  }
-                ]
-              },
-              {
-                "uid": "YnVuZGxlLzM=",
-                "label": "Sprite Yoga Strap",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 5,
-                    "label": "Sprite Yoga Strap 6 foot",
-                    "price": 14,
-                    "quantity": 1
-                  }
-                ]
-              },
-              {
-                "uid": "YnVuZGxlLzQ=",
-                "label": "Sprite Foam Roller",
-                "type": "radio",
-                "values": [
-                  {
-                    "id": 8,
-                    "label": "Sprite Foam Roller",
-                    "price": 19,
-                    "quantity": 1
-                  }
-                ]
-              }
-            ]
+              "quantity": 1,
+              "bundle_options": [
+                {
+                  "uid": "YnVuZGxlLzE=",
+                  "label": "Sprite Stasis Ball",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 1,
+                      "label": "Sprite Stasis Ball 55 cm",
+                      "price": 23,
+                      "quantity": 1
+                    }
+                  ]
+                },
+                {
+                  "uid": "YnVuZGxlLzI=",
+                  "label": "Sprite Foam Yoga Brick",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 4,
+                      "label": "Sprite Foam Yoga Brick",
+                      "price": 5,
+                      "quantity": 1
+                    }
+                  ]
+                },
+                {
+                  "uid": "YnVuZGxlLzM=",
+                  "label": "Sprite Yoga Strap",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 5,
+                      "label": "Sprite Yoga Strap 6 foot",
+                      "price": 14,
+                      "quantity": 1
+                    }
+                  ]
+                },
+                {
+                  "uid": "YnVuZGxlLzQ=",
+                  "label": "Sprite Foam Roller",
+                  "type": "radio",
+                  "values": [
+                    {
+                      "id": 8,
+                      "label": "Sprite Foam Roller",
+                      "price": 19,
+                      "quantity": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       },
       "user_errors": []
     }
@@ -525,25 +605,33 @@ mutation {
     ]
   ) {
     cart {
-      items {
-        uid
-        product {
-          name
-          sku
-        }
-        quantity
-        ... on BundleCartItem {
-          bundle_options {
-            uid
-            label
-            type
-            values {
-              id
+      itemsV2 {
+        items {
+          uid
+          product {
+            name
+            sku
+          }
+          quantity
+          ... on BundleCartItem {
+            bundle_options {
+              uid
               label
-              price
-              quantity
+              type
+              values {
+                id
+                label
+                price
+                quantity
+              }
             }
           }
+        }
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
         }
       }
     }

--- a/src/pages/graphql/schema/cart/mutations/add-simple-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-simple-products.md
@@ -48,13 +48,21 @@ mutation {
     }
   ) {
     cart {
-      items {
-        id
-        product {
-          name
-          sku
+      itemsV2 {
+        items {
+          id
+          product {
+            name
+            sku
+          }
+          quantity
         }
-        quantity
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }
       }
     }
   }
@@ -68,16 +76,24 @@ mutation {
   "data": {
     "addSimpleProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "id": "13",
-            "product": {
-              "name": "Strive Shoulder Pack",
-              "sku": "24-MB04"
-            },
-            "quantity": 1
-          }
-        ]
+        "itemsV2": {
+          "items": [
+            {
+              "id": "13",
+              "product": {
+                "name": "Strive Shoulder Pack",
+                "sku": "24-MB04"
+              },
+              "quantity": 1
+            }
+          ],
+          "total_items": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
+          }          
+        }
       }
     }
   }
@@ -108,18 +124,26 @@ mutation {
     }
   }) {
     cart {
-      items {
-        product {
-           name
-        }
-        quantity
-        ... on SimpleCartItem {
-          customizable_options {
-            label
-            values {
-              value
+      itemsV2 {
+        items {
+          product {
+            name
+          }
+          quantity
+          ... on SimpleCartItem {
+            customizable_options {
+              label
+              values {
+                value
+              }
             }
           }
+        }
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
         }
       }
     }
@@ -134,24 +158,32 @@ mutation {
   "data": {
     "addSimpleProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "product": {
-              "name": "simple"
-            },
-            "quantity": 1,
-            "customizable_options": [
-              {
-                "label": "Field Option",
-                "values": [
-                  {
-                    "value": "field value"
-                  }
-                ]
-              }
-            ]
+        "itemsV2": {
+          "items": [
+            {
+              "product": {
+                "name": "simple"
+              },
+              "quantity": 1,
+              "customizable_options": [
+                {
+                  "label": "Field Option",
+                  "values": [
+                    {
+                      "value": "field value"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       }
     }
   }
@@ -180,13 +212,21 @@ mutation {
     }
   ) {
     cart {
-      items {
-        uid
-        product {
-          name
-          sku
+      itemsV2 {
+        items {
+          uid
+          product {
+            name
+            sku
+          }
+          quantity
         }
-        quantity
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }
       }
     }
   }
@@ -200,16 +240,24 @@ mutation {
   "data": {
     "addSimpleProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "uid": "NDA=",
-            "product": {
-              "name": "Voyage Yoga Bag",
-              "sku": "24-WB01"
-            },
-            "quantity": 1
+        "itemsV2": {
+          "items": [
+            {
+              "uid": "NDA=",
+              "product": {
+                "name": "Voyage Yoga Bag",
+                "sku": "24-WB01"
+              },
+              "quantity": 1
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       }
     }
   }

--- a/src/pages/graphql/schema/cart/mutations/add-virtual-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-virtual-products.md
@@ -43,11 +43,19 @@ mutation {
     }
   ) {
     cart {
-      items {
-        product {
-          name
+      itemsV2 {
+        items {
+          product {
+            name
+          }
+          quantity
         }
-        quantity
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }
       }
       prices {
         grand_total {
@@ -67,14 +75,22 @@ mutation {
   "data": {
     "addVirtualProductsToCart": {
       "cart": {
-        "items": [
-          {
-            "product": {
-              "name": "Gold Membership"
-            },
-            "quantity": 1
+        "itemsV2": {
+          "items": [
+            {
+              "product": {
+                "name": "Gold Membership"
+              },
+              "quantity": 1
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ],
+        },
         "prices": {
           "grand_total": {
             "value": 49.99,

--- a/src/pages/graphql/schema/cart/mutations/apply-coupon.md
+++ b/src/pages/graphql/schema/cart/mutations/apply-coupon.md
@@ -20,7 +20,7 @@ The following example applies the coupon code `H2O` to the cart. For this coupon
 
 **Request:**
 
-``` text
+```graphql
 mutation {
   applyCouponToCart(
     input: {
@@ -29,11 +29,19 @@ mutation {
     }
   ) {
     cart {
-      items {
-        product {
-          name
+      itemsV2 {
+        items {
+          product {
+            name
+          }
+          quantity
         }
-        quantity
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }
       }
       applied_coupons {
         code
@@ -56,26 +64,34 @@ mutation {
   "data": {
     "applyCouponToCart": {
       "cart": {
-        "items": [
-          {
-            "product": {
-              "name": "Gold Membership"
+        "itemsV2": {
+          "items": [
+            {
+              "product": {
+                "name": "Gold Membership"
+              },
+              "quantity": 2
             },
-            "quantity": 2
-          },
-          {
-            "product": {
-              "name": "Strive Shoulder Pack"
+            {
+              "product": {
+                "name": "Strive Shoulder Pack"
+              },
+              "quantity": 1
             },
-            "quantity": 1
-          },
-          {
-            "product": {
-              "name": "Affirm Water Bottle "
-            },
-            "quantity": 1
+            {
+              "product": {
+                "name": "Affirm Water Bottle "
+              },
+              "quantity": 1
+            }
+          ],
+          "total_count": 3,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ],
+        },
         "applied_coupons": {
           "code": "H20"
         },

--- a/src/pages/graphql/schema/cart/mutations/apply-reward-points.md
+++ b/src/pages/graphql/schema/cart/mutations/apply-reward-points.md
@@ -28,19 +28,27 @@ mutation {
   applyRewardPointsToCart(cartId: "8k0Q4MpH2IGahWrTRtqM61YV2MtLPApz")
   {
     cart {
-      items {
-        quantity
-        product {
-          sku
-          name
-          price_range {
-            maximum_price {
-              final_price {
-                currency
-                value
+      itemsV2 {
+        items {
+          quantity
+          product {
+            sku
+            name
+            price_range {
+              maximum_price {
+                final_price {
+                  currency
+                  value
+                }
               }
             }
           }
+        }
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
         }
       }
       applied_reward_points {
@@ -74,23 +82,31 @@ mutation {
   "data": {
     "applyRewardPointsToCart": {
       "cart": {
-        "items": [
-          {
-            "quantity": 1,
-            "product": {
-              "sku": "WJ04",
-              "name": "Ingrid Running Jacket",
-              "price_range": {
-                "maximum_price": {
-                  "final_price": {
-                    "currency": "USD",
-                    "value": 84
+        "itemsV2": {
+          "items": [
+            {
+              "quantity": 1,
+              "product": {
+                "sku": "WJ04",
+                "name": "Ingrid Running Jacket",
+                "price_range": {
+                  "maximum_price": {
+                    "final_price": {
+                      "currency": "USD",
+                      "value": 84
+                    }
                   }
                 }
               }
             }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ],
+        },
         "applied_reward_points": {
           "money": {
             "currency": "USD",

--- a/src/pages/graphql/schema/cart/mutations/assign-customer-to-guest-cart.md
+++ b/src/pages/graphql/schema/cart/mutations/assign-customer-to-guest-cart.md
@@ -45,10 +45,18 @@ mutation {
   assignCustomerToGuestCart(
     cart_id: "MDYKgqIdWMKr7VD1zlYwxrB7kuX8lR5s"
   ) {
-    items {
-      quantity
-      product {
-        sku
+    itemsV2 {
+      items {
+        quantity
+        product {
+          sku
+        }
+      }
+      total_count
+      page_info {
+        page_size
+        current_page
+        total_pages
       }
     }
   }
@@ -61,20 +69,28 @@ mutation {
 {
   "data": {
     "assignCustomerToGuestCart": {
-      "items": [
-        {
-          "quantity": 1,
-          "product": {
-            "sku": "customer_item"
+      "itemsV2": {
+        "items": [
+          {
+            "quantity": 1,
+            "product": {
+              "sku": "customer_item"
+            }
+          },
+          {
+            "quantity": 1,
+            "product": {
+              "sku": "guest_item"
+            }
           }
-        },
-        {
-          "quantity": 1,
-          "product": {
-            "sku": "guest_item"
-          }
+        ],
+        "total_count": 1,
+        "page_info": {
+          "page_size": 20,
+          "current_page": 1,
+          "total_pages": 1
         }
-      ]
+      }
     }
   }
 }

--- a/src/pages/graphql/schema/cart/mutations/merge.md
+++ b/src/pages/graphql/schema/cart/mutations/merge.md
@@ -44,13 +44,21 @@ mutation {
     source_cart_id: "mPKE05OOtcxErbk1Toej6gw6tcuxvT9O",
     destination_cart_id: "CYmiiQRjPVc2gJUc5r7IsBmwegVIFO43"
   ) {
-    items {
-      id
-      product {
-        name
-        sku
+    itemsV2 {
+      items {
+        id
+        product {
+          name
+          sku
+        }
+        quantity
       }
-      quantity
+      total_count
+      page_info {
+        page_size
+        current_page
+        total_pages
+      }
     }
   }
 }
@@ -62,24 +70,32 @@ mutation {
 {
   "data": {
     "mergeCarts": {
-      "items": [
-        {
-          "id": "14",
-          "product": {
-            "name": "Overnight Duffle",
-            "sku": "24-WB07"
+      "itemsV2": {
+        "items": [
+          {
+            "id": "14",
+            "product": {
+              "name": "Overnight Duffle",
+              "sku": "24-WB07"
+            },
+            "quantity": 2
           },
-          "quantity": 2
-        },
-        {
-          "id": "17",
-          "product": {
-            "name": "Radiant Tee",
-            "sku": "WS12"
-          },
-          "quantity": 1
+          {
+            "id": "17",
+            "product": {
+              "name": "Radiant Tee",
+              "sku": "WS12"
+            },
+            "quantity": 1
+          }
+        ],
+        "total_count": 2,
+        "page_info": {
+          "page_size": 20,
+          "current_page": 1,
+          "total_pages": 1
         }
-      ]
+      }
     }
   }
 }
@@ -94,13 +110,21 @@ mutation {
   mergeCarts(
     source_cart_id: "mPKE05OOtcxErbk1Toej6gw6tcuxvT9O"
   ) {
-    items {
-      id
-      product {
-        name
-        sku
+    itemsV2 {
+      items {
+        id
+        product {
+          name
+          sku
+        }
+        quantity
       }
-      quantity
+      total_count
+      page_info {
+        page_size
+        current_page
+        total_pages
+      }
     }
   }
 }
@@ -112,24 +136,32 @@ mutation {
 {
   "data": {
     "mergeCarts": {
-      "items": [
-        {
-          "id": "14",
-          "product": {
-            "name": "Overnight Duffle",
-            "sku": "24-WB07"
+      "itemsV2": {
+        "items": [
+          {
+            "id": "14",
+            "product": {
+              "name": "Overnight Duffle",
+              "sku": "24-WB07"
+            },
+            "quantity": 2
           },
-          "quantity": 2
-        },
-        {
-          "id": "17",
-          "product": {
-            "name": "Radiant Tee",
-            "sku": "WS12"
-          },
-          "quantity": 1
-        }
-      ]
+          {
+            "id": "17",
+            "product": {
+              "name": "Radiant Tee",
+              "sku": "WS12"
+            },
+            "quantity": 1
+          }
+        ]
+      },
+      "total_count": 2,
+      "page_info": {
+        "page_size": 20,
+        "current_page": 1,
+        "total_pages": 1
+      }
     }
   }
 }

--- a/src/pages/graphql/schema/cart/mutations/remove-coupon.md
+++ b/src/pages/graphql/schema/cart/mutations/remove-coupon.md
@@ -20,18 +20,26 @@ The following example removes a coupon from the cart.
 
 **Request:**
 
-``` text
+```graphql
 mutation {
   removeCouponFromCart(
     input:
       { cart_id: "IeTUiU0oCXjm0uRqGCOuhQ2AuQatogjG" }
     ) {
     cart {
-      items {
-        product {
-          name
+      itemsV2 {
+        items {
+          product {
+            name
+          }
+          quantity
         }
-        quantity
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }
       }
       applied_coupons {
         code
@@ -54,20 +62,28 @@ mutation {
   "data": {
     "removeCouponFromCart": {
       "cart": {
-        "items": [
-          {
-            "product": {
-              "name": "Strive Shoulder Pack"
+        "itemsV2": {
+          "items": [
+            {
+              "product": {
+                "name": "Strive Shoulder Pack"
+              },
+              "quantity": 1
             },
-            "quantity": 1
-          },
-          {
-            "product": {
-              "name": "Affirm Water Bottle "
-            },
-            "quantity": 1
+            {
+              "product": {
+                "name": "Affirm Water Bottle "
+              },
+              "quantity": 1
+            }
+          ],
+          "total_count": 2,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ],
+        },
         "applied_coupons": null,
         "prices": {
           "grand_total": {

--- a/src/pages/graphql/schema/cart/mutations/remove-item.md
+++ b/src/pages/graphql/schema/cart/mutations/remove-item.md
@@ -30,12 +30,20 @@ mutation {
   )
  {
   cart {
-    items {
-      id
-      product {
-        name
+    itemsV2 {
+      items {
+        id
+        product {
+          name
+        }
+        quantity
       }
-      quantity
+      total_count
+      page_info {
+        page_size
+        current_page
+        total_pages
+      }
     }
     prices {
       grand_total{
@@ -55,15 +63,23 @@ mutation {
   "data": {
     "removeItemFromCart": {
       "cart": {
-        "items": [
-          {
-            "uid": "NDA=",
-            "product": {
-              "name": "Strive Shoulder Pack"
-            },
-            "quantity": 3
+        "itemsV2": {
+          "items": [
+            {
+              "uid": "NDA=",
+              "product": {
+                "name": "Strive Shoulder Pack"
+              },
+              "quantity": 3
+            }
+          ],
+          "total_count": 1,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ],
+        },
         "prices": {
           "grand_total": {
             "value": 96,

--- a/src/pages/graphql/schema/cart/mutations/set-gift-options.md
+++ b/src/pages/graphql/schema/cart/mutations/set-gift-options.md
@@ -74,13 +74,21 @@ mutation {
       }
       gift_receipt_included
       printed_card_included
-      items {
-        quantity
-        prices {
-          price {
-            value
-            currency
+      itemsV2 {
+        items {
+          quantity
+          prices {
+            price {
+              value
+              currency
+            }
           }
+        }
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
         }
       }
       prices {
@@ -118,26 +126,34 @@ mutation {
         },
         "gift_receipt_included": true,
         "printed_card_included": false,
-        "items": [
-          {
-            "quantity": 1,
-            "prices": {
-              "price": {
-                "value": 32,
-                "currency": "USD"
+        "itemsV2": {
+          "items": [
+            {
+              "quantity": 1,
+              "prices": {
+                "price": {
+                  "value": 32,
+                  "currency": "USD"
+                }
+              }
+            },
+            {
+              "quantity": 1,
+              "prices": {
+                "price": {
+                  "value": 84,
+                  "currency": "USD"
+                }
               }
             }
-          },
-          {
-            "quantity": 1,
-            "prices": {
-              "price": {
-                "value": 84,
-                "currency": "USD"
-              }
-            }
+          ],
+          "total_count": 2,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ],
+        },
         "prices": {
           "gift_options": {
             "gift_wrapping_for_order": {

--- a/src/pages/graphql/schema/cart/mutations/update-items.md
+++ b/src/pages/graphql/schema/cart/mutations/update-items.md
@@ -38,12 +38,20 @@ mutation {
     }
   ){
     cart {
-      items {
-        uid
-        product {
-          name
+      itemsV2 {
+        items {
+          uid
+          product {
+            name
+          }
+          quantity
         }
-        quantity
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }
       }
       prices {
         grand_total{
@@ -63,22 +71,30 @@ mutation {
   "data": {
     "updateCartItems": {
       "cart": {
-        "items": [
-          {
-            "uid": "MjI=",
-            "product": {
-              "name": "Erika Running Short"
+        "itemsV2": {
+          "items": [
+            {
+              "uid": "MjI=",
+              "product": {
+                "name": "Erika Running Short"
+              },
+              "quantity": 1
             },
-            "quantity": 1
-          },
-          {
-            "uid": "MjQ=",
-            "product": {
-              "name": "Voyage Yoga Bag"
-            },
-            "quantity": 3
+            {
+              "uid": "MjQ=",
+              "product": {
+                "name": "Voyage Yoga Bag"
+              },
+              "quantity": 3
+            }
+          ],
+          "total_count": 2,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ],
+        },
         "prices": {
           "grand_total": {
             "value": 152.63,

--- a/src/pages/graphql/schema/cart/queries/cart.md
+++ b/src/pages/graphql/schema/cart/queries/cart.md
@@ -93,18 +93,22 @@ The following query shows the status of a cart that is ready to be converted int
         method_title
       }
     }
-    items {
-      id
-      product {
-        name
-        sku
+    itemsV2 {
+      total_count
+      items {
+        id
+        product {
+          name
+          sku
+        }
+        quantity
       }
-      quantity
-      errors {
-        code
-        message
+      page_info {
+        page_size
+        current_page
+        total_pages
       }
-    }
+    }      
     available_payment_methods {
       code
       title
@@ -222,24 +226,32 @@ The following query shows the status of a cart that is ready to be converted int
           }
         }
       ],
-      "items": [
-        {
-          "uid": "Mg==",
-          "product": {
-            "name": "Strive Shoulder Pack",
-            "sku": "24-MB04"
+      "itemsV2": {
+        "total_count": 2,
+        "items": [
+          {
+            "uid": "Mg==",
+            "product": {
+              "name": "Strive Shoulder Pack",
+              "sku": "24-MB04"
+            },
+            "quantity": 2
           },
-          "quantity": 2
-        },
-        {
-          "uid": "17",
-          "product": {
-            "name": "Savvy Shoulder Tote",
-            "sku": "24-WB05"
-          },
-          "quantity": 1
+          {
+            "uid": "17",
+            "product": {
+              "name": "Savvy Shoulder Tote",
+              "sku": "24-WB05"
+            },
+            "quantity": 1
+          }
+        ],
+        "page_info": {
+          "page_size": 20,
+          "current_page": 1,
+          "total_pages": 1
         }
-      ],
+      },
       "available_payment_methods": [
         {
           "code": "braintree_cc_vault",
@@ -284,27 +296,35 @@ If other promotions or price adjustments are applied to the cart through either 
 {
   cart(cart_id: "v7jYJUjvPeHbdMJRcOfZIeQhs2Xc2ZKT") {
     email
-    items {
-      uid
-      prices {
-        total_item_discount {
-          value
-        }
-        price {
-          value
-        }
-        discounts {
-          label
-          amount {
+    itemsV2 {
+      total_count
+      items {
+        uid
+        prices {
+          total_item_discount {
             value
           }
+          price {
+            value
+          }
+          discounts {
+            label
+            amount {
+              value
+            }
+          }
         }
+        product {
+          name
+          sku
+        }
+        quantity
+      },
+      page_info {
+          page_size
+          current_page
+          total_pages
       }
-      product {
-        name
-        sku
-      }
-      quantity
     }
     applied_coupons {
       code
@@ -332,44 +352,52 @@ If other promotions or price adjustments are applied to the cart through either 
   "data": {
     "cart": {
       "email": "roni_cost@example.com",
-      "items": [
-        {
-          "uid": "MjY=",
-          "prices": {
-            "total_item_discount": {
-              "value": 37.7
-            },
-            "price": {
-              "value": 29
-            },
-            "discounts": [
-              {
-                "label": "Discount (3T1free, 10% Off for New Customers)",
-                "amount": {
-                  "value": 37.7
-                }
+      "itemsV2": {
+        "total_count": 1,
+        "items": [
+          {
+            "uid": "MjY=",
+            "prices": {
+              "total_item_discount": {
+                "value": 37.7
               },
-              {
-                "label": "Gift Card",
-                "amount": {
-                  "value": 0.1
-                }
+              "price": {
+                "value": 29
               },
-              {
-                "label": "Store Credit",
-                "amount": {
-                  "value": 0.1
+              "discounts": [
+                {
+                  "label": "Discount (3T1free, 10% Off for New Customers)",
+                  "amount": {
+                    "value": 37.7
+                  }
+                },
+                {
+                  "label": "Gift Card",
+                  "amount": {
+                    "value": 0.1
+                  }
+                },
+                {
+                  "label": "Store Credit",
+                  "amount": {
+                    "value": 0.1
+                  }
                 }
-              }
-            ]
-          },
-          "product": {
-            "name": "Elisa EverCool&trade; Tee",
-            "sku": "WS06"
-          },
-          "quantity": 4
+              ]
+            },
+            "product": {
+              "name": "Elisa EverCool&trade; Tee",
+              "sku": "WS06"
+            },
+            "quantity": 4
+          }
+        ],
+        "page_info": {
+          "page_size": 20,
+          "current_page": 1,
+          "total_pages": 1
         }
-      ],
+      },
       "applied_coupons": [
         {
           "code": "NEW"
@@ -420,27 +448,35 @@ The cart in the example contains 12 units of `24-UG05` and 8 units of `24-UG-01`
 ```graphql
 query {
   cart(cart_id: "v7jYJUjvPeHbdMJRcOfZIeQhs2Xc2ZKT"){
-    items {
-      uid
-      quantity
-      product{
-        name
-        sku
-        price_tiers {
-          quantity
-          final_price {
-            value
+    itemsV2 {
+      total_count
+      items {
+        uid
+        quantity
+        product {
+          name
+          sku
+          price_tiers {
+            quantity
+            final_price {
+              value
+            }
+            discount {
+              amount_off
+              percent_off
+            }
           }
-          discount {
-            amount_off
-            percent_off
+        }
+        prices{
+          price{
+            value
           }
         }
       }
-      prices{
-        price{
-          value
-        }
+      page_info {
+        page_size
+        current_page
+        total_pages
       }
     }
     prices {
@@ -471,88 +507,96 @@ query {
 {
   "data": {
     "cart": {
-      "items": [
-        {
-          "uid": "NjU=",
-          "quantity": 12,
-          "product": {
-            "name": "Go-Get'r Pushup Grips",
-            "sku": "24-UG05",
-            "price_tiers": [
-              {
-                "quantity": 5,
-                "final_price": {
-                  "value": 16
+      "itemsV2": {
+        "total_count": 2,
+        "items": [
+          {
+            "uid": "NjU=",
+            "quantity": 12,
+            "product": {
+              "name": "Go-Get'r Pushup Grips",
+              "sku": "24-UG05",
+              "price_tiers": [
+                {
+                  "quantity": 5,
+                  "final_price": {
+                    "value": 16
+                  },
+                  "discount": {
+                    "amount_off": 3,
+                    "percent_off": 15.79
+                  }
                 },
-                "discount": {
-                  "amount_off": 3,
-                  "percent_off": 15.79
+                {
+                  "quantity": 10,
+                  "final_price": {
+                    "value": 11
+                  },
+                  "discount": {
+                    "amount_off": 8,
+                    "percent_off": 42.11
+                  }
                 }
-              },
-              {
-                "quantity": 10,
-                "final_price": {
-                  "value": 11
-                },
-                "discount": {
-                  "amount_off": 8,
-                  "percent_off": 42.11
-                }
+              ]
+            },
+            "prices": {
+              "price": {
+                "value": 11
               }
-            ]
+            }
           },
-          "prices": {
-            "price": {
-              "value": 11
+          {
+            "uid": "NjY=",
+            "quantity": 8,
+            "product": {
+              "name": "Quest Lumaflex&trade; Band",
+              "sku": "24-UG01",
+              "price_tiers": [
+                {
+                  "quantity": 5,
+                  "final_price": {
+                    "value": 18.05
+                  },
+                  "discount": {
+                    "amount_off": 0.95,
+                    "percent_off": 5
+                  }
+                },
+                {
+                  "quantity": 10,
+                  "final_price": {
+                    "value": 17.1
+                  },
+                  "discount": {
+                    "amount_off": 1.9,
+                    "percent_off": 10
+                  }
+                },
+                {
+                  "quantity": 15,
+                  "final_price": {
+                    "value": 16.15
+                  },
+                  "discount": {
+                    "amount_off": 2.85,
+                    "percent_off": 15
+                  }
+                }
+              ]
+            },
+            "prices": {
+              "price": {
+                "value": 18.05
+              }
             }
           }
-        },
-        {
-          "uid": "NjY=",
-          "quantity": 8,
-          "product": {
-            "name": "Quest Lumaflex&trade; Band",
-            "sku": "24-UG01",
-            "price_tiers": [
-              {
-                "quantity": 5,
-                "final_price": {
-                  "value": 18.05
-                },
-                "discount": {
-                  "amount_off": 0.95,
-                  "percent_off": 5
-                }
-              },
-              {
-                "quantity": 10,
-                "final_price": {
-                  "value": 17.1
-                },
-                "discount": {
-                  "amount_off": 1.9,
-                  "percent_off": 10
-                }
-              },
-              {
-                "quantity": 15,
-                "final_price": {
-                  "value": 16.15
-                },
-                "discount": {
-                  "amount_off": 2.85,
-                  "percent_off": 15
-                }
-              }
-            ]
-          },
-          "prices": {
-            "price": {
-              "value": 18.05
-            }
-          }
+        ],
+        "page_info": {
+          "page_size": 20,
+          "current_page": 1,
+          "total_pages": 1
         }
-      ],
+      },
       "prices": {
         "discounts": [
           {

--- a/src/pages/graphql/schema/orders/mutations/reorder-items.md
+++ b/src/pages/graphql/schema/orders/mutations/reorder-items.md
@@ -51,17 +51,25 @@ mutation{
   reorderItems(orderNumber: "000000003"){
     cart {
       id
-      items {
-        uid
-        product {
-          sku
-        }
-        quantity
-        prices {
-          price {
-            value
+      itemsV2 {
+        items {
+          uid
+          product {
+            sku
+          }
+          quantity
+          prices {
+            price {
+              value
+            }
           }
         }
+        total_count
+        page_info {
+          page_size
+          current_page
+          total_pages
+        }          
       }
     }
     userInputErrors{
@@ -81,32 +89,40 @@ mutation{
     "reorderItems": {
       "cart": {
         "id": "LrMHhWHUaOqiBGC6S0KOcnYKsINUHTWz",
-        "items": [
-          {
-            "uid": "NDQ=",
-            "product": {
-              "sku": "24-UG07"
+        "itemsV2": {
+          "items": [
+            {
+              "uid": "NDQ=",
+              "product": {
+                "sku": "24-UG07"
+              },
+              "quantity": 1,
+              "prices": {
+                "price": {
+                  "value": 12
+                }
+              }
             },
-            "quantity": 1,
-            "prices": {
-              "price": {
-                "value": 12
+            {
+              "uid": "NDU=",
+              "product": {
+                "sku": "WS06"
+              },
+              "quantity": 1,
+              "prices": {
+                "price": {
+                  "value": 29
+                }
               }
             }
-          },
-          {
-            "uid": NDU=,
-            "product": {
-              "sku": "WS06"
-            },
-            "quantity": 1,
-            "prices": {
-              "price": {
-                "value": 29
-              }
-            }
+          ],
+          "total_count": 2,
+          "page_info": {
+            "page_size": 20,
+            "current_page": 1,
+            "total_pages": 1
           }
-        ]
+        }
       },
       "userInputErrors": [
         {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replaces all examples making use of the deprecated `cart.items` by `cart.itemsV2`, which adds pagination capabilities.

This field is already present in 2.4.7-beta3

