### PR TITLE
LYNX-331: [Documentation] Is_available CartItemInterface field

### DIFF
--- a/src/pages/graphql/schema/cart/interfaces/index.md
+++ b/src/pages/graphql/schema/cart/interfaces/index.md
@@ -50,6 +50,7 @@ mutation {
             sku
           }
           quantity
+          is_available
           ... on ConfigurableCartItem {
             configurable_options {
               configurable_product_option_uid
@@ -100,6 +101,7 @@ mutation {
                 "sku": "WSH12"
               },
               "quantity": 1,
+              "is_available": true,
               "configurable_options": [
                 {
                   "configurable_product_option_uid": "Y29uZmlndXJhYmxlLzIwNDgvOTM=",
@@ -122,6 +124,7 @@ mutation {
                 "sku": "24-WG080"
               },
               "quantity": 1,
+              "is_available": true,
               "bundle_options": [
                 {
                   "uid": "YnVuZGxlLzE=",


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) is to add the is_available new field in the example. Related to [LYNX-331](https://jira.corp.adobe.com/browse/LYNX-331)

## Affected pages
https://developer.adobe.com/commerce/webapi/graphql/schema/cart/interfaces/
<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
