### PR TITLE
Mark topics as PaaS only in Getting Started

### DIFF
--- a/src/pages/get-started/api-security.md
+++ b/src/pages/get-started/api-security.md
@@ -19,9 +19,9 @@ Imposing restrictions on the size and number of resources that a user can reques
 By default, these input limits are disabled, but you can use the following methods to enable them:
 
 -  Set the values in the [Admin](https://experienceleague.adobe.com/en/docs/commerce-admin/config/services/magento-web-api).
--  Run the [`bin/magento config:set` command](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/configuration-management/set-configuration-values.html).
--  Add entries to the [`env.php` file](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/files/config-reference-configphp.html#system).
--  Set [environment variables](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/deployment/examples/example-environment-variables.html).
+-  &#8203;<Edition name="paas" /> Run the [`bin/magento config:set` command](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/cli/configuration-management/set-configuration-values.html).
+-  &#8203;<Edition name="paas" /> Add entries to the [`env.php` file](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/files/config-reference-configphp.html#system).
+-  &#8203;<Edition name="paas" /> Set [environment variables](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/deployment/examples/example-environment-variables.html).
 
 When input limiting has been enabled, the system uses the default value for each limitation listed above. You can also configure custom values.
 
@@ -36,7 +36,7 @@ In addition, the Admin provides a configuration setting for limiting session siz
 
 To enable these input limiting features from the Admin, go to **Stores** > Settings > **Configuration** > **Services** > **Web Api Limits** or **GraphQL Input Limits** and set **Enable Input Limits** to **Yes**.
 
-To enable with the CLI, run one or both of the following commands:
+&#8203;<Edition name="paas" /> To enable with the CLI, run one or both of the following commands:
 
 ```bash
 bin/magento config:set webapi/validation/input_limit_enabled 1
@@ -47,6 +47,8 @@ bin/magento config:set graphql/validation/input_limit_enabled 1
 ```
 
 ## Maximum parameter inputs
+
+<Edition name="paas" />
 
 The `EntityArrayValidator` class constructor limits the number of objects that can be given to inputs that represent arrays of objects. For example, the `PUT /V1/guest-carts/{cartId}/collect-totals` endpoint contains the input parameter `additionalData->extension_attributes->gift_messages`, which represents a list of gift message information objects.
 
@@ -106,6 +108,8 @@ By default, any one of these arrays can include up to 20 items, but you can chan
 
 ## Input limit for REST endpoints
 
+<Edition name="paas" />
+
 Some REST endpoints can contain a high number of elements, and developers need a way to set the limit for each endpoint. The limit for a specific REST endpoint can be set in the `webapi.xml` configuration file for synchronous requests and `webapi_async.xml` for asynchronous requests.
 To do this, assign a value for the `<data input-array-size-limit/>` attribute within a `<route>` definition. The value for `input-array-size-limit` must be a non-negative integer.
 
@@ -138,6 +142,8 @@ bin/magento cache:clean config
 
 ## Values by default for REST endpoints
 
+<Edition name="paas" />
+
 If you need to change the default limits for REST endpoints, then edit the `webapi` section of the `<magento_root>/app/etc/env.php` file as follows:
 
 ```php
@@ -163,7 +169,9 @@ The maximum page size setting controls the pagination of various web API respons
 
 ## Default page size
 
-The Default Page Size setting controls the pagination of various web API responses. You can change the default value of `20` in the Admin by selecting **Stores** > Settings > **Configuration** > **Services** > **Web API Input Limits** > **Default Page Size**. To change the value from the CLI, run the following command:
+The Default Page Size setting controls the pagination of various web API responses. You can change the default value of `20` in the Admin by selecting **Stores** > Settings > **Configuration** > **Services** > **Web API Input Limits** > **Default Page Size**.
+
+&#8203;<Edition name="paas" /> To change the value from the CLI, run the following command:
 
 ```bash
 bin/magento config:set webapi/validation/default_page_size 30

--- a/src/pages/get-started/authentication/gs-authentication-oauth.md
+++ b/src/pages/get-started/authentication/gs-authentication-oauth.md
@@ -1,12 +1,17 @@
 ---
 title: OAuth-Based Authentication
 description: How to use OAuth authentication and token passing in the web APIs.
+edition: paas
 keywords:
   - REST
   - Security
 ---
 
 # OAuth-based authentication
+
+<InlineAlert variant="info" slots="text"/>
+
+This topic is for Platform-as-a-Service (PaaS) customers only. Adobe Commerce Cloud Services customers must refer to [REST Authentication](https://developer.adobe.com/commerce/services/cloud/guides/rest/authentication/) for details on authentication.
 
 OAuth authentication with Adobe Commerce and Magento Open Source is based on [OAuth 1.0a](https://tools.ietf.org/html/rfc5849), an open standard for secure API authentication. OAuth is a token-passing mechanism that allows a system to control which third-party applications have access to internal data without revealing or storing any user IDs or passwords.
 

--- a/src/pages/get-started/authentication/gs-authentication-session.md
+++ b/src/pages/get-started/authentication/gs-authentication-session.md
@@ -1,12 +1,17 @@
 ---
 title: Session-Based Authentication
 description: How to use session-based authentication in the web APIs.
+edition: paas
 keywords:
   - REST
   - Security
 ---
 
 # Session-based authentication
+
+<InlineAlert variant="info" slots="text"/>
+
+This topic is for Platform-as-a-Service (PaaS) customers only. Adobe Commerce Cloud Services customers must refer to [REST Authentication](https://developer.adobe.com/commerce/services/cloud/guides/rest/authentication/) for details on authentication.
 
 As a customer, you log in to the storefront with your customer credentials. As an admin, you log in to the Admin with your admin credentials.
 

--- a/src/pages/get-started/authentication/gs-authentication-token.md
+++ b/src/pages/get-started/authentication/gs-authentication-token.md
@@ -1,12 +1,17 @@
 ---
 title: Token-Based Authentication
 description: How to use token-based authentication in web APIs.
+edition: paas
 keywords:
   - REST
   - Security
 ---
 
 # Token-based authentication
+
+<InlineAlert variant="info" slots="text"/>
+
+This topic is for Platform-as-a-Service (PaaS) customers only. Adobe Commerce Cloud Services customers must refer to [REST Authentication](https://developer.adobe.com/commerce/services/cloud/guides/rest/authentication/) for details on authentication.
 
 To make a web API call from a client such as a mobile application, you must supply an *access token* on the call. The token acts like an electronic key that lets you access the API.
 

--- a/src/pages/get-started/authentication/index.md
+++ b/src/pages/get-started/authentication/index.md
@@ -1,12 +1,17 @@
 ---
 title: Authentication
 description: Overview of authentication methods in web APIs.
+edition: paas
 keywords:
   - REST
   - Security
 ---
 
 # Authentication
+
+<InlineAlert variant="info" slots="text"/>
+
+This topic is for Platform-as-a-Service (PaaS) customers only. Adobe Commerce Cloud Services customers must refer to [REST Authentication](https://developer.adobe.com/commerce/services/cloud/guides/rest/authentication/) for details on authentication.
 
 Adobe Commerce and Magento Open Source allow developers to define web API resources and their permissions in the `webapi.xml` configuration file. See [Services as Web APIs](https://developer.adobe.com/commerce/php/development/components/web-api/services/).
 

--- a/src/pages/get-started/create-integration.md
+++ b/src/pages/get-started/create-integration.md
@@ -1,6 +1,7 @@
 ---
 title: Create an Integration
 description: Explains how to create an integration.
+edition: paas
 keywords:
   - Integration
   - REST

--- a/src/pages/get-started/gs-curl.md
+++ b/src/pages/get-started/gs-curl.md
@@ -1,6 +1,7 @@
 ---
 title: Use cURL to Run the Request
 description: Explains how to use cURL.
+edition: paas
 keywords:
   - REST
 ---

--- a/src/pages/get-started/gs-web-api-request.md
+++ b/src/pages/get-started/gs-web-api-request.md
@@ -99,6 +99,8 @@ This JSON-formatted request body includes a `customer` object with the customer 
 
 ## Construct a request
 
+<Edition name="paas" />
+
 This example shows you how to construct a REST web API call to create an account.
 
 1. Open the [Magento/Customer/etc/webapi.xml](https://github.com/magento/magento2/tree/2.4/app/code/Magento/Customer/etc/webapi.xml)
@@ -133,6 +135,8 @@ This example shows you how to construct a REST web API call to create an account
 1. To pass the `customer` data object in the POST call payload, specify JSON or XML request body on the call.
 
 ### Customers Search API request example
+
+<Edition name="paas" />
 
 The following example builds a Customers Search request based on search criteria. It returns a list of customers that match given search criteria.
 

--- a/src/pages/get-started/rate-limiting.md
+++ b/src/pages/get-started/rate-limiting.md
@@ -1,6 +1,7 @@
 ---
 title: Rate limiting
 description: Explains how to limit attacks that attempt to brute force credit card details.
+edition: paas
 keywords:
   - REST
   - Security

--- a/src/pages/get-started/soap-web-api-calls.md
+++ b/src/pages/get-started/soap-web-api-calls.md
@@ -1,5 +1,6 @@
 ---
 title: Use SOAP Services
+edition: paas
 description: A description of available SOAP services and their conventions
 ---
 

--- a/src/pages/get-started/web-api-functional-testing.md
+++ b/src/pages/get-started/web-api-functional-testing.md
@@ -1,6 +1,7 @@
 ---
 title: Web API Functional Testing
 description: How to implement and run functional tests on Web APIs.
+edition: paas
 keywords:
   - GraphQL
   - REST


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) marks blocks of information in the Getting Started Guide as PaaS-only.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
