### PR TITLE
Add PaaS badges for deprecated GraphQL queries

### DIFF
--- a/src/pages/graphql/schema/attributes/queries/attributes-metadata.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: attributesMetadata query
-edition: pwa
+edition: paas
 ---
 
 # attributesMetadata query

--- a/src/pages/graphql/schema/b2b/company/mutations/delete-user.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/delete-user.md
@@ -2,7 +2,7 @@
 title: deleteCompanyUser mutation
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
-edition: b2b
+edition: paas
 ---
 
 # deleteCompanyUser mutation

--- a/src/pages/graphql/schema/cart/mutations/add-bundle-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-bundle-products.md
@@ -2,6 +2,7 @@
 title: addBundleProductsToCart mutation
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 ---
 
 # addBundleProductsToCart mutation

--- a/src/pages/graphql/schema/cart/mutations/add-configurable-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-configurable-products.md
@@ -1,5 +1,6 @@
 ---
 title: addConfigurableProductsToCart mutation
+edition: paas
 ---
 
 # addConfigurableProductsToCart mutation

--- a/src/pages/graphql/schema/cart/mutations/add-simple-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-simple-products.md
@@ -1,5 +1,6 @@
 ---
 title: addSimpleProductsToCart mutation
+edition: paas
 ---
 
 # addSimpleProductsToCart mutation

--- a/src/pages/graphql/schema/cart/mutations/add-virtual-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-virtual-products.md
@@ -1,5 +1,6 @@
 ---
 title: addVirtualProductsToCart mutation
+edition: paas
 ---
 
 # addVirtualProductsToCart mutation

--- a/src/pages/graphql/schema/cart/mutations/create-empty-cart.md
+++ b/src/pages/graphql/schema/cart/mutations/create-empty-cart.md
@@ -1,5 +1,6 @@
 ---
 title: createEmptyCart mutation
+edition: paas
 ---
 
 # createEmptyCart mutation

--- a/src/pages/graphql/schema/cart/mutations/set-payment-place-order.md
+++ b/src/pages/graphql/schema/cart/mutations/set-payment-place-order.md
@@ -2,6 +2,7 @@
 title: setPaymentMethodAndPlaceOrder mutation
 contributor_name: Something Digital (now Rightpoint)
 contributor_link: https://www.rightpoint.com/
+edition: paas
 ---
 
 # setPaymentMethodAndPlaceOrder mutation

--- a/src/pages/graphql/schema/customer/mutations/create.md
+++ b/src/pages/graphql/schema/customer/mutations/create.md
@@ -1,5 +1,6 @@
 ---
 title: createCustomer mutation
+edition: paas
 ---
 
 # createCustomer mutation

--- a/src/pages/graphql/schema/customer/mutations/update.md
+++ b/src/pages/graphql/schema/customer/mutations/update.md
@@ -1,5 +1,6 @@
 ---
 title: updateCustomer mutation
+edition: paas
 ---
 
 # updateCustomer mutation

--- a/src/pages/graphql/schema/customer/queries/orders.md
+++ b/src/pages/graphql/schema/customer/queries/orders.md
@@ -1,5 +1,6 @@
 ---
 title: customerOrders query
+edition: paas
 ---
 
 # customerOrders query

--- a/src/pages/graphql/schema/products/queries/category-list.md
+++ b/src/pages/graphql/schema/products/queries/category-list.md
@@ -1,5 +1,6 @@
 ---
 title: categoryList query
+edition: paas
 ---
 
 # categoryList query

--- a/src/pages/graphql/schema/products/queries/category.md
+++ b/src/pages/graphql/schema/products/queries/category.md
@@ -1,5 +1,6 @@
 ---
 title: category query
+edition: paas
 ---
 
 # category query

--- a/src/pages/graphql/schema/wishlist/queries/wishlist.md
+++ b/src/pages/graphql/schema/wishlist/queries/wishlist.md
@@ -1,5 +1,6 @@
 ---
 title: wishlist query
+edition: paas
 ---
 
 # wishlist query


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds badges for the first two queries that have been removed from ACCS. This is a mini PR because I need a reason to regenerate the cache in order to render the badges correctly.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
