### PR TITLE
LYNX-572: Added entries for new RMA mutations

### DIFF
--- a/src/pages/graphql/schema/orders/mutations/confirm-return.md
+++ b/src/pages/graphql/schema/orders/mutations/confirm-return.md
@@ -129,6 +129,7 @@ Attribute |  Data Type | Description
 
 ## Related topics
 
-*  [`addReturnComment` mutation](add-return-comment.md)
-*  [`addReturnTracking` mutation](add-return-tracking.md)
-*  [`removeReturnTracking` mutation](remove-return-tracking.md)
+* [`requestGuestReturn` mutation](request-guest-return.md) 
+* [`addReturnComment` mutation](add-return-comment.md)
+* [`addReturnTracking` mutation](add-return-tracking.md)
+* [`removeReturnTracking` mutation](remove-return-tracking.md)

--- a/src/pages/graphql/schema/orders/mutations/confirm-return.md
+++ b/src/pages/graphql/schema/orders/mutations/confirm-return.md
@@ -133,7 +133,7 @@ Attribute |  Data Type | Description
 
 ## Related topics
 
-*  [`requestGuestReturn` mutation](request-guest-return.md) 
+*  [`requestGuestReturn` mutation](request-guest-return.md)
 *  [`addReturnComment` mutation](add-return-comment.md)
 *  [`addReturnTracking` mutation](add-return-tracking.md)
 *  [`removeReturnTracking` mutation](remove-return-tracking.md)

--- a/src/pages/graphql/schema/orders/mutations/confirm-return.md
+++ b/src/pages/graphql/schema/orders/mutations/confirm-return.md
@@ -1,0 +1,134 @@
+---
+title: requestReturn mutation
+edition: ee
+---
+
+# confirmReturn mutation
+
+The `confirmReturn` mutation confirms a return request from a guest customer. The merchant subsequently decides whether to accept or reject the request.
+
+## Syntax
+
+```graphql
+mutation {
+  confirmReturn(input: ConfirmReturnInput!): RequestReturnOutput
+}
+```
+
+## Reference
+
+The [`confirmReturn`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-confirmReturn) reference provides detailed information about the types and fields defined in this mutation.
+
+## Example usage
+
+The following example confirms a return request previously issued by a guest customer. At this point, the merchant hasn't taken action, but the response acknowledges the request was received.
+
+**Request:**
+
+```graphql
+mutation{
+  confirmReturn(input: {
+    order_id: "NQ=="
+    confirmation_key: "abcde"
+  }){
+    return {
+      uid
+      items {
+        uid
+        status
+        request_quantity
+        quantity
+        order_item {
+          id
+          eligible_for_return
+          product_sku
+          product_sku
+          product_type
+          quantity_returned
+          status
+        }
+      }
+      number
+      status
+      comments {
+        uid
+        author_name
+        text
+        created_at
+      }
+      customer {
+        firstname
+        lastname
+        email
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "confirmReturn": {
+      "return": {
+        "uid": "Mw==",
+        "items": [
+          {
+            "uid": "Mw==",
+            "status": "PENDING",
+            "request_quantity": 1,
+            "quantity": 0,
+            "order_item": {
+              "id": "MTE=",
+              "eligible_for_return": true,
+              "product_sku": "MS09-M-Red",
+              "product_type": "configurable",
+              "quantity_returned": 0,
+              "status": "Shipped"
+            }
+          }
+        ],
+        "number": "000000003",
+        "status": "PENDING",
+        "comments": [
+          {
+            "uid": "NQ==",
+            "author_name": "Customer Service",
+            "text": "We placed your Return request.",
+            "created_at": "2020-11-19 18:20:28"
+          },
+          {
+            "uid": "Ng==",
+            "author_name": "Bob Loblaw",
+            "text": "I want to return the shirt because I don't like the texture of the fabric",
+            "created_at": "2020-11-19 18:20:28"
+          }
+        ],
+        "customer": {
+          "firstname": "Bob",
+          "lastname": "Loblaw",
+          "email": "test1@example.com"
+        }
+      }
+    }
+  }
+}
+```
+
+### Returns attributes
+
+The `Returns` object contains an array of `Return` objects and pagination information.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`items` | [Return] | A list of return requests
+`page_info` SearchResultPageInfo | Pagination metadata
+`total_count` | Int | The total number of return requests
+
+## Related topics
+
+*  [`addReturnComment` mutation](add-return-comment.md)
+*  [`addReturnTracking` mutation](add-return-tracking.md)
+*  [`removeReturnTracking` mutation](remove-return-tracking.md)

