### PR TITLE
Re-enable subscribeEmailToNewsletter mutation for SaaS

### DIFF
--- a/src/pages/graphql/schema/customer/mutations/subscribe-email-to-newsletter.md
+++ b/src/pages/graphql/schema/customer/mutations/subscribe-email-to-newsletter.md
@@ -2,7 +2,6 @@
 title: subscribeEmailToNewsletter mutation
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
-edition: paas
 ---
 
 # subscribeEmailToNewsletter mutation


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the PaaS only badge from the `subscribeEmailToNewsletter` mutation, per CSSAAS-2424

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
