### PR TITLE
Remove PaaS badge from contactUs query

### DIFF
--- a/src/pages/graphql/schema/store/mutations/contact-us.md
+++ b/src/pages/graphql/schema/store/mutations/contact-us.md
@@ -1,6 +1,5 @@
 ---
 title: contactUs mutation
-edition: paas
 ---
 
 # contactUs mutation


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the PaaS badge from the `contactUs` query. It was added to ACCS per CCSAAS-2146.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
