### PR TITLE
Update place-purchase-order.md

### DIFF
--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/place-order.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/place-order.md
@@ -7,7 +7,9 @@ edition: b2b
 
 The `placeOrderForPurchaseOrder` mutation converts an approved purchase order to an order. If the request is successful, the status of the purchase order is `ORDER_PLACED`.
 
-Use the [`placePurchaseOrder` mutation](place-purchase-order.md) to place a purchase order using the cart ID.
+<InlineAlert variant="info" slots="text" />
+
+If you want to place a purchase order using the cart ID instead of the purchase order UID, use the [`placePurchaseOrder` mutation](place-purchase-order.md).
 
 ## Syntax
 

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/place-purchase-order.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/place-purchase-order.md
@@ -7,7 +7,7 @@ edition: b2b
 
 The `placePurchaseOrder` mutation places a purchase order using the specified `cart_id`. If the request is successful, the status of the purchase order is `ORDER_PLACED`.
 
-Use the [`placeOrderForPurchaseOrder` mutation](place-order.md) to convert a purchase order to an order using the UID.
+Use the [`placePurchaseOrder` mutation](place-order.md) to convert a purchase order to an order using the UID.
 
 ## Syntax
 

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/place-purchase-order.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/place-purchase-order.md
@@ -7,7 +7,9 @@ edition: b2b
 
 The `placePurchaseOrder` mutation places a purchase order using the specified `cart_id`. If the request is successful, the status of the purchase order is `ORDER_PLACED`.
 
-Use the [`placePurchaseOrder` mutation](place-order.md) to convert a purchase order to an order using the UID.
+<InlineAlert variant="info" slots="text" />
+
+To convert a purchase order to an order using the purchase order UID instead of the cart ID, use the  [`placeOrderforPurchase` mutation](place-order.md).
 
 ## Syntax
 


### PR DESCRIPTION
## Purpose of this pull request

Based on feedback from Slack conversation: 

Update the B2B `placePurchaseOrder` and `placeOrder` descriptions to clarify the options to convert a purchase order to an order using either the purchase order UID  or the cart ID.

## Affected pages

- https://developer.adobe.com/commerce/webapi/graphql/schema/b2b/purchase-order/mutations/place-order/
- https://developer.adobe.com/commerce/webapi/graphql/schema/b2b/purchase-order/mutations/place-order/
