### PR TITLE
add external link to toc

### DIFF
--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -1356,6 +1356,11 @@ module.exports = [
     path: "/graphql/reference",
     pages: [
       {
+        title: "2.4.7",
+        path: "https://developer.adobe.com/commerce/webapi/graphql-api/",
+        EventTarget: "_blank"
+      },
+      {
         title: "2.4.6",
         path: "/graphql/reference/2.4.6",
       },


### PR DESCRIPTION
#396 added a link in a paragraph to https://developer.adobe.com/commerce/webapi/graphql/reference/ and removed the TOC link to avoid duplicating the nav, but after looking at it today, I think the average user might not read that far and just assume the link is missing. 

This PR adds a direct link (opens in a new window) to the `2.4.7` GraphQL reference to the TOC to make it more obvious.
