### PR TITLE
Replace links to decommissioned resources

### DIFF
--- a/src/pages/get-started/api-security.md
+++ b/src/pages/get-started/api-security.md
@@ -18,7 +18,7 @@ Imposing restrictions on the size and number of resources that a user can reques
 
 By default, these input limits are disabled, but you can use the following methods to enable them:
 
--  Set the values in the [Admin](https://docs.magento.com/user-guide/configuration/services/magento-web-api.html).
+-  Set the values in the [Admin](https://experienceleague.adobe.com/en/docs/commerce-admin/config/services/magento-web-api).
 -  Run the [`bin/magento config:set` command](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/configuration-management/set-configuration-values.html).
 -  Add entries to the [`env.php` file](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/files/config-reference-configphp.html#system).
 -  Set [environment variables](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/deployment/examples/example-environment-variables.html).

--- a/src/pages/graphql/schema/cart/mutations/set-payment-place-order.md
+++ b/src/pages/graphql/schema/cart/mutations/set-payment-place-order.md
@@ -87,6 +87,6 @@ Error | Description
 `Required parameter "cart_id" is missing` | The required `cart_id` argument contains an empty value.
 `Required parameter "code" for "payment_method" is missing.` | The value specified in the `code` argument is empty.
 `The current user cannot perform operations on cart "XXX"` | An unauthorized user (guest) tried to set a payment method and place an order with a customer's cart, or an authorized user (customer) tried to set a payment method and place an order with a cart of another customer.
-`The shipping address is missing. Set the address and try again.` | You ran `setPaymentMethodAndPlaceOrder` mutation before [setShippingAddressesOnCart](set-shipping-method.md). Set a shipping address first. [GraphQL checkout tutorial](https://devdocs.magento.com/guides/v2.3/graphql/tutorials/checkout/index.html) shows the order placement sequence.
+`The shipping address is missing. Set the address and try again.` | You ran `setPaymentMethodAndPlaceOrder` mutation before [setShippingAddressesOnCart](set-shipping-method.md). Set a shipping address first. [GraphQL checkout tutorial](/graphql/tutorials/checkout/) shows the order placement sequence.
 `The requested Payment Method is not available.` | The payment method specified in the `payment_method` argument is disabled or does not exist.
 `Unable to place order: Some of the products are out of stock.` | Some of the products in a cart are out of stock.

--- a/src/pages/graphql/schema/checkout/mutations/create-braintree-client-token.md
+++ b/src/pages/graphql/schema/checkout/mutations/create-braintree-client-token.md
@@ -46,4 +46,4 @@ mutation {
 
 Error | Description
 --- | ---
-`The Braintree payment method is not active.` | The [Braintree](https://docs.magento.com/m2/ee/user_guide/payment/braintree.html) payment method is disabled in admin.
+`The Braintree payment method is not active.` | The [Braintree](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/payments/braintree) payment method is disabled in admin.

--- a/src/pages/graphql/schema/store/queries/dynamic-blocks.md
+++ b/src/pages/graphql/schema/store/queries/dynamic-blocks.md
@@ -10,7 +10,7 @@ The `dynamicBlocks` query returns a list of dynamic blocks that have been placed
 
 The Banner functionality was removed from Adobe Commerce and Magento Open Source 2.4.0 and replaced with dynamic blocks.
 
-When a [Dynamic Blocks Rotator inline widget is created](https://docs.magento.com/user-guide/cms/dynamic-blocks-rotate.html), the administrator can select the following options:
+When a [Dynamic Blocks Rotator inline widget is created](https://experienceleague.adobe.com/en/docs/commerce-admin/content-design/elements/dynamic-blocks/dynamic-blocks-rotate), the administrator can select the following options:
 
 *  **Specified Dynamic Blocks**
 *  **Cart Price Rule Related**

--- a/src/pages/graphql/tutorials/checkout/apply-coupon.md
+++ b/src/pages/graphql/tutorials/checkout/apply-coupon.md
@@ -20,7 +20,7 @@ Use [applyCouponToCart](apply-coupon.md) to apply a discount coupon to the speci
 
 Coupons must be generated from the Admin.
 
-Creating a coupon is described in [Coupon Codes](https://docs.magento.com/user-guide/marketing/price-rules-cart-coupon.html).
+Creating a coupon is described in [Coupon Codes](https://experienceleague.adobe.com/en/docs/commerce-admin/marketing/promotions/cart-rules/price-rules-cart-coupon).
 For the purpose of this tutorial, create a Cart Price Rule with:
 
 For **Rule Information**:

--- a/src/pages/graphql/tutorials/checkout/index.md
+++ b/src/pages/graphql/tutorials/checkout/index.md
@@ -32,7 +32,7 @@ Complete the following prerequisites:
 
 -  Know how to generate a customer token. See [Authorization tokens](../../usage/authorization-tokens.md) for details.
 
--  In the Admin, create a [coupon](https://docs.magento.com/user-guide/marketing/price-rules-cart-coupon-code-configure.html) that will be used in [Step 7. Apply a coupon](../../tutorials/checkout/apply-coupon.md).
+-  In the Admin, create a [coupon](https://experienceleague.adobe.com/en/docs/commerce-admin/marketing/promotions/cart-rules/price-rules-cart-coupon#configure-coupon-codes) that will be used in [Step 7. Apply a coupon](../../tutorials/checkout/apply-coupon.md).
 
 ### Other resources
 

--- a/src/pages/graphql/usage/caching.md
+++ b/src/pages/graphql/usage/caching.md
@@ -95,7 +95,7 @@ Adding factors could generate too many unique cache keys, thereby reducing the n
 
 ## Caching with Varnish
 
-For on-premise installations, we recommend setting up Varnish as a reverse proxy to serve the full page cache in a production environment. The template `vcl` file that ships with each release configures support for GraphQL caching. We recommend that you review the template file each release to determine whether you need to update the `default.vcl` on your system. To view the contents of the latest template file, you can [download a template file from the Admin](https://docs.magento.com/user-guide/system/cache-full-page.html) or review the `app/code/Magento/PageCache/etc/varnish6.vcl` file in the codebase.
+For on-premise installations, we recommend setting up Varnish as a reverse proxy to serve the full page cache in a production environment. The template `vcl` file that ships with each release configures support for GraphQL caching. We recommend that you review the template file each release to determine whether you need to update the `default.vcl` on your system. To view the contents of the latest template file, you can [download a template file from the Admin](https://experienceleague.adobe.com/en/docs/commerce-admin/systems/tools/cache-management#full-page-caching) or review the `app/code/Magento/PageCache/etc/varnish6.vcl` file in the codebase.
 
 See [Configure and use Varnish](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cache/varnish/config-varnish.html) and [Configure Varnish and your web server](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cache/config-varnish-server.html) for more information.
 
@@ -108,7 +108,7 @@ To enable GraphQL caching on Fastly:
 1. Upgrade the Fastly CDN Module for Adobe Commerce and Magento Open Source 2.x to version 1.2.160 or later.
 1. Upload the updated VCL code to the Fastly servers.
 
-[Set up Fastly](https://devdocs.magento.com/cloud/cdn/configure-fastly.html) describes how to perform both of these tasks.
+[Set up Fastly](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/cdn/setup-fastly/fastly-configuration) describes how to perform both of these tasks.
 
 By default, the Fastly module for Adobe Commerce and Magento Open Source provides the following VCL configuration for caching guest queries:
 

--- a/src/pages/graphql/usage/staging-queries.md
+++ b/src/pages/graphql/usage/staging-queries.md
@@ -9,7 +9,7 @@ keywords:
 
 GraphQL allows you to use certain queries to return preview information for staged content. Staging, a Adobe Commerce feature, allows merchants to schedule a set of changes to the storefront that run for a prescribed time in the future. These changes, also known as a _campaign_, are defined within the Admin. Customers do not have access to staged content, and as a result, staging queries have requirements that do not apply to traditional queries and mutations.
 
-[Content Staging](https://docs.magento.com/m2/ee/user_guide/cms/content-staging.html) in the _Merchant User Guide_ describes how to create a campaign.
+[Content Staging](https://experienceleague.adobe.com/en/docs/commerce-admin/content-design/staging/content-staging) in the _Merchant User Guide_ describes how to create a campaign.
 
 You can use the following queries to return staged preview information.
 

--- a/src/pages/rest/b2b/index.md
+++ b/src/pages/rest/b2b/index.md
@@ -58,4 +58,4 @@ SharedCatalog | Defines the visibility of products and prices in the catalog and
 ## Related information
 
 - [Install the B2B extension](https://experienceleague.adobe.com/docs/commerce-admin/b2b/install.html)
-- [Getting started with <Vars.sitedatavarb2b/>](https://docs.magento.com/user-guide/getting-started.html)
+- [Getting started with <Vars.sitedatavarb2b/>](https://experienceleague.adobe.com/en/docs/commerce-admin/user-guides/home)

--- a/src/pages/rest/inventory/manage-source-items.md
+++ b/src/pages/rest/inventory/manage-source-items.md
@@ -41,7 +41,7 @@ Use the `POST V1/inventory/source-items-delete` endpoint to unassign one or more
 
 <InlineAlert variant="warning" slots="text"/>
 
-Unassigning a source clears all quantity data. For this example, this is OK, because the default source did not contain any quantity data. Reassigning a source that contains real quantity data can potentially cause havoc with pending orders with reservations and affect the salable quantity counts. See the [merchant documentation](https://docs.magento.com/user-guide/catalog/inventory-bulk-transfer-inventory.html) for more details.
+Unassigning a source clears all quantity data. For this example, this is OK, because the default source did not contain any quantity data. Reassigning a source that contains real quantity data can potentially cause havoc with pending orders with reservations and affect the salable quantity counts. See the [merchant documentation](https://experienceleague.adobe.com/en/docs/commerce-admin/inventory/quantities/inventory-transfer) for more details.
 
 **Sample usage:**
 

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -642,7 +642,7 @@ The multiple select attributes for customer and customer address are represented
 }
 ```
 
-The Import JSON API does not create attributes automatically. You need to create attributes manually before importing data. For more information, see [Create attributes](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/attributes.html#create-attributes).
+The Import JSON API does not create attributes automatically. You need to create attributes manually before importing data. For more information, see [Create attributes](https://developer.adobe.com/commerce/php/development/components/attributes/).
 
 **Advanced Pricing payload:**
 

--- a/src/pages/rest/tutorials/index.md
+++ b/src/pages/rest/tutorials/index.md
@@ -34,7 +34,7 @@ Before you begin any tutorial, make sure you know the basics about <Vars.sitedat
 
 *  Find the Commerce REST API documentation. You can view the [static REST API documentation on devdocs](../quick-reference/index.md) or [generate a local API reference](/rest/use-rest/generate-local/).
 
-*  Find the Commerce Merchant documentation. Refer to [Getting Started with <Vars.sitedatavarce/>](https://docs.magento.com/user-guide/getting-started.html) for information about the Luma store that is created when you install Commerce with the sample data.
+*  Find the Commerce Merchant documentation. Refer to [Getting Started with <Vars.sitedatavarce/>](https://experienceleague.adobe.com/en/docs/commerce-admin/user-guides/home) for information about the Luma store that is created when you install Commerce with the sample data.
 
 ## Performing steps
 

--- a/src/pages/rest/tutorials/orders/index.md
+++ b/src/pages/rest/tutorials/orders/index.md
@@ -28,7 +28,7 @@ Complete the following prerequisites:
 
 *  Find the Commerce REST API documentation. You can view the [static REST API documentation on devdocs](../../quick-reference/index.md) or [generate a local API reference](/rest/use-rest/generate-local/).
 
-*  Find the Commerce Merchant documentation. Refer to [Getting Started with <Vars.sitedatavarce/> 2.1](https://docs.magento.com/user-guide/getting-started.html) for information about the Luma store that is created when you install Commerce with the sample data.
+*  Find the Commerce Merchant documentation. Refer to [Getting Started with <Vars.sitedatavarce/> 2.1](https://experienceleague.adobe.com/en/docs/commerce-admin/user-guides/home) for information about the Luma store that is created when you install Commerce with the sample data.
 
 ### Other resources
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) replace links to decommissioned resources with up-to-date links.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi//get-started/api-security/
- https://developer.adobe.com/commerce/webapi//graphql/schema/cart/mutations/set-payment-place-order/
- https://developer.adobe.com/commerce/webapi//graphql/schema/checkout/mutations/create-braintree-client-token/
- https://developer.adobe.com/commerce/webapi//graphql/schema/store/queries/dynamic-blocks/
- https://developer.adobe.com/commerce/webapi//graphql/tutorials/checkout/apply-coupon/
- https://developer.adobe.com/commerce/webapi//graphql/tutorials/checkout/
- https://developer.adobe.com/commerce/webapi//graphql/usage/caching/
- https://developer.adobe.com/commerce/webapi//graphql/usage/staging-queries/
- https://developer.adobe.com/commerce/webapi//rest/b2b/
- https://developer.adobe.com/commerce/webapi//rest/inventory/manage-source-items/
- https://developer.adobe.com/commerce/webapi//rest/modules/import/
- https://developer.adobe.com/commerce/webapi//rest/tutorials/
- https://developer.adobe.com/commerce/webapi//rest/tutorials/orders/