### PR TITLE
More PaaS-only queries and mutations

### DIFF
--- a/src/pages/graphql/payment-methods/hosted-pro.md
+++ b/src/pages/graphql/payment-methods/hosted-pro.md
@@ -1,6 +1,7 @@
 ---
 title: PayPal Website Payments Pro Hosted Solution payment method
 description: Learn how to use the GraphQL API mutation for the PayPal Website Payments Pro Hosted payment solution.
+edition: paas
 keywords:
   - GraphQL
   - Payments

--- a/src/pages/graphql/payment-methods/klarna.md
+++ b/src/pages/graphql/payment-methods/klarna.md
@@ -3,6 +3,7 @@ title: Klarna payment method
 description: Learn how to use the GraphQL API mutation for the Klarna payment solution.
 contributor_name: Klarna
 contributor_link: https://www.klarna.com/
+edition: paas
 keywords:
   - GraphQL
   - Payments

--- a/src/pages/graphql/payment-methods/payflow-express.md
+++ b/src/pages/graphql/payment-methods/payflow-express.md
@@ -1,6 +1,7 @@
 ---
 title: Express Checkout for other PayPal solutions
 description: Learn how to use the GraphQL API mutation for the Express Checkout for other PayPal payment solutions.
+edition: paas
 keywords:
   - GraphQL
   - Payments

--- a/src/pages/graphql/payment-methods/payflow-link.md
+++ b/src/pages/graphql/payment-methods/payflow-link.md
@@ -1,6 +1,7 @@
 ---
 title: PayPal Payflow Link payment method
 description: Learn how to use the GraphQL API mutation for the PayPal Payflow Link payment solution.
+edition: paas
 keywords:
   - GraphQL
   - Payments

--- a/src/pages/graphql/payment-methods/payflow-pro.md
+++ b/src/pages/graphql/payment-methods/payflow-pro.md
@@ -4,6 +4,7 @@ description: Learn how to use the GraphQL API mutation for the PayPal Payflow Pr
 keywords:
   - GraphQL
   - Payments
+edition: paas
 ---
 
 # PayPal Payflow Pro payment method

--- a/src/pages/graphql/schema/cart/mutations/add-downloadable-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-downloadable-products.md
@@ -2,6 +2,7 @@
 title: addDownloadableProductsToCart mutation
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 ---
 
 # addDownloadableProductsToCart mutation

--- a/src/pages/graphql/schema/cart/mutations/clear-cart.md
+++ b/src/pages/graphql/schema/cart/mutations/clear-cart.md
@@ -1,5 +1,6 @@
 ---
 title: clearCart mutation
+edition: paas
 ---
 
 import CommerceOnly from '/src/_includes/commerce-only.md'

--- a/src/pages/graphql/schema/checkout/mutations/create-klarna-payments-session.md
+++ b/src/pages/graphql/schema/checkout/mutations/create-klarna-payments-session.md
@@ -2,6 +2,7 @@
 title: createKlarnaPaymentsSession mutation
 contributor_name: Klarna
 contributor_link: https://www.klarna.com/
+edition: paas
 ---
 
 # createKlarnaPaymentsSession mutation

--- a/src/pages/graphql/schema/checkout/mutations/create-payflow-pro-token.md
+++ b/src/pages/graphql/schema/checkout/mutations/create-payflow-pro-token.md
@@ -1,5 +1,6 @@
 ---
 title: createPayflowProToken mutation
+edition: paas
 ---
 
 # createPayflowProToken mutation

--- a/src/pages/graphql/schema/checkout/mutations/create-paypal-express-token.md
+++ b/src/pages/graphql/schema/checkout/mutations/create-paypal-express-token.md
@@ -1,5 +1,6 @@
 ---
 title: createPaypalExpressToken mutation
+edition: paas
 ---
 
 # createPaypalExpressToken mutation

--- a/src/pages/graphql/schema/checkout/mutations/handle-payflow-pro-response.md
+++ b/src/pages/graphql/schema/checkout/mutations/handle-payflow-pro-response.md
@@ -1,5 +1,6 @@
 ---
 title: handlePayflowProResponse mutation
+edition: paas
 ---
 
 # handlePayflowProResponse mutation

--- a/src/pages/graphql/schema/checkout/queries/get-hosted-pro-url.md
+++ b/src/pages/graphql/schema/checkout/queries/get-hosted-pro-url.md
@@ -1,5 +1,6 @@
 ---
 title: getHostedProUrl query
+edition: paas
 ---
 
 # getHostedProUrl query

