### PR TITLE
LYNX-375: Add doc of the token expiration config

### DIFF
--- a/src/pages/graphql/schema/store/queries/store-config.md
+++ b/src/pages/graphql/schema/store/queries/store-config.md
@@ -213,6 +213,31 @@ The following query returns information about the store's customer configuration
   }
 }
 ```
+### Query a store's access token expiration configuration
+
+The following query returns information about the store's token expiration.
+
+**Request:**
+
+```graphql
+{
+    storeConfig {
+        customer_access_token_lifetime
+    }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "storeConfig": {
+      "customer_access_token_lifetime": 1
+    }
+  }
+}
+```
 
 ### Query a store's fixed product tax configuration
 

--- a/src/pages/graphql/schema/store/queries/store-config.md
+++ b/src/pages/graphql/schema/store/queries/store-config.md
@@ -213,6 +213,7 @@ The following query returns information about the store's customer configuration
   }
 }
 ```
+
 ### Query a store's access token expiration configuration
 
 The following query returns information about the store's token expiration.

--- a/src/pages/graphql/schema/store/queries/store-config.md
+++ b/src/pages/graphql/schema/store/queries/store-config.md
@@ -216,7 +216,7 @@ The following query returns information about the store's customer configuration
 
 ### Query a store's access token expiration configuration
 
-The following query returns information about the store's token expiration.
+The following query returns the value of the **Stores** > Settings > **Configuration** > **Services** > **OAuth** > **Access Token Expiration** > **Customer Token Lifetime (hours)** field.
 
 **Request:**
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to add into the documentation how to query the configuration for access token expiration. It is related to this ticket: [LYNX-375](https://jira.corp.adobe.com/browse/LYNX-375)

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
