### PR TITLE
LYNX-332: change attributeForm note

### DIFF
--- a/src/pages/graphql/schema/attributes/queries/attributes-form.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-form.md
@@ -10,11 +10,11 @@ import BetaNote from '/src/_includes/graphql/notes/beta.md'
 
 The `attributesForm` query retrieves EAV attributes associated with customer and customer address frontend forms.
 
-These forms are visible when using the Admin to create or edit a customer or customer address address (**Stores** > Attributes > **Customer** or **Customer Address**).
+These forms are visible when using the Admin to create or edit a customer or customer address (**Stores** > Attributes > **Customer** or **Customer Address**).
 
 <InlineAlert variant="info" slots="text" />
 
-Use the [country](../../store/queries/country.md) and [countries](../../store/queries/countries.md) mutations to retrieve information about the `region_id` and `country_id` attributes.
+Use the [country](../../store/queries/country.md) and [countries](../../store/queries/countries.md) mutations to retrieve information about the `region_id` and `country_id` attribute options.
 
 The following table maps the display names of the applicable forms to values that you can specify as a `formCode` value.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to change the documentation to reflect that now the **attributes options** for country_id and region_id codes are not included in the query result but the **attributes** country_id and region_id are included. 
Also I removed a duplicated word.
Jira Ticket: [LYNX-332](https://jira.corp.adobe.com/browse/LYNX-332)

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi/graphql/schema/attributes/queries/attributes-form/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
