### PR TITLE
LYNX-385: documentation for estimateShippingMethods mutation

### DIFF
--- a/src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
+++ b/src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
@@ -1,0 +1,104 @@
+---
+title: estimateShippingMethods mutation
+---
+
+# estimateShippingMethods mutation
+
+The `estimateShippingMethods` mutation returns information about estimated cost of available shipping methods, depending on location.
+
+## Syntax
+
+```graphql
+mutation {
+  estimateShippingMethods(input: EstimateTotalsInput!)
+  {
+      [AvailableShippingMethod]
+  }
+}
+```
+
+
+## Reference
+
+The <estimateShippingMethods> reference provides detailed information about the types and fields defined in this <estimateShippingMethods>.
+
+
+## Example usage
+
+In the following example, the customer located in Republic of Ireland wants to check estimated cost of shipping for the cart (`IJGaHxS7p6u5Nu7tQIGQpADRXSoZRbJw`).
+
+
+**Request:**
+
+```graphql
+
+mutation {
+  estimateShippingMethods(input:{
+    cart_id: "IJGaHxS7p6u5Nu7tQIGQpADRXSoZRbJw"
+    address: {
+     	country_code:IE
+    }
+  })
+  {
+    amount{
+      currency
+      value
+    }
+    available
+    carrier_code
+    price_incl_tax {
+      currency
+      value
+    }
+    price_excl_tax {
+      currency
+      value
+    }
+  }
+}
+```
+
+**Response:**
+
+The response contains estimated shipping cost based on selected location (depends on store configuration):
+
+```json
+{
+  "data": {
+    "estimateShippingMethods": [
+      {
+        "amount": {
+          "currency": "EUR",
+          "value": 0
+        },
+        "available": true,
+        "carrier_code": "freeshipping",
+        "price_incl_tax": {
+          "currency": "EUR",
+          "value": 0
+        },
+        "price_excl_tax": {
+          "currency": "EUR",
+          "value": 0
+        }
+      },
+      {
+        "amount": {
+          "currency": "EUR",
+          "value": 10
+        },
+        "available": true,
+        "carrier_code": "flatrate",
+        "price_incl_tax": {
+          "currency": "EUR",
+          "value": 10
+        },
+        "price_excl_tax": {
+          "currency": "EUR",
+          "value": 10
+        }
+      }
+    ]
+  }
+}
+```

--- a/src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
+++ b/src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
@@ -17,16 +17,13 @@ mutation {
 }
 ```
 
-
 ## Reference
 
 The <estimateShippingMethods> reference provides detailed information about the types and fields defined in this <estimateShippingMethods>.
 
-
 ## Example usage
 
 In the following example, the customer located in Republic of Ireland wants to check estimated cost of shipping for the cart (`IJGaHxS7p6u5Nu7tQIGQpADRXSoZRbJw`).
-
 
 **Request:**
 

--- a/src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
+++ b/src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
@@ -19,7 +19,7 @@ mutation {
 
 ## Reference
 
-The <estimateShippingMethods> reference provides detailed information about the types and fields defined in this <estimateShippingMethods>.
+The `estimateShippingMethods` reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -57,7 +57,7 @@ mutation {
 
 **Response:**
 
-The response contains estimated shipping cost based on selected location (depends on store configuration):
+The response contains the estimated shipping, cost based on selected location and store configuration:
 
 ```json
 {

--- a/src/pages/graphql/schema/cart/mutations/index.md
+++ b/src/pages/graphql/schema/cart/mutations/index.md
@@ -39,6 +39,7 @@ The cart mutations allow you to perform the following operations:
 
 * Prepare for checkout
 
+  * [`estimateShippingMethods`](estimate-shipping-methods.md)
   * [`estimateTotals`](estimate-totals.md)
   * [`placeOrder`](place-order.md)
   * [`setBillingAddressOnCart`](set-billing-address.md)
@@ -47,4 +48,3 @@ The cart mutations allow you to perform the following operations:
   * [`setPaymentMethodAndPlaceOrder`](set-payment-place-order.md)
   * [`setShippingAddressesOnCart`](set-shipping-address.md)
   * [`setShippingMethodsOnCart`](set-shipping-method.md)
-  * [`estimateShippingMethods`](estimate-shipping-methods.md)

--- a/src/pages/graphql/schema/cart/mutations/index.md
+++ b/src/pages/graphql/schema/cart/mutations/index.md
@@ -45,3 +45,4 @@ The cart mutations allow you to perform the following operations:
   * [`setPaymentMethodAndPlaceOrder`](set-payment-place-order.md)
   * [`setShippingAddressesOnCart`](set-shipping-address.md)
   * [`setShippingMethodsOnCart`](set-shipping-method.md)
+  * [`estimateShippingMethods`](estimate-shipping-methods.md)


### PR DESCRIPTION
## Purpose of this pull request

This PR provides documentation for `estimateShippingMethods` mutation.
See https://jira.corp.adobe.com/browse/LYNX-385 for details.
Implementation ticket for the mutation: https://jira.corp.adobe.com/browse/LYNX-305

## Affected pages

- src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
- src/pages/graphql/schema/cart/mutations/index.md