--- a/src/pages/graphql/schema/checkout/queries/get-payflow-link-token.md
+++ b/src/pages/graphql/schema/checkout/queries/get-payflow-link-token.md
@@ -1,5 +1,6 @@
 ---
 title: getPayflowLinkToken query
+edition: paas
 ---
 
 # getPayflowLinkToken query

--- a/src/pages/graphql/schema/customer/mutations/send-email-to-friend.md
+++ b/src/pages/graphql/schema/customer/mutations/send-email-to-friend.md
@@ -1,5 +1,6 @@
 ---
 title: sendEmailToFriend mutation
+edition: paas
 ---
 
 # sendEmailToFriend mutation

--- a/src/pages/graphql/schema/customer/mutations/subscribe-email-to-newsletter.md
+++ b/src/pages/graphql/schema/customer/mutations/subscribe-email-to-newsletter.md
@@ -2,6 +2,7 @@
 title: subscribeEmailToNewsletter mutation
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 ---
 
 # subscribeEmailToNewsletter mutation

--- a/src/pages/graphql/schema/customer/queries/downloadable-products.md
+++ b/src/pages/graphql/schema/customer/queries/downloadable-products.md
@@ -1,5 +1,6 @@
 ---
 title: customerDownloadableProducts query
+edition: paas
 ---
 
 # customerDownloadableProducts query

--- a/src/pages/graphql/schema/products/mutations/create-review.md
+++ b/src/pages/graphql/schema/products/mutations/create-review.md
@@ -1,5 +1,6 @@
 ---
 title: createProductReview mutation
+edition: paas
 ---
 
 # createProductReview mutation

--- a/src/pages/graphql/schema/products/queries/product-review-ratings-metadata.md
+++ b/src/pages/graphql/schema/products/queries/product-review-ratings-metadata.md
@@ -1,5 +1,6 @@
 ---
 title: productReviewRatingsMetadata query
+edition: paas
 ---
 
 # productReviewRatingsMetadata query

--- a/src/pages/graphql/schema/products/queries/products.md
+++ b/src/pages/graphql/schema/products/queries/products.md
@@ -1524,6 +1524,8 @@ In this example, the `description` attribute has been enabled by setting the **S
 
 ### Retrieve related products, up-sells, and cross-sells
 
+<Edition name="paas" />
+
 The following query shows how to get related products, up-sells, and cross-sells for a product:
 
 **Request:**

--- a/src/pages/graphql/schema/products/queries/route.md
+++ b/src/pages/graphql/schema/products/queries/route.md
@@ -1,5 +1,6 @@
 ---
 title: route query
+edition: paas
 ---
 
 # route query

--- a/src/pages/graphql/schema/products/queries/url-resolver.md
+++ b/src/pages/graphql/schema/products/queries/url-resolver.md
@@ -1,5 +1,6 @@
 ---
 title: urlResolver query
+edition: paas
 ---
 
 # urlResolver query

--- a/src/pages/graphql/schema/store/mutations/contact-us.md
+++ b/src/pages/graphql/schema/store/mutations/contact-us.md
@@ -1,5 +1,6 @@
 ---
 title: contactUs mutation
+edition: paas
 ---
 
 # contactUs mutation

--- a/src/pages/graphql/schema/store/queries/cms-blocks.md
+++ b/src/pages/graphql/schema/store/queries/cms-blocks.md
@@ -1,5 +1,6 @@
 ---
 title: cmsBlocks query
+edition: paas
 ---
 
 # cmsBlocks query

--- a/src/pages/graphql/schema/store/queries/cms-page.md
+++ b/src/pages/graphql/schema/store/queries/cms-page.md
@@ -1,5 +1,6 @@
 ---
 title: cmsPage query
+edition: paas
 ---
 
 # cmsPage query

--- a/src/pages/graphql/schema/store/queries/dynamic-blocks.md
+++ b/src/pages/graphql/schema/store/queries/dynamic-blocks.md
@@ -1,5 +1,6 @@
 ---
 title: dynamicBlocks query
+edition: paas
 ---
 
 # dynamicBlocks query

--- a/src/pages/graphql/usage/staging-queries.md
+++ b/src/pages/graphql/usage/staging-queries.md
@@ -1,6 +1,7 @@
 ---
 title: GraphQL staging queries
 description: Learn how to preview scheduled campaign information.
+edition: paas
 keywords:
   - GraphQL
 ---


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the PaaS only badge to multiple queries and mutations. These entities were excluded from the ACCS schema by disabling the corresponding *GraphQL module in the repo's `etc/config.php` file.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
