### PR TITLE
Convert test-pull-request workflow to reusable

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -1,100 +1,12 @@
 ---
-  ###########################
-  ###########################
-  ## Pull request testing ##
-  ###########################
-  ###########################
   name: Validate pull request
   
-  # Documentation:
-  # - Workflow: https://help.github.com/en/articles/workflow-syntax-for-github-actions
-  # - SuperLinter: https://github.com/github/super-linter
-  # - Link validation: https://github.com/remarkjs/remark-validate-links
-  
-  ######################################################
-  # Start the job on a pull request to the main branch #
-  ######################################################
   on: pull_request
 
-  #################################################
-  # Disable all permissions on the workflow level #
-  #################################################
-  permissions: {}
+  permissions:
+    contents: read
+    statuses: write
   
-  ###############
-  # Set the Job #
-  ###############
   jobs:
-    lint:
-      # Set the agent to run on
-      runs-on: ubuntu-latest
-  
-      ############################################
-      # Grant status permission for MULTI_STATUS #
-      ############################################
-      permissions:
-        contents: read
-        statuses: write
-  
-      ##################
-      # Load all steps #
-      ##################
-      steps:
-        ##########################
-        # Checkout the code base #
-        ##########################
-        - name: Checkout Code
-          uses: actions/checkout@v4
-          with:
-            # Full git history is needed to get a proper list of changed files
-            # within `super-linter`
-            fetch-depth: 0
-        - name: Load super-linter configuration
-          run: cat .github/super-linter.env >> "$GITHUB_ENV"
-  
-        ################################
-        # Run Linters against code base #
-        ################################
-        - name: Lint Code Base
-          #
-          # Use full version number to avoid cases when a next
-          # released version is buggy
-          # About slim image: https://github.com/github/super-linter#slim-image
-          uses: super-linter/super-linter/slim@v7.2.0
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            DEFAULT_BRANCH: main
-
-    test:
-      runs-on: ubuntu-latest
-      needs: lint
-      permissions:
-        contents: read
-        statuses: write
-      steps:
-        - uses: actions/checkout@v4
-        - name: Use Setup Node and Install Dependencies Action
-          uses: commerce-docs/devsite-install-action@main
-          with:
-            node-version-file: '.nvmrc'
-            cache-dependency-path: 'yarn.lock'
-  
-        - name: Check links
-          run: yarn test
-
-    build:
-      runs-on: ubuntu-latest
-      needs: test
-      permissions:
-        contents: read
-        statuses: write
-      steps:
-        - uses: actions/checkout@v4
-        - name: Use Setup Node and Install Dependencies Action
-          uses: commerce-docs/devsite-install-action@main
-          with:
-            node-version-file: '.nvmrc'
-            cache-dependency-path: 'yarn.lock'
-  
-        - name: Build site
-          run: yarn build
+    testing:
+      uses: AdobeDocs/commerce-php/.github/workflows/validate-pr_job.yml@ds_pr-test-wf

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -9,4 +9,4 @@
   
   jobs:
     testing:
-      uses: AdobeDocs/commerce-php/.github/workflows/validate-pr_job.yml@ds_pr-test-wf
+      uses: AdobeDocs/commerce-php/.github/workflows/validate-pr_job.yml@main


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) converts the test-pull-request workflow to a reusable workflow implemented in AdobeDocs/commerce-php/pull/351.
This will improve maintenance by reducing code duplication.

REQUIRED ACTIONS:

- [ ] Update required checks in the branch protection settings