--- a/src/pages/graphql/schema/orders/mutations/confirm-return.md
+++ b/src/pages/graphql/schema/orders/mutations/confirm-return.md
@@ -5,6 +5,10 @@ edition: ee
 
 # confirmReturn mutation
 
+<InlineAlert variant="info" slots="text1" />
+
+This mutation is part of the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/storefront-compatibility/). It will be added to Adobe Commerce 2.4.8-beta2.
+
 The `confirmReturn` mutation confirms a return request from a guest customer. The merchant subsequently decides whether to accept or reject the request.
 
 ## Syntax
@@ -14,11 +18,11 @@ mutation {
   confirmReturn(input: ConfirmReturnInput!): RequestReturnOutput
 }
 ```
-
+<!--
 ## Reference
 
 The [`confirmReturn`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-confirmReturn) reference provides detailed information about the types and fields defined in this mutation.
-
+-->
 ## Example usage
 
 The following example confirms a return request previously issued by a guest customer. At this point, the merchant hasn't taken action, but the response acknowledges the request was received.

--- a/src/pages/graphql/schema/orders/mutations/confirm-return.md
+++ b/src/pages/graphql/schema/orders/mutations/confirm-return.md
@@ -1,5 +1,5 @@
 ---
-title: requestReturn mutation
+title: confirmReturn mutation
 edition: ee
 ---
 

--- a/src/pages/graphql/schema/orders/mutations/confirm-return.md
+++ b/src/pages/graphql/schema/orders/mutations/confirm-return.md
@@ -129,7 +129,7 @@ Attribute |  Data Type | Description
 
 ## Related topics
 
-* [`requestGuestReturn` mutation](request-guest-return.md) 
-* [`addReturnComment` mutation](add-return-comment.md)
-* [`addReturnTracking` mutation](add-return-tracking.md)
-* [`removeReturnTracking` mutation](remove-return-tracking.md)
+*  [`requestGuestReturn` mutation](request-guest-return.md) 
+*  [`addReturnComment` mutation](add-return-comment.md)
+*  [`addReturnTracking` mutation](add-return-tracking.md)
+*  [`removeReturnTracking` mutation](remove-return-tracking.md)

--- a/src/pages/graphql/schema/orders/mutations/request-guest-return.md
+++ b/src/pages/graphql/schema/orders/mutations/request-guest-return.md
@@ -1,5 +1,5 @@
 ---
-title: requestReturn mutation
+title: requestGuestReturn mutation
 edition: ee
 ---
 

--- a/src/pages/graphql/schema/orders/mutations/request-guest-return.md
+++ b/src/pages/graphql/schema/orders/mutations/request-guest-return.md
@@ -8,7 +8,7 @@ edition: ee
 The `requestGuestReturn` mutation initiates a guest buyer's request to return an item for replacement or refund.
 A confirmation email is sent to the guest provided email address with a link to confirm the return request and continue the process.
 
-The following examples illustrate how to retrieve the token and item ID values needed to run the `requestGuestReturn` mutation:
+The following queries illustrate how to retrieve the token and item ID values needed to run the `requestGuestReturn` mutation:
 
 *  [Retrieve details about an order placed by a guest or customer who is not logged in](../queries/guest-order.md)
 *  [Retrieve detailed information about a specific guest order](../queries/guest-order-by-token.md)

--- a/src/pages/graphql/schema/orders/mutations/request-guest-return.md
+++ b/src/pages/graphql/schema/orders/mutations/request-guest-return.md
@@ -1,0 +1,144 @@
+---
+title: requestReturn mutation
+edition: ee
+---
+
+# requestReturn mutation
+
+The `requestGuestReturn` mutation initiates a guest buyer's request to return an item for replacement or refund.
+A confirmation email is sent to the guest provided email address with a link to confirm the return request and continue the process.
+
+The following examples illustrate how to retrieve the token and item ID values needed to run the `requestGuestReturn` mutation:
+
+*  [Retrieve details about an order placed by a guest or customer who is not logged in](../queries/guest-order)
+*  [Retrieve detailed information about a specific guest order](../queries/guest-order-by-token)
+
+<InlineAlert variant="info" slots="text" />
+
+Use the [`storeConfig` query](../../store/queries/store-config.md) with the `returns_enabled` attribute to determine whether returned merchandise authorization (RMAs) are enabled.
+
+## Syntax
+
+```graphql
+mutation {
+  requestGuestReturn(input: RequestGuestReturnInput!): RequestReturnOutput
+}
+```
+
+## Reference
+
+The [`requestGuestReturn`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestReturn) reference provides detailed information about the types and fields defined in this mutation.
+
+## Example usage
+
+The following example requests a product return from a guest customer.
+
+**Request:**
+
+```graphql
+mutation{
+  requestGuestReturn(input: {
+    token: "0:3:E2uahokr8ud2uV3/z/7ELF0yQGDtT6vHUbLEGCpM3wUfouCNWf7ZGaMUYEhRKnrbGCq9l4zDbpO8JMPqfA=="
+    contact_email: "test1@example.com"
+    comment_text: "I want to return the shirt because I don't like the texture of the fabric"
+    items: {
+      order_item_uid: "MTE="
+      quantity_to_return: 1
+    }
+  }){
+    return {
+      uid
+      items {
+        uid
+        status
+        request_quantity
+        quantity
+        order_item {
+          id
+          eligible_for_return
+          product_sku
+          product_sku
+          product_type
+          quantity_returned
+          status
+        }
+      }
+      number
+      status
+      comments {
+        uid
+        author_name
+        text
+        created_at
+      }
+      customer {
+        firstname
+        lastname
+        email
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "requestGuestReturn": {
+      "return": {
+        "uid": "Mw==",
+        "items": [
+          {
+            "uid": "Mw==",
+            "status": "PENDING",
+            "request_quantity": 1,
+            "quantity": 0,
+            "order_item": {
+              "id": "MTE=",
+              "eligible_for_return": true,
+              "product_sku": "MS09-M-Red",
+              "product_type": "configurable",
+              "quantity_returned": 0,
+              "status": "Shipped"
+            }
+          }
+        ],
+        "number": "000000003",
+        "status": "UNCONFIRMED",
+        "comments": [
+          {
+            "uid": "Ng==",
+            "author_name": "Bob Loblaw",
+            "text": "I want to return the shirt because I don't like the texture of the fabric",
+            "created_at": "2020-11-19 18:20:28"
+          }
+        ],
+        "customer": {
+          "firstname": "Bob",
+          "lastname": "Loblaw",
+          "email": "test1@example.com"
+        }
+      }
+    }
+  }
+}
+```
+
+### Returns attributes
+
+The `Returns` object contains an array of `Return` objects and pagination information.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`items` | [Return] | A list of return requests
+`page_info` SearchResultPageInfo | Pagination metadata
+`total_count` | Int | The total number of return requests
+
+## Related topics
+
+*  [`addReturnComment` mutation](add-return-comment.md)
+*  [`addReturnTracking` mutation](add-return-tracking.md)
+*  [`removeReturnTracking` mutation](remove-return-tracking.md)
+*  [`confirmReturn` mutation](confirm-return.md)

--- a/src/pages/graphql/schema/orders/mutations/request-guest-return.md
+++ b/src/pages/graphql/schema/orders/mutations/request-guest-return.md
@@ -35,7 +35,7 @@ The [`requestGuestReturn`](https://developer.adobe.com/commerce/webapi/graphql-a
 -->
 ## Example usage
 
-The following example requests a product return from a guest customer. Note that the return status after this request is `UNCONFIRMED`, as guest users need to confirm the return request as stated above. 
+The following example requests a product return from a guest customer. Note that the return status after this request is `UNCONFIRMED`, as guest users need to confirm the return request as stated above.
 
 **Request:**
 

--- a/src/pages/graphql/schema/orders/mutations/request-guest-return.md
+++ b/src/pages/graphql/schema/orders/mutations/request-guest-return.md
@@ -138,7 +138,7 @@ Attribute |  Data Type | Description
 
 ## Related topics
 
-* [`confirmReturn` mutation](confirm-return.md)
-* [`addReturnComment` mutation](add-return-comment.md)
-* [`addReturnTracking` mutation](add-return-tracking.md)
-* [`removeReturnTracking` mutation](remove-return-tracking.md)
+*  [`confirmReturn` mutation](confirm-return.md)
+*  [`addReturnComment` mutation](add-return-comment.md)
+*  [`addReturnTracking` mutation](add-return-tracking.md)
+*  [`removeReturnTracking` mutation](remove-return-tracking.md)

--- a/src/pages/graphql/schema/orders/mutations/request-guest-return.md
+++ b/src/pages/graphql/schema/orders/mutations/request-guest-return.md
@@ -3,15 +3,15 @@ title: requestGuestReturn mutation
 edition: ee
 ---
 
-# requestReturn mutation
+# requestGuestReturn mutation
 
 The `requestGuestReturn` mutation initiates a guest buyer's request to return an item for replacement or refund.
 A confirmation email is sent to the guest provided email address with a link to confirm the return request and continue the process.
 
 The following examples illustrate how to retrieve the token and item ID values needed to run the `requestGuestReturn` mutation:
 
-*  [Retrieve details about an order placed by a guest or customer who is not logged in](../queries/guest-order)
-*  [Retrieve detailed information about a specific guest order](../queries/guest-order-by-token)
+*  [Retrieve details about an order placed by a guest or customer who is not logged in](../queries/guest-order.md)
+*  [Retrieve detailed information about a specific guest order](../queries/guest-order-by-token.md)
 
 <InlineAlert variant="info" slots="text" />
 
@@ -27,11 +27,11 @@ mutation {
 
 ## Reference
 
-The [`requestGuestReturn`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestReturn) reference provides detailed information about the types and fields defined in this mutation.
+The [`requestGuestReturn`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestGuestReturn) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 
-The following example requests a product return from a guest customer.
+The following example requests a product return from a guest customer. Note that the return status after this request is `UNCONFIRMED`, as guest users need to confirm the return request as stated above. 
 
 **Request:**
 
@@ -138,7 +138,7 @@ Attribute |  Data Type | Description
 
 ## Related topics
 
-*  [`addReturnComment` mutation](add-return-comment.md)
-*  [`addReturnTracking` mutation](add-return-tracking.md)
-*  [`removeReturnTracking` mutation](remove-return-tracking.md)
-*  [`confirmReturn` mutation](confirm-return.md)
+* [`confirmReturn` mutation](confirm-return.md)
+* [`addReturnComment` mutation](add-return-comment.md)
+* [`addReturnTracking` mutation](add-return-tracking.md)
+* [`removeReturnTracking` mutation](remove-return-tracking.md)

--- a/src/pages/graphql/schema/orders/mutations/request-guest-return.md
+++ b/src/pages/graphql/schema/orders/mutations/request-guest-return.md
@@ -5,6 +5,10 @@ edition: ee
 
 # requestGuestReturn mutation
 
+<InlineAlert variant="info" slots="text1" />
+
+This mutation is part of the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/storefront-compatibility/). It will be added to Adobe Commerce 2.4.8-beta2.
+
 The `requestGuestReturn` mutation initiates a guest buyer's request to return an item for replacement or refund.
 A confirmation email is sent to the guest provided email address with a link to confirm the return request and continue the process.
 
@@ -24,11 +28,11 @@ mutation {
   requestGuestReturn(input: RequestGuestReturnInput!): RequestReturnOutput
 }
 ```
-
+<!--
 ## Reference
 
 The [`requestGuestReturn`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestGuestReturn) reference provides detailed information about the types and fields defined in this mutation.
-
+-->
 ## Example usage
 
 The following example requests a product return from a guest customer. Note that the return status after this request is `UNCONFIRMED`, as guest users need to confirm the return request as stated above. 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) add two new entries into order/mutations, both related with the newly introduced feature of allowing returns (RMA) for guests

* `requestGuestReturn`
* `confirmReturn`

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
