### PR TITLE
Add links to API playground

### DIFF
--- a/src/pages/graphql/index.md
+++ b/src/pages/graphql/index.md
@@ -22,3 +22,7 @@ The following image shows a sample query, its response, and the GraphQL browser:
 <InlineAlert variant="info" slots="text" />
 
 The Catalog Service, Live Search, and Product Recommendations services have schemas that are independent from the core schema for Adobe Commerce and Magento Open Source. You can find the schema reference documentation and examples for these services in [Storefront Services GraphQL](https://developer.adobe.com/commerce/services/graphql/).
+
+## Commerce API playground
+
+The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) enables you to run selected queries against a live instance of Adobe Commerce with Luma sample data. The playground includes example core and Storefront Services queries. You can customize the output of the queries to help you understand the power of our GraphQL APIs.

--- a/src/pages/graphql/schema/cart/queries/cart.md
+++ b/src/pages/graphql/schema/cart/queries/cart.md
@@ -22,6 +22,10 @@ The [`cart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#
 
 ## Sample queries
 
+The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) provides a sample `cart` query that you can run against a live instance of Adobe Commerce with Luma sample data.
+
+You can convert the hard-coded `cart_id` values in the following sample queries to a [variable](../../../usage/index.md#query-variables) and run them in the API playground. Note that the responses may vary, depending on the configuration of the Commerce instance.
+
 ### Cart ready for checkout
 
 The following query shows the status of a cart that is ready to be converted into an order.

--- a/src/pages/graphql/schema/store/queries/store-config.md
+++ b/src/pages/graphql/schema/store/queries/store-config.md
@@ -16,6 +16,8 @@ The [`storeConfig`](https://developer.adobe.com/commerce/webapi/graphql-api/inde
 
 ## Example usage
 
+The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) provides a sample `storeConfig` query that you can run against a live instance of Adobe Commerce with Luma sample data. Note that the responses may vary, depending on the configuration of the Commerce instance.
+
 ### Query a store's configuration
 
 The `storeConfig` query can return `base` and `extended` store configuration setting. The following call returns all `base` details of a store's configuration.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds links to the GraphQL API playground at https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/

I'm not including a link to `wishlist_v2` because the query is currently broken. I'll follow up when it's fixed.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
