### PR TITLE
INTERNAL - Update oauth signature method supported

### DIFF
--- a/src/pages/get-started/authentication/oauth-errors.md
+++ b/src/pages/get-started/authentication/oauth-errors.md
@@ -17,7 +17,7 @@ HTTP code | Error code | Text representation | Description
 400 | 3 | `parameter_rejected` | The type of the parameter or its value do not meet the protocol requirements (for example,  array is passed instead of the string).
 400 | 4 | `timestamp_refused` | The timestamp value in the oauth_timestamp parameter is incorrect.
 401 | 5 | `nonce_used` | The nonce-timestamp combination has already been used.
-400 | 6 | `signature_method_rejected`| The signature method is not supported. The following methods are supported: HMAC-SHA1.
+400 | 6 | `signature_method_rejected`| The signature method is not supported. The following methods are supported: HMAC-SHA256.
 401 | 7 | `signature_invalid` | The signature is invalid.
 401 | 8 | `consumer_key_rejected` | The Consumer Key has incorrect length or does not exist.
 401 | 9 | `token_used` | An attempt of authorization of an already authorized token or an attempt to exchange a not temporary token for a permanent one.


### PR DESCRIPTION
If you try to use HMAC-SHA1 you get the following 400 bad request response:

`{
	"message": "Signature method %1 is not supported",
	"parameters": [
		"HMAC-SHA1"
	]
}`

## Purpose of this pull request

This pull request (PR) ...

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi/get-started/authentication/oauth-errors/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
