### PR TITLE
Updates the `getPaymentConfig` query with the correct `three_ds_mode` attribute

### DIFF
--- a/src/pages/graphql/payment-services-extension/queries/get-payment-config.md
+++ b/src/pages/graphql/payment-services-extension/queries/get-payment-config.md
@@ -50,7 +50,7 @@ The following example runs the `getPaymentConfig` query for a `location: CHECKOU
                 }
                 is_visible
                 payment_source
-                three_ds
+                three_ds_mode
                 is_vault_enabled
                 cc_vault_code
                 requires_card_details
@@ -157,7 +157,7 @@ The following example runs the `getPaymentConfig` query for a `location: CHECKOU
                     ],
                     "is_visible": true,
                     "payment_source": "cc",
-                    "three_ds": false,
+                    "three_ds_mode": false,
                     "is_commerce_vault_enabled": true,
                     "cc_vault_code": "payment_services_paypal_vault"
                     "requires_card_details": false
@@ -344,7 +344,9 @@ Attribute |  Data Type | Description
 `is_vault_enabled` | Boolean | Indicates whether card vaulting is enabled
 `payment_source` | String | The identifiable payment source for the payment method
 `requires_card_details` | Boolean | Indicates whether card and bin details are required. This value is true when the Signifyd integration is enabled for hosted fields
-`three_ds` | Boolean | Indicates whether 3DS mode is enabled
+`three_ds_mode` | ThreeDSMode | Indicates which 3D Secure authentication mode is in use. The possible values are `OFF`, `SCA_WHEN_REQUIRED`, `SCA_ALWAYS`
+
+**Note:** The `three_ds` attribute is deprecated. The `HostedFieldsConfig` payment method configuration currently uses a `three_ds_mode` attribute instead.
 
 ### `SmartButtonsConfig` attributes
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the `getPaymentConfig` query with the correct `three_ds_mode` attribute. Now, the `three_ds` attribute is deprecated since implementation of PS extension version 2.10.0.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
