### PR TITLE
Add links to SpectaQL docs

### DIFF
--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -166,6 +166,10 @@ module.exports = [
                 path: "/graphql/schema/cart/mutations/apply-coupon/",
               },
               {
+                title: "applyCouponsToCart",
+                path: "/graphql/schema/cart/mutations/apply-coupons/"
+              },
+              {
                 title: "applyGiftCartToCart",
                 path: "/graphql/schema/cart/mutations/apply-giftcard/",
               },
@@ -180,6 +184,10 @@ module.exports = [
               {
                 title: "assignCustomerToGuestCart",
                 path: "/graphql/schema/cart/mutations/assign-customer-to-guest-cart/",
+              },
+              {
+                title: "clearCart",
+                path: "/graphql/schema/cart/mutations/clear-cart/"
               },
               {
                 title: "createEmptyCart",
@@ -200,6 +208,10 @@ module.exports = [
               {
                 title: "removeCouponFromCart",
                 path: "/graphql/schema/cart/mutations/remove-coupon/",
+              },
+              {
+                title: "removeCouponsFromCart",
+                path: "/graphql/schema/cart/mutations/remove-coupons"
               },
               {
                 title: "removeGiftCardFromCart",

--- a/src/data/navigation/sections/rest.js
+++ b/src/data/navigation/sections/rest.js
@@ -453,17 +453,21 @@ module.exports = [
             ]
         },
         {
-            title:"Import",
-            path:"/rest/modules/import/"
+            title: "Import",
+            path: "/rest/modules/import/"
         },
-    {
-        title: "Sales refunds",
-        path: "/rest/modules/sales/",
-    },
-  ],
+        {
+            title: "Multicoupon",
+            path: "/rest/modules/multicoupon/"
+        },
+        {
+            title: "Sales refunds",
+            path: "/rest/modules/sales/"
+        },
+    ],
   },
   {
     title: "Attributes",
     path: "/rest/attributes/"
   },
-  ];
+];

--- a/src/pages/graphql/schema/cart/mutations/clear-cart.md
+++ b/src/pages/graphql/schema/cart/mutations/clear-cart.md
@@ -18,7 +18,7 @@ mutation {
 
 ## Reference
 
-The `clearCart` reference provides detailed information about the types and fields defined in this mutation.
+The [`clearCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-clearCart) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/create-guest-cart.md
+++ b/src/pages/graphql/schema/cart/mutations/create-guest-cart.md
@@ -18,7 +18,7 @@ mutation {
 
 ## Reference
 
-The `createGuestCart` reference provides detailed information about the types and fields defined in this mutation.
+The [`createGuestCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createGuestCart) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
+++ b/src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
@@ -19,7 +19,7 @@ mutation {
 
 ## Reference
 
-The `estimateShippingMethods` reference provides detailed information about the types and fields defined in this mutation.
+The [`estimateShippingMethods`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-estimateShippingMethods) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
@@ -33,7 +33,7 @@ mutation {
   estimateShippingMethods(input:{
     cart_id: "IJGaHxS7p6u5Nu7tQIGQpADRXSoZRbJw"
     address: {
-     	country_code:IE
+         country_code:IE
     }
   })
   {

--- a/src/pages/graphql/schema/cart/mutations/estimate-totals.md
+++ b/src/pages/graphql/schema/cart/mutations/estimate-totals.md
@@ -19,7 +19,7 @@ mutation {
 
 ## Reference
 
-The `estimateTotals` reference provides detailed information about the types and fields defined in this mutation.
+The [`estimateTotals`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-estimateTotals) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/confirm-email.md
+++ b/src/pages/graphql/schema/customer/mutations/confirm-email.md
@@ -10,13 +10,13 @@ The `confirmEmail` mutation completes the customer activation process by confirm
 
 `mutation: {confirmEmail(input: ConfirmEmailInput!) {CustomerOutput}}`
 
-The following call confirms `roni_cost@example.com` as the email address of the customer by using the confirmation key `abcde`.
-
 ## Reference
 
-The `confirmEmail` reference provides detailed information about the types and fields defined in this mutation.
+The [`confirmEmail`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-confirmEmail) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
+
+The following call confirms `roni_cost@example.com` as the email address of the customer by using the confirmation key `abcde`.
 
 **Request:**
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds links to the 2.4.7 SpectaQL docs. I also added missing left navigation

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
