### PR TITLE
Adding ItemsV2 to tutorial

### DIFF
--- a/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
+++ b/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
@@ -32,7 +32,7 @@ The following mutation adds a simple product into the shopping cart.
 
 Replace `{ CART_ID }` with the unique shopping cart ID from [Step 2. Create empty cart](../../tutorials/checkout/add-product-to-cart.md).
 
-In this example, we will add the Aim Analog Watch (SKU 24-MG04) from the default Luma catalog to the cart. The SKU identifies the product to be added.
+In this example, we will add the Salt Water Magazine (SKU VDL01) from the default Luma catalog to the cart. The SKU identifies the product to be added.
 
 **Request:**
 
@@ -45,20 +45,22 @@ mutation {
         {
           data: {
             quantity: 1
-            sku: "24-MG04"
+            sku: "VDL01"
           }
         }
       ]
     }
   ) {
     cart {
-      items {
-        id
-        product {
-          sku
-          stock_status
+      itemsV2 {
+        items {
+          id
+          product {
+            sku
+            stock_status
+          }
+          quantity
         }
-        quantity
       }
     }
   }
@@ -76,7 +78,7 @@ mutation {
           {
             "id": "5",
             "product": {
-              "sku": "24-MG04",
+              "sku": "VDL01",
               "stock_status": "IN_STOCK"
             },
             "quantity": 1
@@ -135,7 +137,7 @@ mutation {
           {
             "id": "5",
             "product": {
-              "sku": "24-MG04",
+              "sku": "240-LV04",
               "stock_status": "IN_STOCK"
             },
             "quantity": 1

--- a/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
+++ b/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
@@ -78,7 +78,7 @@ mutation {
           {
             "id": "5",
             "product": {
-              "sku": "VDL01",
+              "sku": "24-MG04",
               "stock_status": "IN_STOCK"
             },
             "quantity": 1

--- a/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
+++ b/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
@@ -32,7 +32,7 @@ The following mutation adds a simple product into the shopping cart.
 
 Replace `{ CART_ID }` with the unique shopping cart ID from [Step 2. Create empty cart](../../tutorials/checkout/add-product-to-cart.md).
 
-In this example, we will add the Salt Water Magazine (SKU VDL01) from the default Luma catalog to the cart. The SKU identifies the product to be added.
+In this example, we will add the Aim Analog Watch (SKU 24-MG04) from the default Luma catalog to the cart. The SKU identifies the product to be added.
 
 **Request:**
 
@@ -45,7 +45,7 @@ mutation {
         {
           data: {
             quantity: 1
-            sku: "VDL01"
+            sku: "24-MG04"
           }
         }
       ]

--- a/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
+++ b/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
@@ -137,7 +137,7 @@ mutation {
           {
             "id": "5",
             "product": {
-              "sku": "240-LV04",
+              "sku": "24-MG04",
               "stock_status": "IN_STOCK"
             },
             "quantity": 1


### PR DESCRIPTION
This PR updates [this tutorial page](https://developer.adobe.com/commerce/webapi/graphql/tutorials/checkout/add-product-to-cart/) to include `itemsV2`. ~It also changes the example product to one found in the current Venia catalog.~