### PR TITLE
Add 'Jump to Top' to GraphQL API reference

### DIFF
--- a/spectaql/comdox-theme/views/partials/graphql/_query-or-mutation-or-subscription.hbs
+++ b/spectaql/comdox-theme/views/partials/graphql/_query-or-mutation-or-subscription.hbs
@@ -77,6 +77,6 @@
         {{/if}}
       {{/if}}
     </div>
-    <a href="#top">Jump to Top</a>
+    <a href="#top">back to top</a>
   </div>
 </section>

--- a/spectaql/comdox-theme/views/partials/graphql/_query-or-mutation-or-subscription.hbs
+++ b/spectaql/comdox-theme/views/partials/graphql/_query-or-mutation-or-subscription.hbs
@@ -1,0 +1,82 @@
+<section id="{{./htmlId}}"
+  class="operation operation-{{#if isQuery}}query{{else if isMutation}}mutation{{else if isSubscription}}subscription{{else}}unknown{{/if}}"
+  data-traverse-target="{{./htmlId}}">
+  {{# unless @first }}
+    {{#if parentHtmlId }}
+      <div class="operation-group-name">
+        <a href="#group-{{./parentHtmlId}}">{{./parentName}}</a>
+      </div>
+    {{/if}}
+  {{/unless}}
+
+  <h2 class="operation-heading {{#if (and isDeprecated (not @root.info.x-hideIsDeprecated)) }}operation-deprecated{{/if}}">
+    {{md (codify name) stripParagraph="true"}}
+  </h2>
+
+  {{#if (and deprecationReason (not @root.info.x-hideDeprecationReason))}}
+    <div class="doc-row">
+      <div class="doc-copy">
+        <div class="doc-copy-section">
+          <div class="deprecation-reason">
+            {{ md deprecationReason stripParagraph=true }}
+          </div>
+        </div>
+      </div>
+    </div>
+  {{/if}}
+
+  {{#if description}}
+    <div class="doc-row">
+      <div class="doc-copy">
+        <div class="operation-description doc-copy-section">
+          <h5>Description</h5>
+          {{ md (interpolateReferences description) }}
+        </div>
+      </div>
+    </div>
+  {{/if}}
+
+  <div class="doc-row">
+    <div class="doc-copy">
+      {{#if response}}
+        <div class="operation-response doc-copy-section">
+          <h5>Response</h5>
+          <p>
+            Returns
+            {{! If it's got items, then it's an array, and we don't care about the indefiniteArticle }}
+            {{#unless response.isArray }}
+              {{ indefiniteArticle response.underlyingType.name }}
+            {{/unless}}
+            {{~ md (mdTypeLink . codify=true) stripParagraph=true }}
+          </p>
+        </div>
+      {{/if}}
+      {{>graphql/_query-or-mutation-arguments}}
+    </div>
+
+    <div class="doc-examples">
+      {{#if (firstTruthy query mutation subscription)}}
+        <h4 class="example-heading">Example</h4>
+
+        <div class="example-section example-section-is-code operation-query-example">
+          <h5>Query</h5>
+          {{printGraphQL (firstTruthy query mutation subscription)}}
+        </div>
+
+        {{#if variables}}
+          <div class="example-section example-section-is-code operation-variables-example">
+            <h5>Variables</h5>
+            {{printJSON variables}}
+          </div>
+        {{/if}}
+        {{#if response.data}}
+          <div class="example-section example-section-is-code operation-response-example">
+            <h5>Response</h5>
+            {{printJSON response.data}}
+          </div>
+        {{/if}}
+      {{/if}}
+    </div>
+    <a href="#top">Jump to Top</a>
+  </div>
+</section>

--- a/spectaql/comdox-theme/views/partials/graphql/type.hbs
+++ b/spectaql/comdox-theme/views/partials/graphql/type.hbs
@@ -1,0 +1,33 @@
+<section id="{{./htmlId}}"
+  class="definition definition-{{ kebabCase ./kind defaultValue='unknown' }}"
+  data-traverse-target="{{./htmlId}}">
+  {{#unless @first }}
+    {{#if parentHtmlId }}
+      <div class="definition-group-name">
+        <a href="#group-{{parentHtmlId}}">{{./parentName}}</a>
+      </div>
+    {{/if}}
+  {{/unless}}
+  {{#if name}}
+    <h2 class="definition-heading">{{name}}{{!--  - {{kind}} --}}</h2>
+  {{/if}}
+
+  <div class="doc-row">
+    {{#if (equal ./kind "SCALAR")}}
+      {{>graphql/kinds/scalar .}}
+    {{else if (equal ./kind "OBJECT")}}
+      {{>graphql/kinds/object .}}
+    {{else if (equal ./kind "ENUM")}}
+      {{>graphql/kinds/enum .}}
+    {{else if (equal ./kind "INPUT_OBJECT")}}
+      {{>graphql/kinds/input-object .}}
+    {{else if (equal ./kind "UNION")}}
+      {{>graphql/kinds/union .}}
+    {{else if (equal ./kind "INTERFACE")}}
+      {{>graphql/kinds/interface .}}
+    {{else}}
+      {{ log "unknown type.hbs" . }}
+    {{/if}}
+    <a href="#top">Jump to Top</a>
+  </div>
+</section>

--- a/spectaql/comdox-theme/views/partials/graphql/type.hbs
+++ b/spectaql/comdox-theme/views/partials/graphql/type.hbs
@@ -28,6 +28,6 @@
     {{else}}
       {{ log "unknown type.hbs" . }}
     {{/if}}
-    <a href="#top">Jump to Top</a>
+    <a href="#top">back to top</a>
   </div>
 </section>

--- a/spectaql/config.yml
+++ b/spectaql/config.yml
@@ -64,7 +64,7 @@ spectaql:
   # "spectaql": Outputs the same HTML structure as the "default" theme, but with some CSS enhancements
   #
   # Default: "default"
-  # themeDir: path/to/theme
+  themeDir: spectaql/comdox-theme
   theme: spectaql
 
   # If you're embedding SpectaQL's output, and you've got something like a Nav Bar that


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds 'Jump to Top' hyperlink to GraphQL API reference at the end of each doc row for instant navigation to the top of the page which can be annoying for long pages via scrolling.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi/graphql/reference/

## Preview

https://commerce-docs.github.io/commerce-webapi/graphql/reference/