### PR TITLE
Please mention that POST "ship" REST API call does not validate total shipped items quantity.

### DIFF
--- a/src/pages/rest/tutorials/inventory/create-shipment.md
+++ b/src/pages/rest/tutorials/inventory/create-shipment.md
@@ -22,6 +22,10 @@ When you complete a partial or full shipment, Adobe Commerce deducts the reserve
 
 Although you can use the `POST V1/shipment` endpoint to create a shipment, the `POST /V1/order/:orderId/ship` endpoint is a better option in that it is more efficient and the payload can be simpler.
 
+<InlineAlert variant="info" slots="text"/>
+
+To avoid multiple (duplicate) shipment record creation for the same item in the order, you must use the `POST /V1/order/:orderId/ship` endpoint instead of the `POST V1/shipment` endpoint. Only the newer `POST /V1/order/:orderId/ship` endpoint can validate total shipped quantity for each item in the order.
+
 We'll ship 35 `24-WB01` items and 20 `24-WB03` items from the Northeast warehouse. The `order_item_id` value for `24-WB01` is 3, and the value for `24-WB03` is 4.
 
 **Endpoint:**


### PR DESCRIPTION
## Purpose of this pull request

This pull request is to mention that POST "/order/{orderId}/ship" REST API call does not validate total shipped items quantity.
Please also mention that to validate total shipped quantity for each item in the order POST "/order/{orderId}/ship" REST API call must be used.

## Affected pages

https://developer.adobe.com/commerce/webapi/rest/tutorials/inventory/create-shipment/