### PR TITLE
Add Commerce-only tag to import topic

### DIFF
--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -1,6 +1,7 @@
 ---
 title: Import API
 description: Import entities into Adobe Commerce using REST.
+edition: ee
 keywords:
   - REST
 ---


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the `edition: ee` tag to the Import Data topic

## Affected pages

https://developer.adobe.com/commerce/webapi/rest/modules/import/#import-csv-api

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
