### PR TITLE
Fix highlighting error

### DIFF
--- a/src/pages/rest/modules/custom-attributes.md
+++ b/src/pages/rest/modules/custom-attributes.md
@@ -27,7 +27,7 @@ The following sections describe the REST endpoints that support custom attribute
 
 <InlineAlert variant="important" slots="text" />
 
-Adobe Commerce as a Cloud Service does not support REST endpoints that modify the cart on behalf of a customer or guest user. Use the GraphQL [`setCustomAttributesOnCart` mutation](../../graphql/schema/attributes/mutations/set-custom-cart.md) and the [`setCustomAttributesOnCartItem mutation](../../graphql/schema/attributes/mutations/set-custom-cart-item.md) instead for these types of users. Admin users can use the REST endpoints to set custom attributes on the cart and cart items.
+Adobe Commerce as a Cloud Service does not support REST endpoints that modify the cart on behalf of a customer or guest user. Use the GraphQL [`setCustomAttributesOnCart` mutation](../../graphql/schema/attributes/mutations/set-custom-cart.md) and the [`setCustomAttributesOnCartItem` mutation](../../graphql/schema/attributes/mutations/set-custom-cart-item.md) instead for these types of users. Admin users can use the REST endpoints to set custom attributes on the cart and cart items.
 
 When the quote is converted to an order, the custom attributes are copied to the order.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a display error caused by not providing a closing backtick around a mutation name.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
