### PR TITLE
Move Services queries back to webapi

### DIFF
--- a/src/_includes/graphql/catalog-service/categories.md
+++ b/src/_includes/graphql/catalog-service/categories.md
@@ -1,0 +1,33 @@
+The categories query returns the `CategoryView` object, which implements `CategoryViewInterface`.
+
+### CategoryView type
+
+Field | Data Type | Description
+--- | --- | ---
+`availableSortBy` | [String] | Lists the available sorting methods. Maps to Display Settings > Available Product Listing Sort By.
+`children` | [String!] | A list of subcategories within the category.
+`defaultSortBy` | String | The default sorting method. Maps to Display Settings > Default Product List Sort By.
+`id` | ID! | The category ID.
+`level` | Int | Indicates the depth of the category within the tree.
+`name` | String | The category display name.
+`parentId` | String! | ID of the parent category.
+`path` | String | The path to the category, as a string of category IDs, separated by slashes (/). For example, 1/2/20
+`roles` | [String!]! | A comma-separated list of keywords that are visible only to search engines.
+`urlKey` | String | The part of the URL that identifies the category.
+`urlPath` | String | The URL path for the category.
+
+### CategoryViewInterface attributes
+
+The `CategoryViewInterface`  returns information about the CategoryView
+
+Field | Data Type | Description
+--- | --- | ---
+`availableSortBy` | String | Lists the available sorting methods. Maps to Display Settings > Available Product Listing Sort By.
+`defaultSortBy` | String | The default sorting method. Maps to Display Settings > Default Product List Sort By.
+`id` | ID! | The category ID.
+`level` | Int | Indicates the depth of the category within the tree.
+`name` | String | The category display name.
+`path` | String | The path to the category, as a string of category IDs, separated by slashes (/). For example, 1/2/20
+`roles` | [String!]! | A comma-separated list of keywords that are visible only to search engines.
+`urlKey` | String | The part of the URL that identifies the category.
+`urlPath` | String | The URL path for the category.

--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -1,0 +1,8 @@
+Header | Description
+--- | ---
+`Magento-Customer-Group` | Specify the [customer group code](#find-the-customer-group-code) for the API request.
+`Magento-Environment-Id` | This value is displayed at **System** > **Commerce Services Connector** > **SaaS Identifier** > **Data Space ID** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
+`Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
+`Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.
+`Magento-Website-Code`| The code assigned to the website associated with the active store view. For example, `base`.
+`X-Api-Key` | Set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -1,0 +1,253 @@
+The `ProductView` return object is an interface that can contain the following fields. It is implemented by the [`SimpleProductView`](#simpleproductview-type) and [`ComplexProductView`](#complexproductview-type) types.
+
+Field | Data Type | Description
+--- | --- | ---
+`addToCartAllowed` | Boolean | Indicates whether the product can be added to the cart.
+`attributes(roles: [String])` | [`[ProductViewAttribute]`](#productviewattribute-type) | A list of merchant-defined attributes designated for the storefront.
+`description` | String | The detailed description of the product.
+`externalId`| String | The external ID of the product.
+`id` | ID! | The product ID, generated as a composite key, unique per locale.
+`images(roles: [String])` | [`[ProductViewImage]`](#productviewimage-type`) | A list of images defined for the product.
+`inputOptions` | [`[ProductViewInputOption]`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
+`inStock` | Boolean | Indicates whether the product is in stock.
+`lastModifiedAt` | DateTime | Date and time when the product was last updated.
+`links(linkTypes: [String!])` | [`[ProductViewLink]`](#productviewlink-type) | A list of product links.
+`lowStock` | Boolean | Indicates whether the product stock is low.
+`metaDescription` | String | A brief overview of the product for search results listings.
+`metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.
+`metaTitle` | String | A string that is displayed in the title bar and tab of the browser and in search results lists.
+`name` | String | Product name.
+`shortDescription` | String | A summary of the product.
+`sku` | String | Product SKU.
+`url` | String | Canonical URL of the product.
+`urlKey` | String | URL key of the product.
+
+### ComplexProductView type
+
+The `ComplexProductView` type represents bundle, configurable, and group products. Complex product prices are returned as a price range, because price values can vary based on selected options. The type implements `ProductView`.
+
+Field | Data Type | Description
+--- | --- | ---
+`addToCartAllowed` | Boolean | Indicates whether the product can be added to the cart.
+`attributes(roles: [String])` | [`[ProductViewAttribute]`](#productviewattribute-type) | A list of merchant-defined attributes designated for the storefront.
+`description` | String | The detailed description of the product.
+`externalId`| String | The external ID of the product.
+`id` | ID! | The product ID, generated as a composite key, unique per locale.
+`images(roles: [String])` | [`[ProductViewImage]`](#productviewimage-type) | A list of images defined for the product.
+`inputOptions` | [`[ProductViewInputOption]`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
+`inStock` | Boolean | Indicates whether the product is in stock.
+`links(linkTypes: [String!])` | [`[ProductViewLink]`](#productviewlink-type) | A list of product links.
+`lowStock` | Boolean | Indicates whether the product stock is low.
+`metaDescription` | String | A brief overview of the product for search results listings.
+`metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.
+`metaTitle` | String | A string that is displayed in the title bar and tab of the browser and in search results lists.
+`name` | String | Product name.
+`options` | [`[ProductViewOption]`](#productviewoption-type) | A list of selectable options.
+`priceRange` | [`ProductViewPriceRange`](#productviewpricerange-type) | A range of possible prices for a complex product.
+`shortDescription` | String | A summary of the product.
+`sku` | String | Product SKU.
+`url` | String | Canonical URL of the product.
+`urlKey` | String | URL key of the product.
+`videos` | `[ProductViewVideo]`(#productviewvideo-type) | A list of videos linked to the product.
+
+### Price type
+
+The `Price type` defines the price of a simple product or a part of a price range for a complex product. It can include a list of price adjustments.
+
+Field | Data Type | Description
+--- | --- | ---
+`adjustments` | [`[PriceAdjustment]`](#priceadjustment-type) | A list of price adjustments.
+`amount` | [`ProductViewMoney`](#productviewmoney-type) | Contains the monetary value and currency code of a product.
+
+### PriceAdjustment type
+
+The `PriceAdjustment` type specifies the amount and type of a price adjustment. An example code value is `weee`.
+
+Field | Data Type | Description
+--- | --- | ---
+`amount` | Float | The amount of the price adjustment.
+`code` | String | Identifies the type of price adjustment.
+
+### ProductViewAttribute type
+
+The `ProductViewAttribute` type is a container for customer-defined attributes that are displayed the storefront.
+
+Field | Data Type | Description
+--- | --- | ---
+`label` | String | Label of the attribute.
+`name` | String! | Name of an attribute code.
+`roles` | [String] | Roles designated for an attribute on the storefront, such as "Show on PLP", "Show in PDP", or "Show in Search".
+`value` | JSON | Attribute value, arbitrary of type.
+
+### ProductViewImage type
+
+The `ProductViewImage` type contains details about a product image.
+
+Field | Data Type | Description
+--- | --- | ---
+`label` | String | The display label of the product image.
+`roles` | [String] | A list that describes how the image is used. Can be `image`, `small_image`, or `thumbnail`.
+`url` | String! | The URL to the product image.
+
+### ProductViewLink type
+
+The `ProductViewLink` type contains details about product links for related products and cross selling.
+
+Field | Data Type | Description
+--- | --- | ---
+`linkTypes` | [String!]! | Types of links for this product. Can be `crosssell`, `related`, and `upsell`.
+`product` | `ProductView!` | Details about the product in the link.
+
+### ProductViewMoney type
+
+The `ProductViewMoney` type defines a monetary value, including a numeric value and a currency code.
+
+Field | Data Type | Description
+--- | --- | ---
+`currency` | ProductViewCurrency | A three-letter currency code, such as USD or EUR.
+`value` | Float | A number expressing a monetary value.
+
+### ProductViewInputOption type
+
+Product input options provide details about how a shopper can enter customization details for a product. For example, for product personalization the input options might provide the fields for the shopper to add an image or text for a monogram. The input option can include an associated `markupAmount` that is applied to the product price. For additional information, see [Product settings - Customizable Options](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/settings/settings-advanced-custom-options).
+
+Field | Data Type | Description
+-- | -- | --
+`fileExtensions` | String | A comma separated list of accepted file types for the input option if it has an associated file, for example `png, jpg`.
+`id` | ID | The ID of the option value.
+`imageSize` | [`ProductViewInputOptionImageSize`](#productviewimagesize-type) | Dimensions of an image associated with the input option.
+`markupAmount` | Float | Amount to add or subtract from the product price when the option is configured.
+`range` |[`ProductViewInputOptionRange`](#productviewinputoptionrange-type)| Value limits associated with an input option, for example allowed characters or file size.
+`required` | Boolean | Indicates whether the option must be supplied.
+`sortOrder` | Int | Indicates the order in which the option is displayed if multiple input options are configured.
+`suffix` | String | SKU suffix added to the customized product.
+`title` | String | The display name of the option value.
+`type` | String | The type of control for entering the input option, for example `textfield`, `textarea`, `date`, `date_time`, `time`, `file`.
+
+### ProductViewInputOptionRange type
+
+Lists the value range associated with a `[ProductViewInputOption]`. For example, if the input option is a text field, the range represents the number of characters.
+
+Field | Data Type | Description
+-- | -- | --
+`from` | Float | Minimum value accepted for the option input.
+`to` | Float | Maximum value accepted for the option input.
+
+### ProductViewInputOptionImageSize type
+
+Lists the image dimensions for an image associated with a `[ProductViewInputOption]`.
+
+Field | Data Type | Description
+-- | -- | --
+`height` | Int | Height of image provided for an input option.
+`width` |  Int | Width of image provided for an input option.
+
+### ProductViewOption type
+
+Product options provide a way to configure products by making selections of particular option values predefined for the product. Selecting one or many options points to a specific simple product.
+
+Field | Data Type | Description
+--- | --- | ---
+`id` | ID | The ID of the option.
+`multi` | Boolean | Indicates whether the option allows multiple choices.
+`required` | Boolean | Indicates whether the option must be selected.
+`title` | String | The display name of the option.
+`values` | [`[ProductViewOptionValue!]`](#productviewoptionvalue-Interface) | List of available option values.
+
+### ProductViewOptionValue interface
+
+The `ProductViewOptionValue` interface defines the product fields available to the `ProductViewOptionValueProduct` and `ProductViewOptionValueConfiguration` types.
+
+Field | Data Type | Description
+--- | --- | ---
+`id` | ID | The ID of an option value.
+`inStock` | Boolean | Indicates if the option is in stock.
+`title` | String | The display name of the option value.
+
+### ProductViewOptionValueConfiguration type
+
+The `ProductViewOptionValueConfiguration` type is an implementation of `ProductViewOptionValue` for configuration values.
+
+Field | Data Type | Description
+--- | --- | ---
+`id` | ID | The ID of an option value.
+`inStock` | Boolean | Indicates if the option is in stock.
+`title` | String | The display name of the option value.
+
+### ProductViewOptionValueProduct type
+
+The `ProductViewOptionValueProduct` type is an implementation of `ProductViewOptionValue` that adds details about a simple product.
+
+Field | Data Type | Description
+--- | --- | ---
+`id` | ID | The ID of an option value.
+`inStock` | Boolean | Indicates if the option is in stock.
+`isDefault` | Boolean | Indicates whether the option is the default.
+`product` | [`SimpleProductView`](#simpleproductview-type) | Details about a simple product.
+`quantity` | [`SimpleProductView`](#simpleproductview-type) | Default quantity of an option value.
+`title` | String | The display name of the option value.
+
+### ProductViewOptionValueSwatch type
+
+The `ProductViewOptionValueSwatch` type is an implementation of `ProductViewOptionValue` that adds details about a product swatch.
+
+Field | Data Type | Description
+--- | --- | ---
+`id` | ID | The ID of an option value.
+`inStock` | Boolean | Indicates if the option is in stock.
+`title` | String | The display name of the option value.
+`type` | SwatchType | Indicates the type of swatch. Can be `TEXT`, `IMAGE`, `COLOR_HEX`, or `CUSTOM`.
+`value` | String | The value of the swatch.
+
+### ProductViewPrice type
+
+The `ProductViewPrice` type provides the base product price view, inherent for simple products.
+
+Field | Data Type | Description
+--- | --- | ---
+`final` | Price | Price value after discounts, excluding personalized promotions.
+`regular` | Price | Base product price specified by the merchant.
+`roles` | [String] | Determines if the price should be visible or hidden.
+
+### ProductViewPriceRange type
+
+The `ProductViewPriceRange` type lists the minimum and maximum price of a complex product.
+
+Field | Data Type | Description
+--- | --- | ---
+`maximum` | ProductViewPrice | Maximum price.
+`minimum` | ProductViewPrice | Minimum price.
+
+### ProductViewVideo type
+
+Field | Data Type | Description
+--- | --- | ---
+`url` | String | The URL to link to the product video.
+`description` | String | Description of the product video.
+`title` | String | Title of the product video.
+
+### SimpleProductView type
+
+The `SimpleProductView` type represents all product types, except bundle, configurable, and group. Simple product prices do not contain price ranges. `SimpleProductView` implements `ProductView`.
+
+Field | Data Type | Description
+--- | --- | ---
+`addToCartAllowed` | Boolean | Indicates whether the product can be added to the cart.
+`attributes(roles: [String])` | [`[ProductViewAttribute]`](#productviewattribute-type) | A list of merchant-defined attributes designated for the storefront.
+`description` | String | The detailed description of the product.
+`externalId`| String | The external ID of the product.
+`id` | ID! | The product ID, generated as a composite key, unique per locale.
+`images(roles: [String])` | [`[ProductViewImage]`](#productviewimage-type) | A list of images defined for the product.
+`inputOptions` | [`[ProductViewInputOption]`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
+`inStock` | Boolean | Indicates whether the product is in stock.
+`links(linkTypes: [String!])` | [`[ProductViewLink]`](#productviewlink-type) | A list of product links.
+`lowStock` | Boolean | Indicates whether the product stock is low.
+`metaDescription` | String | A brief overview of the product for search results listings.
+`metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.
+`metaTitle` | String | A string that is displayed in the title bar and tab of the browser and in search results lists.
+`name` | String | Product name.
+`price` | [`ProductViewPrice`](#productviewprice-type) | Base product price view.
+`shortDescription` | String | A summary of the product.
+`sku` | String | Product SKU.
+`url` | String | Canonical URL of the product.
+`urlKey` | String | URL key of the product.

--- a/src/_includes/graphql/catalog-service/product-view.md
+++ b/src/_includes/graphql/catalog-service/product-view.md
@@ -11,7 +11,7 @@ Field | Data Type | Description
 `inputOptions` | [`[ProductViewInputOption]`](#productviewinputoption-type) | A list of input options the shopper can supply to customize a product.
 `inStock` | Boolean | Indicates whether the product is in stock.
 `lastModifiedAt` | DateTime | Date and time when the product was last updated.
-`links(linkTypes: [String!])` | [`[ProductViewLink]`](#productviewlink-type) | A list of product links.
+`links(linkTypes: [String!])` | [`[ProductViewLink]`](#productviewlink-type) | A list of related, corss-sell, or up-sell products.
 `lowStock` | Boolean | Indicates whether the product stock is low.
 `metaDescription` | String | A brief overview of the product for search results listings.
 `metaKeyword` | String | A comma-separated list of keywords that are visible only to search engines.

--- a/src/_includes/graphql/customer-group-code.md
+++ b/src/_includes/graphql/customer-group-code.md
@@ -1,0 +1,18 @@
+The customer group code is the encrypted value of the customer group ID, which determines discounts and tax class for pricing contexts. For B2B implementations, the customer group ID also determines the Shared Catalog context.
+
+Use one of the following codes for a default customer group based on your requirements.
+
+Customer Group | Code
+---------------| -----------------
+**NOT LOGGED IN** | `b6589fc6ab0dc82cf12099d1c2d40ab994e8410c`
+**General** | `356a192b7913b04c54574d18c28d46e6395428ab`
+**Wholesale** | `da4b9237bacccdf19c0760cab7aec4a8359010b0`
+**Retailer** |`77de68daecd823babbb58edb1c8e14d7106e83bb`
+
+For merchant-defined groups, the customer group code is the encrypted value of the ID, `sha1(<customer_group_id>)`.
+
+For B2B implementations, the customer group code is the encrypted value of the customer group ID associated with the shared catalog, `sha1(<customer_group_id>)`.
+
+<InlineAlert variant="info" slots="text"/>
+
+Find a list of available customer group IDs from the Admin (**Customers** > **Customer Groups**). For details, see [Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and [Shared Catalogs](https://experienceleague.adobe.com/en/docs/commerce-admin/b2b/shared-catalogs/catalog-shared) in the _Merchant Guide_.

--- a/src/_includes/graphql/endpoints.md
+++ b/src/_includes/graphql/endpoints.md
@@ -1,0 +1,23 @@
+&#8203;<Edition name="paas" />
+
+| Environment | Endpoint    |
+|------------ | ----------: |
+| **Testing**    | `https://catalog-service-sandbox.adobe.io/graphql` |
+| **Production** | `https://catalog-service.adobe.io/graphql` |
+
+&#8203;<Edition name="saas" />
+
+|  Environment | Endpoint |
+| ------------ | --------:|
+| Testing | `https://na1-sandbox.api.commerce.adobe.com/{{tenant-id}}/graphql` |
+| Production (Not available yet) | `https://na1.api.commerce.adobe.com/{{tenant-id}}/graphql` |
+
+**URL structure for SaaS endpoints**
+
+```text
+https://<region>-<environment>.api.commerce.adobe.com/<tenantId>/graphql
+```
+
+- `<region>` is the cloud region where your instance is deployed.
+- `<environment>` is the environment type, such as `sandbox`. If the environment is production, this value is omitted.
+- `<tenantId>` is the unique identifier for your organization's specific instance within the Adobe Experience Cloud.

--- a/src/_includes/graphql/live-search-headers.md
+++ b/src/_includes/graphql/live-search-headers.md
@@ -1,0 +1,7 @@
+Header name| Description
+--- | ---
+`Magento-Environment-Id` | This value is displayed at **Stores** > **Configuration** > **Services** > **Magento Services** > **SaaS Environment** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
+`Magento-Store-Code` | The code assigned to the store associated with the active store view. For example, `main_website_store`.
+`Magento-Store-View-Code` | The code assigned to the active store view. For example, `default`.
+`Magento-Website-Code` | The code assigned to the website associated with the active store view. For example, `base`.
+`X-Api-Key` | This value must be set to `search_gql`.

--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -317,7 +317,35 @@ module.exports = [
       },
       {
         title: "Catalog Service",
-        path: "https://developer.adobe.com/commerce/services/graphql/catalog-service/"
+        path: "/graphql/schema/catalog-service/",
+        pages:[
+          {
+            title: "Queries",
+            path: "/graphql/schema/catalog-service/queries/",
+            pages: [
+              {
+                title: "categories",
+                path: "/graphql/schema/catalog-service/queries/categories.md",
+              },
+              {
+                title: "products",
+                path: "/graphql/schema/catalog-service/queries/products.md"
+              },
+              {
+                title: "productSearch",
+                path: "/graphql/schema/live-search/queries/product-search.md",
+              },
+              {
+                title: "refineProduct",
+                path: "/graphql/schema/catalog-service/queries/refine-product.md"
+              },
+              {
+                title: "variants",
+                path: "/graphql/schema/catalog-service/queries/product-variants.md"
+              }
+            ],
+          },
+        ],
       },
       {
         title: "Checkout",
@@ -683,7 +711,23 @@ module.exports = [
       },
       {
         title: "Live Search",
-        path: "https://developer.adobe.com/commerce/services/graphql/live-search/"
+        path: "/graphql/schema/live-search",
+        pages: [
+          {
+            title: "Queries",
+            path: "/graphql/schema/live-search/queries/",
+            pages: [
+              {
+                title: "attributeMetadata",
+                path: "/graphql/schema/live-search/queries/attribute-metadata/",
+              },
+              {
+                title: "productSearch",
+                path: "/graphql/schema/live-search/queries/product-search/",
+              }
+            ],
+          }
+        ]
       },
       {
         title: "Negotiable quotes (B2B)",
@@ -853,7 +897,19 @@ module.exports = [
       },
       {
         title: "Product Recommendations",
-        path: "https://developer.adobe.com/commerce/services/graphql/recommendations/recommendations/"
+        path: "/graphql/schema/product-recommendations/",
+        pages: [
+          {
+            title: "Queries",
+            path: "/graphql/schema/product-recommendations/queries/",
+            pages: [
+              {
+                title: "recommendations",
+                path: "/graphql/schema/product-recommendations/queries/recommendations/",
+              }
+            ]
+          },
+        ]
       },
       {
         title: "Products",

--- a/src/pages/graphql/index.md
+++ b/src/pages/graphql/index.md
@@ -19,10 +19,6 @@ The following image shows a sample query, its response, and the GraphQL browser:
 
 ![GraphiQL browser](../_images/graphql/graphql-browser.png)
 
-<InlineAlert variant="info" slots="text" />
-
-The Catalog Service, Live Search, and Product Recommendations services have schemas that are independent from the core schema for Adobe Commerce and Magento Open Source. You can find the schema reference documentation and examples for these services in [Storefront Services GraphQL](https://developer.adobe.com/commerce/services/graphql/).
-
 ## Commerce API playground
 
 The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) enables you to run selected queries against a live instance of Adobe Commerce with Luma sample data. The playground includes example core and Storefront Services queries. You can customize the output of the queries to help you understand the power of our GraphQL APIs.

--- a/src/pages/graphql/schema/catalog-service/index.md
+++ b/src/pages/graphql/schema/catalog-service/index.md
@@ -1,0 +1,15 @@
+---
+title: Catalog Service for Adobe Commerce
+description: Learn how Catalog Service implements GraphQL.
+keywords:
+  - GraphQL
+  - Services
+---
+
+# Catalog Service for Adobe Commerce
+
+The Catalog Service for Adobe Commerce extension contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the [core GraphQL schema](../index.md). The queries in this schema allow Commerce merchants to quickly and fully render product-related content on the storefront, including product detail pages and product list pages.
+
+You can optionally implement [API Mesh for Adobe Developer App Builder](https://developer.adobe.com/graphql-mesh-gateway/) to integrate the two Adobe Commerce GraphQL systems with private and third-party APIs and other software interfaces using Adobe Developer. The mesh can be configured to ensure calls routed to each endpoint contain the correct authorization information in the headers.
+
+The [Catalog Service Guide](https://experienceleague.adobe.com/docs/commerce-merchant-services/catalog-service/overview.html) describes the architecture and implementation of this product.

--- a/src/pages/graphql/schema/catalog-service/index.md
+++ b/src/pages/graphql/schema/catalog-service/index.md
@@ -10,6 +10,6 @@ keywords:
 
 The Catalog Service for Adobe Commerce extension contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the [core GraphQL schema](../index.md). The queries in this schema allow Commerce merchants to quickly and fully render product-related content on the storefront, including product detail pages and product list pages.
 
-You can optionally implement [API Mesh for Adobe Developer App Builder](https://developer.adobe.com/graphql-mesh-gateway/) to integrate the two Adobe Commerce GraphQL systems with private and third-party APIs and other software interfaces using Adobe Developer. The mesh can be configured to ensure calls routed to each endpoint contain the correct authorization information in the headers.
+You can optionally implement [API Mesh for Adobe Developer App Builder](https://developer.adobe.com/graphql-mesh-gateway/) to integrate the core and Catalog Service GraphQL schemas with private and third-party APIs, as well as other software interfaces. The mesh can be configured to ensure that calls routed to each endpoint contain the correct authorization information in the headers.
 
 The [Catalog Service Guide](https://experienceleague.adobe.com/docs/commerce-merchant-services/catalog-service/overview.html) describes the architecture and implementation of this product.

--- a/src/pages/graphql/schema/catalog-service/queries/categories.md
+++ b/src/pages/graphql/schema/catalog-service/queries/categories.md
@@ -1,0 +1,216 @@
+---
+title: categories query | GraphQL Developer Guide
+description: Describes how to construct and use the Catalog Service categories query.
+keywords:
+  - GraphQL
+  - Services
+---
+
+# categories query
+
+The `categories` query returns category data. If the `subtree` input object is specified, the query returns details about subcategories.
+
+## Syntax
+
+```graphql
+type Query {
+  categories(ids: [String!], roles: [String!], subtree: Subtree): [CategoryView]
+}
+```
+
+Where `subtree` is:
+
+```graphql
+input Subtree {
+    startLevel: Int!,
+    depth: Int!
+}
+```
+
+If using the `subtree` input, only one category `id` can be specified in the query.
+The `subtree` object allows you to specify how many levels of subcategories to return. Some sites may have a high number of subcategories, and returning the entire category tree could cause performance issues. It is recommended to keep `depth` to a maximum of 3 for the same reason.
+
+## Endpoints
+
+import StorefrontAPIEndpoints from '/src/_includes/graphql/endpoints.md'
+
+<StorefrontAPIEndpoints />
+
+## Required headers
+
+Specify the following HTTP headers to run this query.
+
+import Headers from '/src/_includes/graphql/catalog-service/headers.md'
+
+<Headers />
+
+###  Find the customer group code
+
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroupCode />
+
+## Example usage
+
+The following query returns a category tree.
+
+<CodeBlock slots="heading, code" repeat="2" languages="JSON" />
+
+**Request:**
+
+```graphql
+categories(ids: ["11"], roles: ["show_in_menu", "active"], subtree: {
+    "depth": 3,
+    "startLevel": 1
+}) {
+    name
+    id
+    level
+    roles
+    path
+    urlPath
+    urlKey
+    parentId
+    children
+    }
+```
+
+**Response:**
+
+```json
+[
+   {
+      "name":"Bottoms",
+      "id":"13",
+      "level":3,
+      "roles":[
+         "active",
+         "show_in_menu"
+      ],
+      "path":"1/2/11/13",
+      "urlPath":"men/bottoms-men",
+      "urlKey":"bottoms-men",
+      "parentId":"11",
+      "children":[
+         "18",
+         "19"
+      ]
+   },
+   {
+      "name":"Tops",
+      "id":"12",
+      "level":3,
+      "roles":[
+         "active",
+         "show_in_menu"
+      ],
+      "path":"1/2/11/12",
+      "urlPath":"men/tops-men",
+      "urlKey":"tops-men",
+      "parentId":"11",
+      "children":[
+         "14",
+         "15",
+         "16",
+         "17"
+      ]
+   },
+   {
+      "name":"Jackets",
+      "id":"14",
+      "level":4,
+      "roles":[
+         "active",
+         "show_in_menu"
+      ],
+      "path":"1/2/11/12/14",
+      "urlPath":"men/tops-men/jackets-men",
+      "urlKey":"jackets-men",
+      "parentId":"12",
+      "children":[
+      ]
+   },
+   {
+      "name":"Pants",
+      "id":"18",
+      "level":4,
+      "roles":[
+         "active",
+         "show_in_menu"
+      ],
+      "path":"1/2/11/13/18",
+      "urlPath":"men/bottoms-men/pants-men",
+      "urlKey":"pants-men",
+      "parentId":"13",
+      "children":[
+      ]
+   },
+   {
+      "name":"Tanks",
+      "id":"17",
+      "level":4,
+      "roles":[
+         "active",
+         "show_in_menu"
+      ],
+      "path":"1/2/11/12/17",
+      "urlPath":"men/tops-men/tanks-men",
+      "urlKey":"tanks-men",
+      "parentId":"12",
+      "children":[
+      ]
+   },
+   {
+      "name":"Hoodies & Sweatshirts",
+      "id":"15",
+      "level":4,
+      "roles":[
+         "active",
+         "show_in_menu"
+      ],
+      "path":"1/2/11/12/15",
+      "urlPath":"men/tops-men/hoodies-and-sweatshirts-men",
+      "urlKey":"hoodies-and-sweatshirts-men",
+      "parentId":"12",
+      "children":[
+      ]
+   },
+   {
+      "name":"Shorts",
+      "id":"19",
+      "level":4,
+      "roles":[
+         "active",
+         "show_in_menu"
+      ],
+      "path":"1/2/11/13/19",
+      "urlPath":"men/bottoms-men/shorts-men",
+      "urlKey":"shorts-men",
+      "parentId":"13",
+      "children":[
+
+      ]
+   }
+]
+```
+
+## Input fields
+
+Field | Data type | Description
+--- | --- | ---
+`ids` | [String!] | Array of category IDs to return. If using `subtree`, must contain only one ID.
+`roles` | [String!]! |  The list of category roles to be queried.
+`subtree` | [[subtree](#subtree-input)] | Defines how many subcategories to return.
+
+### subtree input
+
+Field | Data type | Description
+--- | --- | ---
+`startLevel` | [Int!] |The level in the category tree where the search should begin. Minimum of 1.
+`depth` | [Int!]! |  The number of subtrees to return. Values over 3 may impact performance.
+
+## Output fields
+
+import Output from '/src/_includes/graphql/catalog-service/categories.md'
+
+<Output />

--- a/src/pages/graphql/schema/catalog-service/queries/categories.md
+++ b/src/pages/graphql/schema/catalog-service/queries/categories.md
@@ -200,7 +200,7 @@ Field | Data type | Description
 --- | --- | ---
 `ids` | [String!] | Array of category IDs to return. If using `subtree`, must contain only one ID.
 `roles` | [String!]! |  The list of category roles to be queried.
-`subtree` | [[subtree](#subtree-input)] | Defines how many subcategories to return.
+`subtree` | [[subtree](#subtree-input)] | Defines the number of sub-levels of categories to return.
 
 ### subtree input
 

--- a/src/pages/graphql/schema/catalog-service/queries/index.md
+++ b/src/pages/graphql/schema/catalog-service/queries/index.md
@@ -1,0 +1,18 @@
+---
+title: Catalog Service queries
+description: Learn how Catalog Service implements GraphQL.
+keywords:
+  - GraphQL
+  - Services
+---
+
+# Catalog Service queries
+
+Catalog Service provides the following queries:
+
+*  [`categories`](categories.md)
+*  [`products`](products.md)
+*  [`refineProduct`](refine-product.md)
+*  [`variants`](product-variants.md)
+
+It also extends the Live Search [`productSearch`](../live-search/product-search.md#catalog-service) query to return product view data.

--- a/src/pages/graphql/schema/catalog-service/queries/index.md
+++ b/src/pages/graphql/schema/catalog-service/queries/index.md
@@ -15,4 +15,4 @@ Catalog Service provides the following queries:
 *  [`refineProduct`](refine-product.md)
 *  [`variants`](product-variants.md)
 
-It also extends the Live Search [`productSearch`](../live-search/product-search.md#catalog-service) query to return product view data.
+It also extends the Live Search [`productSearch`](../../live-search/queries/product-search.md#catalog-service) query to return product view data.

--- a/src/pages/graphql/schema/catalog-service/queries/product-variants.md
+++ b/src/pages/graphql/schema/catalog-service/queries/product-variants.md
@@ -475,7 +475,7 @@ query {
 
 ## Return variants by `optionId`
 
-This query returns the SKU, name, and images for all size large variants of product MH07. The `optionIDs` input parameter value is sourced from the [Return details about a complex product](products.md#return-details-about-a-complex-product) example in the products query.
+This query returns the SKU, name, and images for all size large variants of product MH07. The `optionIDs` input parameter value is sourced from the [Return details about a complex product](products.md#return-details-about-a-complex-product) example in the products query. The `optionIDs` parameter can be specified as a single string, or an array if you supply multiple values.
 
 <CodeBlock slots="heading, code" repeat="2" languages="JSON, CURL, JSON" />
 
@@ -606,7 +606,7 @@ You must specify a SKU value for the query.
 
 Field | Data type | Description
 --- | --- | ---
-`cursor` | String | Manages pagination of variant results. Include the `cursor` value returned in the results from a previous `variants` query to fetch the next set of results. See [Return results by cursor position](#return-results-by-cursor-position).(#return-results-by-cursor-position).(#return-results-by-cursor-position) example.
+`cursor` | String | Manages pagination of variant results. Include the `cursor` value returned in the results from a previous `variants` query to fetch the next set of results. See [Return results by cursor position](#return-results-by-cursor-position) example.
 `optionIds` | [String!] | A list of IDs assigned to the product options the shopper has selected, such as specific colors and sizes.
 `pageSize` | Int | Specifies the maximum number of results to return. Default: 100.
 `sku` | String! |  The SKU of a complex product.

--- a/src/pages/graphql/schema/catalog-service/queries/product-variants.md
+++ b/src/pages/graphql/schema/catalog-service/queries/product-variants.md
@@ -1,0 +1,634 @@
+---
+title: variants query
+description: "Describes how to construct and use the Catalog Service `variants` query to retrieve details about the variants available for a product."
+keywords:
+  - GraphQL
+  - Services
+---
+
+# variants query
+
+The `variants` query returns details about all variations of a product.
+
+The `variants` query is useful for showing variant images on product detail (PDP) or product listing (PLP) pages without submitting multiple API requests.
+
+Query results are paginated with a default, maximum pagination size of 100. The query supports [cursor-based pagination](https://graphql.org/learn/pagination/#pagination-and-edges) as follows:
+
+- The initial query returns a cursor value marking the last item in the current page.
+- If all results are returned, the `cursor` value is `null`.
+- If more results are available, use the `cursor` value returned in subsequent queries to fetch additional results. For an example, see [Paginate product variant results](#return-all-variants-using-pagination).
+
+## Syntax
+
+```graphql
+variants(sku: String!, optionIds: [String!], pageSize: Int, cursor: String): ProductViewVariantResults
+```
+
+## Endpoints
+
+import StorefrontAPIEndpoints from '/src/_includes/graphql/endpoints.md'
+
+<StorefrontAPIEndpoints />
+
+## Required headers
+
+You must specify the following HTTP headers to run this query.
+
+import Docs from '/src/_includes/graphql/catalog-service/headers.md'
+
+<Docs />
+
+###  Find the customer group code
+
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroupCode />
+
+## Example usage
+
+The `variants` query requires at least one SKU value as input. Optionally, you can specify `optionIDs` and pagination controls. Specify `optionIDs` to retrieve variants based on product options such as size or color. See [Input fields](#input-fields).
+
+## Return all variants using pagination
+
+The following query returns the SKU, name, and available image information for all variants of the MH07 product. Setting the query pagination to `10` fetches the first ten results.
+
+<CodeBlock slots="heading, code" repeat="2" languages="JSON" />
+
+**Request:**
+
+```graphql
+query {
+  variants(sku: "MH07", pageSize: 10) {
+    variants {
+      selections
+      product {
+        sku
+        name
+        images(roles: []) {
+          url
+          label
+          roles
+        }
+      }
+    }
+    cursor
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "variants": {
+      "variants": [
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzU4",
+            "Y29uZmlndXJhYmxlLzE4Ni8xODM="
+          ],
+          "product": {
+            "sku": "MH07-31-Black",
+            "name": "Hero Hoodie28-31-Black",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzU5",
+            "Y29uZmlndXJhYmxlLzE4Ni8xODM="
+          ],
+          "product": {
+            "sku": "MH07-31-Blue",
+            "name": "Hero Hoodie28-31-Blue",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzE4Ni8xODM=",
+            "Y29uZmlndXJhYmxlLzkzLzYx"
+          ],
+          "product": {
+            "sku": "MH07-31-Gray",
+            "name": "Hero Hoodie28-31-Gray",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzYy",
+            "Y29uZmlndXJhYmxlLzE4Ni8xODM="
+          ],
+          "product": {
+            "sku": "MH07-31-Green",
+            "name": "Hero Hoodie28-31-Green",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzU4",
+            "Y29uZmlndXJhYmxlLzE4Ni8xODY="
+          ],
+          "product": {
+            "sku": "MH07-34-Black",
+            "name": "Hero Hoodie28-34-Black",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzE4Ni8xODY=",
+            "Y29uZmlndXJhYmxlLzkzLzU5"
+          ],
+          "product": {
+            "sku": "MH07-34-Blue",
+            "name": "Hero Hoodie28-34-Blue",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzYx",
+            "Y29uZmlndXJhYmxlLzE4Ni8xODY="
+          ],
+          "product": {
+            "sku": "MH07-34-Gray",
+            "name": "Hero Hoodie28-34-Gray",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzE4Ni8xODY=",
+            "Y29uZmlndXJhYmxlLzkzLzYy"
+          ],
+          "product": {
+            "sku": "MH07-34-Green",
+            "name": "Hero Hoodie28-34-Green",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzU4",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzg="
+          ],
+          "product": {
+            "sku": "MH07-L-Black",
+            "name": "Hero Hoodie-L-Black",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-black_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzg=",
+            "Y29uZmlndXJhYmxlLzkzLzU5"
+          ],
+          "product": {
+            "sku": "MH07-L-Blue",
+            "name": "Hero Hoodie28-L-Blue",
+            "images": []
+          }
+        }
+      ],
+      "cursor": "TUgwNy1MLUJsdWU6Ojo6OjoxMA=="
+    }
+  }
+}
+```
+
+#### Return results by `cursor` position
+
+Using the cursor value from the previous response (`TUgwNy1MLUJsdWU6Ojo6OjoxMA==`) as input, run the same query to fetch the next set of results. When the last variant item is returned, the cursor value is `null`.
+
+<CodeBlock slots="heading, code" repeat="2" languages="JSON" />
+
+**Request:**
+
+```graphql
+query {
+  variants(sku: "MH07", pageSize: 10 cursor: "TUgwNy1MLUJsdWU6Ojo6OjoxMA==") {
+    variants {
+      selections
+      product {
+        sku
+        name
+        images(roles: []) {
+          url
+          label
+          roles
+        }
+      }
+    }
+    cursor
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "variants": {
+      "variants": [
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzYx",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzg="
+          ],
+          "product": {
+            "sku": "MH07-L-Gray",
+            "name": "Hero Hoodie-L-Gray",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              },
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_alt1_2.jpg",
+                "label": "",
+                "roles": []
+              },
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_back_2.jpg",
+                "label": "",
+                "roles": []
+              }
+            ]
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzYy",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzg="
+          ],
+          "product": {
+            "sku": "MH07-L-Green",
+            "name": "Hero Hoodie-L-Green",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-green_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzU4",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzc="
+          ],
+          "product": {
+            "sku": "MH07-M-Black",
+            "name": "Hero Hoodie-M-Black",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-black_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzU5",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzc="
+          ],
+          "product": {
+            "sku": "MH07-M-Blue",
+            "name": "Hero Hoodie28-M-Blue",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzYx",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzc="
+          ],
+          "product": {
+            "sku": "MH07-M-Gray",
+            "name": "Hero Hoodie-M-Gray",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              },
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_alt1_2.jpg",
+                "label": "",
+                "roles": []
+              },
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_back_2.jpg",
+                "label": "",
+                "roles": []
+              }
+            ]
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzYy",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzc="
+          ],
+          "product": {
+            "sku": "MH07-M-Green",
+            "name": "Hero Hoodie-M-Green",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-green_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzU4",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzY="
+          ],
+          "product": {
+            "sku": "MH07-S-Black",
+            "name": "Hero Hoodie-S-Black",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-black_main_1.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzU5",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzY="
+          ],
+          "product": {
+            "sku": "MH07-S-Blue",
+            "name": "Hero Hoodie28-S-Blue",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzYx",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzY=",
+            "Y29uZmlndXJhYmxlLzkzLzUwOA=="
+          ],
+          "product": {
+            "sku": "MH07-S-Gray",
+            "name": "Hero Hoodie-S-Gray",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              },
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_alt1_2.jpg",
+                "label": "",
+                "roles": []
+              },
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_back_2.jpg",
+                "label": "",
+                "roles": []
+              }
+            ]
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzY=",
+            "Y29uZmlndXJhYmxlLzkzLzYy"
+          ],
+          "product": {
+            "sku": "MH07-S-Green",
+            "name": "Hero Hoodie-S-Green",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-green_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "cursor": "TUgwNy1TLUdyZWVuOjo6Ojo6MTA="
+    }
+  }
+}
+```
+
+## Return variants by `optionId`
+
+This query returns the SKU, name, and images for all size large variants of product MH07. The `optionIDs` input parameter value is sourced from the [Return details about a complex product](products.md#return-details-about-a-complex-product) example in the products query.
+
+<CodeBlock slots="heading, code" repeat="2" languages="JSON, CURL, JSON" />
+
+**Request:**
+
+```graphql
+query {
+  variants(sku: "MH07", optionIds: "Y29uZmlndXJhYmxlLzE4Ni8xNzg=") {
+    variants {
+      selections
+      product {
+        sku
+        name
+        images(roles: []) {
+          url
+          label
+          roles
+        }
+      }
+    }
+    cursor
+  }
+}
+
+```
+
+**Response**
+
+```json
+{
+  "data": {
+    "variants": {
+      "variants": [
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzg=",
+            "Y29uZmlndXJhYmxlLzkzLzU4"
+          ],
+          "product": {
+            "sku": "MH07-L-Black",
+            "name": "Hero Hoodie-L-Black",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-black_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzg=",
+            "Y29uZmlndXJhYmxlLzkzLzU5"
+          ],
+          "product": {
+            "sku": "MH07-L-Blue",
+            "name": "Hero Hoodie28-L-Blue",
+            "images": []
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzg=",
+            "Y29uZmlndXJhYmxlLzkzLzYx"
+          ],
+          "product": {
+            "sku": "MH07-L-Gray",
+            "name": "Hero Hoodie-L-Gray",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              },
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_alt1_2.jpg",
+                "label": "",
+                "roles": []
+              },
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-gray_back_2.jpg",
+                "label": "",
+                "roles": []
+              }
+            ]
+          }
+        },
+        {
+          "selections": [
+            "Y29uZmlndXJhYmxlLzkzLzYy",
+            "Y29uZmlndXJhYmxlLzE4Ni8xNzg="
+          ],
+          "product": {
+            "sku": "MH07-L-Green",
+            "name": "Hero Hoodie-L-Green",
+            "images": [
+              {
+                "url": "http://example.com/media/catalog/product/m/h/mh07-green_main_2.jpg",
+                "label": "",
+                "roles": [
+                  "image",
+                  "small_image",
+                  "thumbnail"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "cursor": null
+    }
+  }
+}
+```
+
+## Input fields
+
+You must specify a SKU value for the query.
+
+Field | Data type | Description
+--- | --- | ---
+`cursor` | String | Manages pagination of variant results. Include the `cursor` value returned in the results from a previous `variants` query to fetch the next set of results. See [Return results by cursor position](#return-results-by-cursor-position).(#return-results-by-cursor-position).(#return-results-by-cursor-position) example.
+`optionIds` | [String!] | A list of IDs assigned to the product options the shopper has selected, such as specific colors and sizes.
+`pageSize` | Int | Specifies the maximum number of results to return. Default: 100.
+`sku` | String! |  The SKU of a complex product.
+
+## Output fields
+
+This query returns a `ProductViewVariantResults` object, which contains the `cursor` field and a list of `ProductViewVariant` objects, one for each variant associated with the product SKU.
+
+| Field     | Data Type          | Description                                 |
+|---------------|------------------------|-------------------------------------------------|
+| `cursor`      | `String`               | Returns the cursor for the last item in the current page of results. Use this cursor in the `variants` query to fetch the next set of results. If there are no more results, the cursor value is `null`. |
+| `variants`    | `[ProductViewVariant]!`| List of product variants. |
+
+### ProductViewVariant type
+
+| Field         | Data Type              | Description                                     |
+|---------------|------------------------|-------------------------------------------------|
+| `product`     | [`ProductView`](#productview-interface)  | Provides information about the returned variant. |
+| `selections`  | `[String!]`            | List of option id values that define the variant. For example, the id value for color and size options for a clothing product.|
+
+### ProductView interface
+
+import Docs2 from '/src/_includes/graphql/catalog-service/product-view.md'
+
+<Docs2 />

--- a/src/pages/graphql/schema/catalog-service/queries/products.md
+++ b/src/pages/graphql/schema/catalog-service/queries/products.md
@@ -18,7 +18,7 @@ The Catalog Service query requires one or more SKU values as input. The query is
 
 <InlineAlert variant="info" slots="text"/>
 
-Use the Live Search [`productSearch` query](../live-search/product-search.md) to return product listing page content.
+Use the Live Search [`productSearch` query](../../live-search/queries/product-search.md) to return product listing page content.
 
 The `ProductView` output object is significantly different than the core `products` query `Products` output object. Key differences include:
 

--- a/src/pages/graphql/schema/catalog-service/queries/products.md
+++ b/src/pages/graphql/schema/catalog-service/queries/products.md
@@ -36,7 +36,7 @@ The `ProductView` output object is significantly different than the core `produc
 ## Syntax
 
 ```graphql
-products (skus [String]) [ProductView]
+products(skus: [String]): [ProductView]
 ```
 
 ## Endpoints

--- a/src/pages/graphql/schema/catalog-service/queries/products.md
+++ b/src/pages/graphql/schema/catalog-service/queries/products.md
@@ -1,0 +1,847 @@
+---
+title: products query
+description: Describes how to construct and use the Catalog Service products query.
+keywords:
+  - GraphQL
+  - Services
+---
+
+# products query
+
+The Catalog Service for Adobe Commerce `products` query returns details about the SKUs specified as input. Although this query has the same name as the [`products` query](https://developer.adobe.com/commerce/webapi/graphql/schema/products/queries/products/) that is provided with core Adobe Commerce and Magento Open Source, there are some differences.
+
+The Catalog Service query requires one or more SKU values as input. The query is primarily designed to retrieve information to render the following types of content:
+
+*  Product detail pages - You can provide full details about the product identified by the specified SKU.
+
+*  Product compare pages - You can retrieve selected information about multiple products, such as the name, price and image.
+
+<InlineAlert variant="info" slots="text"/>
+
+Use the Live Search [`productSearch` query](../live-search/product-search.md) to return product listing page content.
+
+The `ProductView` output object is significantly different than the core `products` query `Products` output object. Key differences include:
+
+* Products are either simple or complex. Simple, virtual, downloadable, and gift card products map to `SimpleProductView`. All other product types map to `ComplexProductView`.
+
+  * Simple products have defined prices.
+  * Complex products have price ranges. Since complex products are comprised of multiple simple products, they have access to simple product prices.
+
+* Both simple and complex products can have merchant-defined input options that allow shoppers to customize a product by adding text, date, an image, or a file, for example adding text for engraving. These options can have an associated markup that is applied to the product price. These options are exposed in a top-level `inputOptions` container `[ProductViewInputOption]`.
+
+*  Merchant-defined attributes are exposed in a top-level `attributes` container `[ProductViewAttribute]` and indicate their storefront roles. Roles include Show on PDP, Show on PLP, and Show on Search Results.
+
+*  Images are also accessible as a top-level container and can be filtered by their role. An image can have an `image`, `small_image`, or `thumbnail` role.
+
+## Syntax
+
+```graphql
+products (skus [String]) [ProductView]
+```
+
+## Endpoints
+
+import StorefrontAPIEndpoints from '/src/_includes/graphql/endpoints.md'
+
+<StorefrontAPIEndpoints />
+
+## Required headers
+
+You must specify the following HTTP headers to run this query.
+
+import Docs from '/src/_includes/graphql/catalog-service/headers.md'
+
+<Docs />
+
+###  Find the customer group code
+
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroupCode />
+
+## Example usage
+
+The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) provides a sample `products` query that you can run against a live instance of Adobe Commerce with Luma sample data. Note that the responses may vary, depending on the configuration of the Commerce instance.
+
+### Return details about a simple product
+
+The following query returns details about a simple product.
+
+<CodeBlock slots="heading, code" repeat="2" languages="JSON" />
+
+**Request:**
+
+```graphql
+query {
+
+    products(skus: ["24-UG07"]) {
+        __typename
+        id
+        sku
+        name
+        description
+        shortDescription
+        addToCartAllowed
+        url
+        images(roles: []) {
+            url
+            label
+            roles
+        }
+        attributes(roles: []) {
+            name
+            label
+            value
+            roles
+        }
+        inputOptions {
+            id
+            title
+            required
+            type
+            markupAmount
+            suffix
+            sortOrder
+            range {
+                from
+                to
+            }
+            imageSize {
+                width
+                height
+            }
+            fileExtensions
+        }
+        ... on SimpleProductView {
+            price {
+                final {
+                    amount {
+                        value
+                        currency
+                    }
+                }
+                regular {
+                    amount {
+                        value
+                        currency
+                    }
+                }
+                roles
+            }
+        }
+        links {
+            product {
+                sku
+
+            }
+            linkTypes
+        }
+    }
+}
+```
+
+**Response:**
+
+```json
+{
+    "data": {
+        "products": [
+            {
+                "__typename": "SimpleProductView",
+                "id": "TWpRdFZVY3dOdwBaR1ZtWVhWc2RBAFlqVTFPRFEyTVdRdE4yWXhaaTAwTWpOaExXRTRabVV0TVRnd1pXRTVOV0V3TWpGaQBiV0ZwYmw5M1pXSnphWFJsWDNOMGIzSmwAWW1GelpRAFRVRkhVMVJITURBMU5UZ3dNakF3",
+                "sku": "24-UG07",
+                "name": "Dual Handle Cardio Ball",
+                "description": "<p>Make the most of your limited workout window with our Dual-Handle Cardio Ball. The 15-lb ball maximizes the effort-impact to your abdominal, upper arm and lower-body muscles. It features a handle on each side for a firm, secure grip.</p>\r\n<ul>\r\n<li>Durable plastic shell with sand fill.\r\n<li>Two handles.\r\n<li>15 lbs.\r\n</ul>",
+                "shortDescription": "",
+                "addToCartAllowed": true,
+                "url": "http://example.com/dual-handle-cardio-ball.html",
+                "images": [
+                    {
+                        "url": "http://example.com/media/catalog/product/u/g/ug07-bk-0.jpg",
+                        "label": "Image",
+                        "roles": [
+                            "image",
+                            "small_image",
+                            "thumbnail"
+                        ]
+                    },
+                    {
+                        "url": "http://example.com/media/catalog/product/u/g/ug07-bk-0_alt1.jpg",
+                        "label": "Image",
+                        "roles": []
+                    }
+                ],
+                "attributes": [
+                    {
+                        "name": "activity",
+                        "label": "Activity",
+                        "value": [
+                            "Athletic",
+                            "Sports",
+                            "Gym"
+                        ],
+                        "roles": [
+                            "visible_in_pdp",
+                            "visible_in_compare_list",
+                            "visible_in_search"
+                        ]
+                    },
+                    {
+                        "name": "category_gear",
+                        "label": "Category",
+                        "value": [
+                            "Cardio",
+                            "Exercise"
+                        ],
+                        "roles": [
+                            "visible_in_pdp",
+                            "visible_in_search"
+                        ]
+                    },
+                    {
+                        "name": "color",
+                        "label": "Color",
+                        "value": "Black",
+                        "roles": [
+                            "visible_in_pdp",
+                            "visible_in_plp"
+                        ]
+                    },
+                    {
+                        "name": "eco_collection",
+                        "label": "Eco Collection",
+                        "value": "no",
+                        "roles": [
+                            "visible_in_pdp"
+                        ]
+                    },
+                    {
+                        "name": "erin_recommends",
+                        "label": "Erin Recommends",
+                        "value": "yes",
+                        "roles": [
+                            "visible_in_pdp"
+                        ]
+                    },
+                    {
+                        "name": "gender",
+                        "label": "Gender",
+                        "value": [
+                            "Men",
+                            "Women",
+                            "Unisex"
+                        ],
+                        "roles": [
+                            "visible_in_pdp",
+                            "visible_in_search"
+                        ]
+                    },
+                    {
+                        "name": "material",
+                        "label": "Material",
+                        "value": "Plastic",
+                        "roles": [
+                            "visible_in_pdp",
+                            "visible_in_search"
+                        ]
+                    },
+                    {
+                        "name": "new",
+                        "label": "New",
+                        "value": "no",
+                        "roles": [
+                            "visible_in_pdp"
+                        ]
+                    },
+                    {
+                        "name": "performance_fabric",
+                        "label": "Performance Fabric",
+                        "value": "no",
+                        "roles": [
+                            "visible_in_pdp"
+                        ]
+                    },
+                    {
+                        "name": "sale",
+                        "label": "Sale",
+                        "value": "yes",
+                        "roles": [
+                            "visible_in_pdp"
+                        ]
+                    }
+                ],
+                "inputOptions": [
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8xOQ==",
+                        "title": "Customizable Option - area",
+                        "type": "area",
+                        "range": {
+                            "from": 0.0,
+                            "to": 255.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 1,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-area",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMA==",
+                        "title": "Customizable Option - field",
+                        "type": "field",
+                        "range": {
+                            "from": 0.0,
+                            "to": 255.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 2,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-field",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMQ==",
+                        "title": "Customizable Option - file",
+                        "type": "file",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "jpg, png",
+                        "sortOrder": 3,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-file",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMg==",
+                        "title": "Customizable Option - date",
+                        "type": "date",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 4,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-date",
+                        "markupAmount": 126.0
+                    },
+                ],
+                "price": {
+                    "final": {
+                        "amount": {
+                            "value": 12,
+                            "currency": "USD"
+                        }
+                    },
+                    "regular": {
+                        "amount": {
+                            "value": 12,
+                            "currency": "USD"
+                        }
+                    },
+                    "roles": [
+                        "visible"
+                    ]
+                },
+                "links": [
+                    {
+                        "product": {
+                            "sku": "24-UG06"
+                        },
+                        "linkTypes": [
+                            "related"
+                        ]
+                    },
+                    {
+                        "product": {
+                            "sku": "MH07"
+                        },
+                        "linkTypes": [
+                            "related"
+                        ]
+                    },
+                    {
+                        "product": {
+                            "sku": "24-WG088"
+                        },
+                        "linkTypes": [
+                            "crosssell"
+                        ]
+                    },
+                    {
+                        "product": {
+                            "sku": "24-WG085_Group"
+                        },
+                        "linkTypes": [
+                            "related"
+                        ]
+                    },
+                    {
+                        "product": {
+                            "sku": "24-UG02"
+                        },
+                        "linkTypes": [
+                            "related"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+### Return details about a complex product
+
+The following query returns details about a complex product.
+
+<CodeBlock slots="heading, code" repeat="2" languages="JSON" />
+
+**Request:**
+
+```graphql
+query {
+
+    products(skus: ["MH07"]) {
+        __typename
+        id
+        sku
+        name
+        description
+        shortDescription
+        addToCartAllowed
+        url
+        images(roles: []) {
+            url
+            label
+            roles
+        }
+        attributes(roles: []) {
+            name
+            label
+            value
+            roles
+        }
+        ... on ComplexProductView {
+        inputOptions {
+            id
+            title
+            required
+            type
+            markupAmount
+            suffix
+            sortOrder
+            range {
+                from
+                to
+            }
+            imageSize {
+                width
+                height
+            }
+            fileExtensions
+            }
+            options {
+                id
+                title
+                required
+                values {
+                    id
+                    title
+                    ... on ProductViewOptionValueProduct {
+                        title,
+                        quantity,
+                        isDefault,
+                        product {
+                            sku
+                            shortDescription
+                            name
+                            links {
+                                product {
+                                    sku
+                                }
+                                linkTypes
+                            }
+                            price {
+                                final {
+                                    amount {
+                                        value
+                                        currency
+                                    }
+                                }
+                                regular {
+                                    amount {
+                                        value
+                                        currency
+                                    }
+                                }
+                                roles
+                            }
+                        }
+                    }
+                }
+            }
+            priceRange {
+                maximum {
+                    final {
+                        amount {
+                            value
+                            currency
+                        }
+                    }
+                    regular {
+                        amount {
+                            value
+                            currency
+                        }
+                    }
+                    roles
+                }
+                minimum {
+                    final {
+                        amount {
+                            value
+                            currency
+                        }
+                    }
+                    regular {
+                        amount {
+                            value
+                            currency
+                        }
+                    }
+                    roles
+                }
+            }
+        }
+    }
+  }
+```
+
+**Response:**
+
+```json
+{
+    "data": {
+        "products": [
+            {
+                "__typename": "ComplexProductView",
+                "id": "VFVnd053AFpHVm1ZWFZzZEEAWWpVMU9EUTJNV1F0TjJZeFppMDBNak5oTFdFNFptVXRNVGd3WldFNU5XRXdNakZpAGJXRnBibDkzWldKemFYUmxYM04wYjNKbABZbUZ6WlEAVFVGSFUxUkhNREExTlRnd01qQXc",
+                "sku": "MH07",
+                "name": "Hero Hoodie",
+                "description": "<p>Gray and black color blocking sets you apart as the Hero Hoodie keeps you warm on the bus, campus or cold mean streets. Slanted outsize front pockets keep your style real . . . convenient.</p>\r\n<p>&bull; Full-zip gray and black hoodie.<br />&bull; Ribbed hem.<br />&bull; Standard fit.<br />&bull; Drawcord hood cinch.<br />&bull; Water-resistant coating.</p>",
+                "shortDescription": "",
+                "addToCartAllowed": true,
+                "url": "http://example.com/hero-hoodie.html",
+                "images": [
+                    {
+                        "url": "http://example.com/media/catalog/product/m/h/mh07-gray_main_2.jpg",
+                        "label": "",
+                        "roles": [
+                            "image",
+                            "small_image",
+                            "thumbnail"
+                        ]
+                    },
+                    {
+                        "url": "http://example.com/media/catalog/product/m/h/mh07-gray_alt1_2.jpg",
+                        "label": "",
+                        "roles": []
+                    },
+                    {
+                        "url": "http://example.com/media/catalog/product/m/h/mh07-gray_back_2.jpg",
+                        "label": "",
+                        "roles": []
+                    }
+                ],
+              "inputOptions": [
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8xOQ==",
+                        "title": "Customizable Option - area",
+                        "type": "area",
+                        "range": {
+                            "from": 0.0,
+                            "to": 255.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 1,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-area",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMA==",
+                        "title": "Customizable Option - field",
+                        "type": "field",
+                        "range": {
+                            "from": 0.0,
+                            "to": 255.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 2,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-field",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMQ==",
+                        "title": "Customizable Option - file",
+                        "type": "file",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "jpg, png",
+                        "sortOrder": 3,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-file",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMg==",
+                        "title": "Customizable Option - date",
+                        "type": "date",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 4,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-date",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yMw==",
+                        "title": "Customizable Option - date_time",
+                        "type": "date_time",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 5,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-date_time",
+                        "markupAmount": 126.0
+                    },
+                    {
+                        "required": false,
+                        "id": "Y3VzdG9tLW9wdGlvbi8yNA==",
+                        "title": "Customizable Option - time",
+                        "type": "time",
+                        "range": {
+                            "from": 0.0,
+                            "to": 0.0
+                        },
+                        "fileExtensions": "",
+                        "sortOrder": 6,
+                        "suffix": "test-e2e-configurable-smoke138330433-opt-time",
+                        "markupAmount": 126.0
+                    }
+                ],
+                "attributes": [
+                    {
+                        "name": "climate",
+                        "label": "Climate",
+                        "value": "Spring",
+                        "roles": [
+                            "visible_in_pdp",
+                            "visible_in_search"
+                        ]
+                    },
+                    {
+                        "name": "eco_collection",
+                        "label": "Eco Collection",
+                        "value": "no",
+                        "roles": [
+                            "visible_in_pdp"
+                        ]
+                    },
+                    {
+                        "name": "erin_recommends",
+                        "label": "Erin Recommends",
+                        "value": "no",
+                        "roles": [
+                            "visible_in_pdp"
+                        ]
+                    },
+                    {
+                        "name": "material",
+                        "label": "Material",
+                        "value": [
+                            "Fleece",
+                            "Hemp",
+                            "Polyester"
+                        ],
+                        "roles": [
+                            "visible_in_pdp",
+                            "visible_in_search"
+                        ]
+                    },
+                    {
+                        "name": "new",
+                        "label": "New",
+                        "value": "yes",
+                        "roles": [
+                            "visible_in_pdp"
+                        ]
+                    },
+                    {
+                        "name": "pattern",
+                        "label": "Pattern",
+                        "value": "Color-Blocked",
+                        "roles": [
+                            "visible_in_pdp",
+                            "visible_in_search"
+                        ]
+                    },
+                    {
+                        "name": "performance_fabric",
+                        "label": "Performance Fabric",
+                        "value": "no",
+                        "roles": [
+                            "visible_in_pdp"
+                        ]
+                    },
+                    {
+                        "name": "sale",
+                        "label": "Sale",
+                        "value": "no",
+                        "roles": [
+                            "visible_in_pdp"
+                        ]
+                    }
+                ],
+                "links": [
+                    {
+                        "product": {
+                            "sku": "24-UG07"
+                        },
+                        "linkTypes": [
+                            "crosssell"
+                        ]
+                    },
+                    {
+                        "product": {
+                            "sku": "24-UG06"
+                        },
+                        "linkTypes": [
+                            "related",
+                            "crosssell"
+                        ]
+                    },
+                    {
+                        "product": {
+                            "sku": "24-WG088"
+                        },
+                        "linkTypes": [
+                            "crosssell"
+                        ]
+                    },
+                    {
+                        "product": {
+                            "sku": "24-WG080"
+                        },
+                        "linkTypes": [
+                            "crosssell"
+                        ]
+                    }
+                ],
+                "options": [
+                    {
+                        "id": "size",
+                        "title": "Size",
+                        "required": false,
+                        "values": [
+                            {
+                                "id": "Y29uZmlndXJhYmxlLzE1OS8xNjY=",
+                                "title": "XS"
+                            },
+                            {
+                                "id": "Y29uZmlndXJhYmxlLzE1OS8xNjc=",
+                                "title": "S"
+                            },
+                            {
+                                "id": "Y29uZmlndXJhYmxlLzE1OS8xNjg=",
+                                "title": "M"
+                            },
+                            {
+                                "id": "Y29uZmlndXJhYmxlLzE1OS8xNjk=",
+                                "title": "L"
+                            },
+                            {
+                                "id": "Y29uZmlndXJhYmxlLzE1OS8xNzA=",
+                                "title": "XL"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "color",
+                        "title": "Color",
+                        "required": false,
+                        "values": [
+                            {
+                                "id": "Y29uZmlndXJhYmxlLzkzLzQ5",
+                                "title": "Black"
+                            },
+                            {
+                                "id": "Y29uZmlndXJhYmxlLzkzLzUy",
+                                "title": "Gray"
+                            },
+                            {
+                                "id": "Y29uZmlndXJhYmxlLzkzLzUz",
+                                "title": "Green"
+                            }
+                        ]
+                    }
+                ],
+                "priceRange": {
+                    "maximum": {
+                        "final": {
+                            "amount": {
+                                "value": 54,
+                                "currency": "USD"
+                            }
+                        },
+                        "regular": {
+                            "amount": {
+                                "value": 54,
+                                "currency": "USD"
+                            }
+                        },
+                        "roles": [
+                            "visible"
+                        ]
+                    },
+                    "minimum": {
+                        "final": {
+                            "amount": {
+                                "value": 54,
+                                "currency": "USD"
+                            }
+                        },
+                        "regular": {
+                            "amount": {
+                                "value": 54,
+                                "currency": "USD"
+                            }
+                        },
+                        "roles": [
+                            "visible"
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+}
+```
+
+## Output fields
+
+import Docs2 from '/src/_includes/graphql/catalog-service/product-view.md'
+
+<Docs2 />

--- a/src/pages/graphql/schema/catalog-service/queries/refine-product.md
+++ b/src/pages/graphql/schema/catalog-service/queries/refine-product.md
@@ -1,0 +1,291 @@
+---
+title: refineProduct query | GraphQL Developer Guide
+description: Describes how to construct and use the Catalog Service refineProduct query.
+keywords:
+  - GraphQL
+  - Services
+---
+
+# refineProduct query
+
+The `refineProduct` query narrows the results of a `products` query that was run against a complex product. Before you run the `refineProduct` query, you must run the `products` query and construct the response so that it returns a list of `options` within a `ComplexProductView` inline fragment. When a shopper selects a product option (such as size or color) on the storefront, run the `refineProduct` query, specifying the SKU and selected option value IDs as input. Depending on the number of product options the complex product has, you might need to run the `refineProduct` query multiple times, until the shopper has selected a specific variant.
+
+You should construct the response of your query so that it contains both the `ComplexProductView` and `SimpleProductView` inline fragments. If the shopper has not selected all of the required options, the query will return the IDs of unselected options and the minimum and maximum price of the product, based on the selected options and possible remaining options. If the shopper has selected all the required options, the query returns details about a simple product, which includes a set price.
+
+## Syntax
+
+```graphql
+refineProduct(sku: String!, optionIds: [String!]!): ProductView
+```
+
+## Endpoints
+
+import StorefrontAPIEndpoints from '/src/_includes/graphql/endpoints.md'
+
+<StorefrontAPIEndpoints />
+
+## Required headers
+
+You must specify the following HTTP headers to run this query.
+
+import Docs from '/src/_includes/graphql/catalog-service/headers.md'
+
+<Docs />
+
+###  Find the customer group code
+
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroupCode />
+
+## Example usage
+
+### Return details about a partially selected complex product
+
+The following query returns details about the color options available for a medium-sized variant of product `MH12`. The value of the `optionIDs` input parameter is taken from the `products` query's [Return details about a complex product](products.md#return-details-about-a-complex-product) example.
+
+<CodeBlock slots="heading, code" repeat="2" languages="JSON" />
+
+**Request:**
+
+```graphql
+query {
+    refineProduct(optionIds: ["Y29uZmlndXJhYmxlLzE4Ni8xNzc="], sku: "MH12") {
+        __typename
+        id
+        sku
+        name
+        url
+        ... on SimpleProductView {
+            price {
+                final {
+                    amount {
+                        value
+                    }
+                }
+                regular {
+                    amount {
+                        value
+                    }
+                }
+            }
+        }
+        ... on ComplexProductView {
+            options {
+                id
+                title
+                required
+                values {
+                    id
+                    title
+
+                }
+            }
+            priceRange {
+                maximum {
+                    final {
+                        amount {
+                            value
+                        }
+                    }
+                    regular {
+                        amount {
+                            value
+                        }
+                    }
+                }
+                minimum {
+                    final {
+                        amount {
+                            value
+                        }
+                    }
+                    regular {
+                        amount {
+                            value
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "refineProduct": {
+      "__typename": "ComplexProductView",
+      "id": "VFVneE1nAFpHVm1ZWFZzZEEATXpSbE1qYzBNR0V0TnpRM015MDBZemc1TFRnM016QXROVGMwTURObVkyVXlOMkZsAGJXRnBibDkzWldKemFYUmxYM04wYjNKbABZbUZ6WlEAVFVGSFUxUkhNREExTlRjNU1ETTQ",
+      "sku": "MH12",
+      "name": "Ajax Full-Zip Sweatshirt 2",
+      "url": "http://example.com/ajax-full-zip-sweatshirt.html",
+      "options": [
+        {
+          "id": "color",
+          "title": "Color",
+          "required": false,
+          "values": [
+            {
+              "id": "Y29uZmlndXJhYmxlLzkzLzU5",
+              "title": "Blue"
+            },
+            {
+              "id": "Y29uZmlndXJhYmxlLzkzLzY3",
+              "title": "Red"
+            },
+            {
+              "id": "Y29uZmlndXJhYmxlLzkzLzYy",
+              "title": "Green"
+            }
+          ]
+        }
+      ],
+      "priceRange": {
+        "maximum": {
+          "final": {
+            "amount": {
+              "value": 69
+            }
+          },
+          "regular": {
+            "amount": {
+              "value": 69
+            }
+          }
+        },
+        "minimum": {
+          "final": {
+            "amount": {
+              "value": 69
+            }
+          },
+          "regular": {
+            "amount": {
+              "value": 69
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Return details about a fully selected complex product
+
+In the following query, the shopper has selected options for both size and color. The response contains details about the corresponding simple product.
+
+<CodeBlock slots="heading, code" repeat="3" languages="JSON" />
+
+**Request:**
+
+```graphql
+query {
+    refineProduct(optionIds: ["Y29uZmlndXJhYmxlLzE4Ni8xNzc=", "Y29uZmlndXJhYmxlLzkzLzU5"], sku: "MH12") {
+        __typename
+        id
+        sku
+        name
+        url
+        ... on SimpleProductView {
+            price {
+                final {
+                    amount {
+                        value
+                    }
+                }
+                regular {
+                    amount {
+                        value
+                    }
+                }
+            }
+        }
+        ... on ComplexProductView {
+            options {
+                id
+                title
+                required
+                values {
+                    id
+                    title
+
+                }
+            }
+            priceRange {
+                maximum {
+                    final {
+                        amount {
+                            value
+                        }
+                    }
+                    regular {
+                        amount {
+                            value
+                        }
+                    }
+                }
+                minimum {
+                    final {
+                        amount {
+                            value
+                        }
+                    }
+                    regular {
+                        amount {
+                            value
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "refineProduct": {
+      "__typename": "SimpleProductView",
+      "id": "VFVneE1pMU5MVUpzZFdVAFpHVm1ZWFZzZEEATXpSbE1qYzBNR0V0TnpRM015MDBZemc1TFRnM016QXROVGMwTURObVkyVXlOMkZsAGJXRnBibDkzWldKemFYUmxYM04wYjNKbABZbUZ6WlEAVFVGSFUxUkhNREExTlRjNU1ETTQ",
+      "sku": "MH12-M-Blue",
+      "name": "Ajax Full-Zip Sweatshirt -M-Blue",
+      "url": "http://example.com/catalog/product/view/id/235/s/ajax-full-zip-sweatshirt-m-blue/",
+      "price": {
+        "final": {
+          "amount": {
+            "value": 69
+          }
+        },
+        "regular": {
+          "amount": {
+            "value": 69
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Input fields
+
+You must specify a SKU value and at least one option ID as input.
+
+Field | Data type | Description
+--- | --- | ---
+`optionIds` | [String!]! | A list of IDs assigned to the product options the shopper has selected, such specific colors and sizes.
+`sku` | String! |  The SKU of a complex product.
+
+## Output fields
+
+import Docs2 from '/src/_includes/graphql/catalog-service/product-view.md'
+
+<Docs2 />

--- a/src/pages/graphql/schema/catalog-service/queries/refine-product.md
+++ b/src/pages/graphql/schema/catalog-service/queries/refine-product.md
@@ -10,7 +10,7 @@ keywords:
 
 The `refineProduct` query helps narrow down the results of a `products` query that was run against a complex product. To use this query effectively, first run the `products` query and ensure that the response includes a list of options within a `ComplexProductView` inline fragment. When a shopper selects a product option (such as size or color) on the storefront, you can then run the `refineProduct query` by specifying the SKU and the selected option value IDs as input. Depending on the number of product options available for the complex product, you might need to run the `refineProduct` query multiple times until the shopper has selected a specific variant.
 
-Ensure that your query response includes both the` ComplexProductView` and `SimpleProductView` inline fragments. If the shopper has not selected all required options, the query returns the IDs of unselected options along with the minimum and maximum price of the product, based on the selected options and possible remaining options. If all required options are selected, the query returns details about a simple product, including its set price.
+Ensure that your query response includes both the `ComplexProductView` and `SimpleProductView` inline fragments. If the shopper has not selected all required options, the query returns the IDs of unselected options along with the minimum and maximum price of the product, based on the selected options and possible remaining options. If all required options are selected, the query returns details about a simple product, including its set price.
 
 ## Syntax
 

--- a/src/pages/graphql/schema/catalog-service/queries/refine-product.md
+++ b/src/pages/graphql/schema/catalog-service/queries/refine-product.md
@@ -8,9 +8,9 @@ keywords:
 
 # refineProduct query
 
-The `refineProduct` query narrows the results of a `products` query that was run against a complex product. Before you run the `refineProduct` query, you must run the `products` query and construct the response so that it returns a list of `options` within a `ComplexProductView` inline fragment. When a shopper selects a product option (such as size or color) on the storefront, run the `refineProduct` query, specifying the SKU and selected option value IDs as input. Depending on the number of product options the complex product has, you might need to run the `refineProduct` query multiple times, until the shopper has selected a specific variant.
+The `refineProduct` query helps narrow down the results of a `products` query that was run against a complex product. To use this query effectively, first run the `products` query and ensure that the response includes a list of options within a `ComplexProductView` inline fragment. When a shopper selects a product option (such as size or color) on the storefront, you can then run the `refineProduct query` by specifying the SKU and the selected option value IDs as input. Depending on the number of product options available for the complex product, you might need to run the `refineProduct` query multiple times until the shopper has selected a specific variant.
 
-You should construct the response of your query so that it contains both the `ComplexProductView` and `SimpleProductView` inline fragments. If the shopper has not selected all of the required options, the query will return the IDs of unselected options and the minimum and maximum price of the product, based on the selected options and possible remaining options. If the shopper has selected all the required options, the query returns details about a simple product, which includes a set price.
+Ensure that your query response includes both the` ComplexProductView` and `SimpleProductView` inline fragments. If the shopper has not selected all required options, the query returns the IDs of unselected options along with the minimum and maximum price of the product, based on the selected options and possible remaining options. If all required options are selected, the query returns details about a simple product, including its set price.
 
 ## Syntax
 
@@ -281,7 +281,7 @@ You must specify a SKU value and at least one option ID as input.
 
 Field | Data type | Description
 --- | --- | ---
-`optionIds` | [String!]! | A list of IDs assigned to the product options the shopper has selected, such specific colors and sizes.
+`optionIds` | [String!]! | A list of IDs assigned to the product options the shopper has selected, such as specific colors and sizes.
 `sku` | String! |  The SKU of a complex product.
 
 ## Output fields

--- a/src/pages/graphql/schema/index.md
+++ b/src/pages/graphql/schema/index.md
@@ -5,7 +5,3 @@ title: GraphQL schema
 # GraphQL schema
 
 We have reorganized the Adobe Commerce and Magento Open Source GraphQL reference documentation to make it easier to find related queries, mutations, interfaces, and other data types. Use the left navigation to review usage information and examples for each entity in the Commerce schema.
-
-<InlineAlert variant="info" slots="text" />
-
-The Catalog Service, Live Search, and Product Recommendations services have schemas that are independent from the core schema for Adobe Commerce and Magento Open Source. You can find the schema reference documentation and examples for these services in [Storefront Services GraphQL](https://developer.adobe.com/commerce/services/graphql/).

--- a/src/pages/graphql/schema/live-search/index.md
+++ b/src/pages/graphql/schema/live-search/index.md
@@ -1,0 +1,32 @@
+---
+title: Live Search
+description: Learn how Live Search implements GraphQL.
+keywords:
+  - GraphQL
+  - Services
+  - Search
+---
+
+# Live Search
+
+Live Search is a set of standalone packages for Adobe Commerce that replaces the standard search capabilities. It provides GraphQL functionality that is currently separate from the built-in GraphQL functionality provided in Adobe Commerce and Magento Open Source. Live Search GraphQL requires connecting to a different endpoint and specifying a different set of HTTP headers.
+
+You can connect to the Live Search GraphQL endpoint to test sample queries using an Integrated Development Environment (IDE) in two ways:
+
+-  Through the GraphQL Playground IDE embedded in the Commerce Admin. The embedded IDE manages the endpoint URL and required HTTP headers. To access this IDE, go to **Marketing** > SEO & Search > **Live Search**.
+
+-  Through a standalone version of GraphQL Playground, or any other IDE, such as GraphiQL or Postman. In these applications you must specify the endpoint URL and provide a set of HTTP headers for each call.
+
+For instructions on how to install and implement this product, see [Introduction to Live Search](https://experienceleague.adobe.com/docs/commerce-merchant-services/live-search/overview.html).
+
+## Error Codes
+
+The Live Search queries can return the following error codes when a query encounters an error.
+
+|**Error Code**|**Description**|
+|---|---|
+|1000 |Catches any other error that is not recognized by the service.|
+|1001 |`index_not_found_exception`<br />Live Search exception message.|
+|1002 |`search_phase_execution_exception`<br />Live Search exception message.|
+|1003 |`mapper_parsing_exception`<br />Live Search exception message.|
+|1004 |`invalid_argument_exception`<br /> The request has an invalid argument.|

--- a/src/pages/graphql/schema/live-search/queries/attribute-metadata.md
+++ b/src/pages/graphql/schema/live-search/queries/attribute-metadata.md
@@ -1,0 +1,175 @@
+---
+title: attributeMetadata query
+description: Describes how to construct and use the Live Search attributeMetadata query.
+keywords:
+  - GraphQL
+  - Services
+  - Search
+---
+
+# attributeMetadata query
+
+The `attributeMetadata` query returns a list of product attribute codes that can be used for sorting or filtering in a [`productSearch` query](./product-search.md). The query response can include the attribute name, display label, and a Boolean value that indicates if the attribute has a numeric value.
+
+## Syntax
+
+`attributeMetadata: AttributeMetadataResponse!`
+
+## Endpoints
+
+import StorefrontAPIEndpoints from '/src/_includes/graphql/endpoints.md'
+
+<StorefrontAPIEndpoints />
+
+## Required headers
+
+You must specify the following HTTP headers to run this query.
+
+import Docs from '/src/_includes/graphql/live-search-headers.md'
+
+<Docs />
+
+## Example usage
+
+The following query returns details about all product attributes that can be used to define the sorting order or as a filter in a `productSearch` query.
+
+**Request:**
+
+```graphql
+{
+  attributeMetadata{
+    sortable {
+      attribute
+      label
+      numeric
+    }
+    filterableInSearch  {
+      attribute
+      label
+      numeric
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "extensions": {
+    "request-id": "5Kd6pzYc02PlHIbbmNDTff3VaXF0EnYf"
+  },
+  "data": {
+    "attributeMetadata": {
+      "sortable": [
+        {
+          "attribute": "name",
+          "label": "Product Name",
+          "numeric": false
+        },
+        {
+          "attribute": "price",
+          "label": "Price",
+          "numeric": true
+        },
+        {
+          "attribute": "position",
+          "label": "position",
+          "numeric": true
+        }
+      ],
+      "filterableInSearch": [
+        {
+          "attribute": "categoryIds",
+          "label": "categoryIds",
+          "numeric": false
+        },
+        {
+          "attribute": "collar",
+          "label": "Collar",
+          "numeric": false
+        },
+        {
+          "attribute": "visibility",
+          "label": "visibility",
+          "numeric": false
+        },
+        {
+          "attribute": "activity",
+          "label": "Activity",
+          "numeric": false
+        },
+        {
+          "attribute": "gender",
+          "label": "Gender",
+          "numeric": false
+        },
+        {
+          "attribute": "size",
+          "label": "Size",
+          "numeric": false
+        },
+        {
+          "attribute": "price",
+          "label": "price",
+          "numeric": true
+        },
+        {
+          "attribute": "sleeve",
+          "label": "Sleeve",
+          "numeric": false
+        },
+        {
+          "attribute": "eco_collection",
+          "label": "Eco Collection",
+          "numeric": false
+        },
+        {
+          "attribute": "categories",
+          "label": "categories",
+          "numeric": false
+        },
+        {
+          "attribute": "climate",
+          "label": "Climate",
+          "numeric": false
+        },
+        {
+          "attribute": "sku",
+          "label": "sku",
+          "numeric": false
+        }
+      ]
+    }
+  }
+}
+```
+
+## Output fields
+
+The `AttributeMetadataResponse` return object can contain the following fields:
+
+Field | Data Type | Description
+--- | --- | ---
+`filterableInSearch` | [FilterableInSearchAttribute](#filterableinsearchattribute-data-type) | An array of product attributes that can be used for filtering in a `productSearch` query
+`sortable` | [SortableAttribute](#sortableattribute-data-type) | An array of product attributes that can be used for sorting in a `productSearch` query
+
+### FilterableInSearchAttribute data type
+
+The `FilterableInSearchAttribute` data type can contain the following fields:
+
+Field | Data Type | Description
+--- | --- | ---
+`attribute` | String! | The unique identifier for an attribute code. This value should be in lowercase letters and without spaces
+`label` | String | The display name assigned to the attribute
+`numeric` | Boolean | Indicates whether this attribute has a numeric value, such as a price or integer
+
+### SortableAttribute data type
+
+The `SortableAttribute` data type can contain the following fields:
+
+Field | Data Type | Description
+--- | --- | ---
+`attribute` | String! | The unique identifier for an attribute code. This value should be in lowercase letters and without spaces
+`label` | String | The display name assigned to the attribute
+`numeric` | Boolean | Indicates whether this attribute has a numeric value, such as a price or integer

--- a/src/pages/graphql/schema/live-search/queries/attribute-metadata.md
+++ b/src/pages/graphql/schema/live-search/queries/attribute-metadata.md
@@ -9,7 +9,7 @@ keywords:
 
 # attributeMetadata query
 
-The `attributeMetadata` query returns a list of product attribute codes that can be used for sorting or filtering in a [`productSearch` query](./product-search.md). The query response can include the attribute name, display label, and a Boolean value that indicates if the attribute has a numeric value.
+The `attributeMetadata` query returns a list of product attribute codes that can be used for sorting or filtering in a [`productSearch` query](./product-search.md). The query response can include the attribute name, display label, and a Boolean value that indicates if the attribute has a numeric value that can be used for numeric operations, such as range filters or sorting.
 
 ## Syntax
 
@@ -162,7 +162,7 @@ Field | Data Type | Description
 --- | --- | ---
 `attribute` | String! | The unique identifier for an attribute code. This value should be in lowercase letters and without spaces
 `label` | String | The display name assigned to the attribute
-`numeric` | Boolean | Indicates whether this attribute has a numeric value, such as a price or integer
+`numeric` | Boolean | Indicates whether this attribute has a numeric value, such as a price or integer that can be used for numeric operations, such as range filters or sorting.
 
 ### SortableAttribute data type
 
@@ -172,4 +172,4 @@ Field | Data Type | Description
 --- | --- | ---
 `attribute` | String! | The unique identifier for an attribute code. This value should be in lowercase letters and without spaces
 `label` | String | The display name assigned to the attribute
-`numeric` | Boolean | Indicates whether this attribute has a numeric value, such as a price or integer
+`numeric` | Boolean | Indicates whether this attribute has a numeric value, such as a price or integer that can be used for numeric operations, such as range filters or sorting.

--- a/src/pages/graphql/schema/live-search/queries/index.md
+++ b/src/pages/graphql/schema/live-search/queries/index.md
@@ -1,0 +1,15 @@
+---
+title: Live Search queries
+description: Learn how Live Search implements GraphQL.
+keywords:
+  - GraphQL
+  - Services
+  - Search
+---
+
+# Live Search queries
+
+Live Search provides the following queries:
+
+* [`attributeMetadata`](./attribute-metadata.md)
+* [`productSearch`](./product-search.md)

--- a/src/pages/graphql/schema/live-search/queries/product-search.md
+++ b/src/pages/graphql/schema/live-search/queries/product-search.md
@@ -1,0 +1,1441 @@
+---
+title: productSearch query
+description: Describes how to construct and use the productSearch query in both Live Search and Catalog Service.
+keywords:
+  - GraphQL
+  - Services
+  - Search
+---
+
+# productSearch query
+
+This article discusses the `productSearch` query that is available in the Live Search and Catalog Service extension. While similar in structure and functionality, there are differences in what they output.
+
+See [Boundaries and Limits](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/boundaries-limits) for the latest recommendations for creating performant queries.
+
+## Syntax
+
+```graphql
+productSearch(
+    phrase: String!
+    context: [QueryContextInput!]
+    current_page: Int = 1
+    page_size: Int = 20
+    sort: [ProductSearchSortInput!]
+    filter: [SearchClauseInput!]
+): ProductSearchResponse!
+```
+
+## Construct a productSearch query
+
+Live Search uses the `productSearch` query to search for products instead of the `products` query, which is provided with Adobe Commerce and Magento Open Source. Although the two queries are functionally similar, they have different input requirements. The `products` query returns information that is relevant for layered navigation, while the `productSearch` query returns faceting data and other features that are specific to Live Search.
+
+<InlineAlert variant="info" slots="text" />
+
+The Catalog Service `productSearch` query uses Live Search to return details about the SKUs specified as input. [Learn more](#catalog-service).
+
+The `productSearch` query accepts the following fields as input:
+
+- `phrase` - The string of text to search for. This field is required but an empty string may be used if only filtering by `category` or `categoryPath`.
+- `context` - (Live Search only) Query context that allows customized search results to be returned based on the customer group passed. This is used to get the view history of a SKU.
+- `current_page` and `page_size`- These optional fields allow the search results to be broken down into smaller groups so that a limited number of items are returned at a time. The default value of `page_size` is `20`, and the default value for `current_page` is `1`. In the response, counting starts at page one.
+- `sort` - An object that defines one or more product attributes to use to sort the search results. The default sortable product attributes in Luma are `price`, `name`, and `position`. A product's position is assigned within a category.
+- `filter` - An object that defines one or more product attributes or categories used to narrow the search results. In the Luma theme, the `sku`, `price`, and `size` attributes are among the product attributes that can be used to filter query results.
+
+<InlineAlert variant="info" slots="text" />
+
+The initial release does not allow for different merchandising strategies per customer group.
+
+### phrase
+
+The `phrase` field contains the text that a shopper enters on the storefront. Live Search applies all configured rules, synonyms, and other configuration settings to determine the search results. All `productSearch` queries must contain the `phrase` field. If the query filters on a category or category path, the value of the `phrase` field can be an empty string.
+
+The following example sets `pants` as the phrase to search for:
+
+```graphql
+phrase: "pants"
+```
+
+<InlineAlert variant="info" slots="text"/>
+
+Use the [`attributeMetadata` query](./attribute-metadata.md) to return a list of product attributes that can be used to define a filter.
+
+### context
+
+<InlineAlert variant="info" slots="text"/>
+
+The `context` object is only applicable to Live Search.
+
+The `context` object passes both the customer group code and user view history to the query. If no value is passed, the "Not Logged In" group is used.
+
+ ```graphql
+ context: {
+  customerGroup: "b6589fc6ab0dc82cf12099d1c2d40ab994e8410c",
+  userViewHistory: [
+    {
+      sku: "sku-01",
+      dateTime: "2022-10-13T20:53:21.338Z"
+    },
+    {
+      sku: "sku-02",
+      dateTime: "2022-10-13T20:53:21.338Z"
+    }
+  ]
+} 
+```
+
+### current_page
+
+The `currentPage` field specifies which page of results to return. If no value is specified, the first page is returned.
+
+The system returns an error if you specify a value that is greater than the number of available pages.
+
+The following example sets the current page to 5:
+
+```graphql
+current_page: 5
+```
+
+### page_size
+
+When you run a query, you do not know in advance how many items the query will return. The query could return a few items, or it could return hundreds. The `page_size` field determines how many items to return at one time. If you use the default value of 20, and the query returns 97 items, the results are stored in four pages containing 20 items each, and one page containing 17 items.
+
+The following example sets the page size to 10:
+
+```graphql
+page_size: 10
+```
+
+### sort
+
+The `sort` field allows you to specify one or more product attributes to be used to sort the results. If you specify more than one attribute, Live Search sorts by the first field listed. If any items have the same value, those items are sorted by the secondary field. The value for each field can be set to either `ASC` or `DESC`.
+
+The following example causes the query to filter first by `price`, and then by `name`:
+
+```graphql
+sort: [
+    {
+      attribute: "price"
+      direction: DESC
+    }
+    {
+      attribute: "name"
+      direction: DESC
+    }
+]
+```
+
+### Filtering
+
+The `filter` attribute is the part of the query that uses product attributes as facets or categories that are defined in the Admin. For example, to filter results by color, a color facet must be defined in Live Search, based on the existing `color` attribute.
+
+#### Filtering by attributes
+
+An attribute filter consists of a product `attribute`, a comparison operator, and the value that is being searched for. Together, they help narrow the search results, based on shopper input. For example:
+
+- To set up a filter for jackets based on size, set the product attribute to `size`.
+- To filter on medium-sized jackets only, set the `eq` field to `M`.
+- To filter on both medium- and large-sized jackets, set the `in` field to `["M", "L"]`.
+
+If an attribute is numeric, you can filter on it as a price range, such as between $50 and $100. For example, to filter on a price range, set the `attribute` to `price`, and assign the `range` field with `from` and `to` values as `50` and `100`, respectively. Products that are equal to the upper range are not included in the results. This aligns with how price ranges are defined for facets.
+
+You can define multiple filters in the same call. The following example filters on the price and size:
+
+```graphql
+filter: [
+    {
+      attribute: "price"
+      range: {
+        from: 50
+        to: 100
+      }
+    },
+    {
+      attribute: "size"
+      in: ["M", "L"]
+    }
+]
+```
+
+An attribute must be set to `filterableInSearch: true` if it is passed in as part of the filter. Otherwise, a "500 error" is returned.
+
+Only facets specified in Live Search are returned.
+
+<InlineAlert variant="info" slots="text"/>
+
+Use the [`attributeMetadata` query](./attribute-metadata.md) to return a list of product attributes that can be used to define a filter.
+
+#### Filtering using search capability
+
+<InlineAlert variant="info" slots="text"/>
+
+This feature is in beta. For installation information, see the [Live Search guide](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/install#install-the-live-search-beta) in the merchant documentation.
+
+This beta supports three new capabilities:
+
+- **Layered search** - Search within another search context - With this capability, you can undertake up to two layers of search for your search queries. For example:
+  
+  - **Layer 1 search** - Search for "motor" on "product_attribute_1".
+  - **Layer 2 search** - Search for "part number 123" on "product_attribute_2". This example searches for "part number 123" within the results for "motor".
+
+  Layered search is available for both `startsWith` search indexation and `contains` search indexation as described below:
+
+- **startsWith search indexation** - Search using `startsWith` indexation. This new capability allows:
+
+  - Searching for products where the attribute value starts with a particular string.
+  - Configuring an "ends with" search so shoppers can search for products where the attribute value ends with a particular string. To enable an "ends with" search, the product attribute needs to be ingested in reverse and the API call should also be a reversed string.
+
+- **contains search indexation** -Search an attribute using contains indexation. This new capability allows:
+
+    - Searching for a query within a larger string. For example, if a shopper searches for the product number "PE-123" in the string "HAPE-123".
+
+        - Note: This search type is different from the existing [phrase search](https://developer.adobe.com/commerce/services/graphql/live-search/product-search/#phrase), which performs an autocomplete search. For example, if your product attribute value is "outdoor pants", a phrase search returns a response for "out pan", but does not return a response for "oor ants". A contains search, however, does return a response for "oor ants".
+
+Refer to the following examples to learn how to implement these new search capabilities in your Live Search API.
+
+##### startsWith condition example
+
+The following example shows how you can search the "manufacturer" product attribute using a `startsWith` value of "Sieme".
+
+```graphql
+filter: [  
+  {  
+    attribute: "manufacturer",  
+    startsWith: "Sieme"  
+  }  
+]
+```
+
+##### contains condition example
+
+The following example shows how you can search the "manufacturer" product attribute using a `contains` value of "auto". The result of this query would match manufacturers named "ABC Auto Company" and "ABCauto" for example.
+
+```graphql
+filter: [  
+  {  
+    attribute: "manufacturer",  
+    contains: "auto"  
+  }  
+]
+```
+
+##### endsWith filter example
+
+To search an attribute value using `endsWith`, you must reverse the attribute value when you ingest the data. Then, you can use the `startsWith` condition on the specific attribute. In the following example, the part number is actually: `PN-5763`.
+
+```graphql
+filter: [  
+  {  
+    attribute: "part_number_reverse",  
+    startsWith: "3675-NP"  
+  }  
+]
+```
+
+**Example queries**
+
+The following example shows how to search within search results using "motor" as the search phrase and filtering on "manufacturer" that "startsWith" the term "Sieme":
+
+```graphql
+productSearch(  
+  phrase: "motor",  
+    filter: [  
+      {  
+        attribute: "manufacturer",  
+        startsWith: "Sieme"  
+      }  
+    ]  
+)
+```
+
+The following example shows how to search within search results using "motor" as the search phrase and filtering on "part_number" that "startsWith" the term "PE-123":
+
+```graphql
+productSearch(  
+  phrase: "motor",  
+    filter: [  
+      {  
+        attribute: "part_number",  
+        startsWith: "PE-123"  
+      }  
+    ]  
+)
+```
+
+The following example shows how to search within search results using "motor" as the search phrase and filtering on "manufacturer" that "endsWith" the term "PE-123":
+
+```graphql
+productSearch(  
+  phrase: "motor",  
+    filter: [  
+      {  
+        attribute: "reverse_part_number",  
+        startsWith: "321-EP"  
+      }  
+    ]  
+)
+```
+
+The following example shows how to search within search results using "motor" as the search phrase and filtering on "description" that "contains" the phrase "warranty included":
+
+```graphql
+productSearch(  
+  phrase: "motor",  
+    filter: [  
+      {  
+        attribute: "description",  
+        contains: "warranty included"  
+      }  
+    ]  
+)
+```
+
+The following example shows how to search a particular attribute for `startsWith` but not search within the search result:
+
+```graphql
+productSearch(  
+  phrase: "",  
+    filter: [  
+      {  
+        attribute: "part_number",  
+        startsWith: "PE-123"  
+      }  
+  ]  
+)
+```
+
+##### Limitations
+
+The beta has the following limitations:
+
+- You can specify a maximum of six attributes to be enabled for **Contains** and six attributes to be enabled for **Starts with**.
+- Each aggregation returns a maximum of 1000 facets.
+- `startsWith` and `contains` both require a minimum of two characters in the search.
+- `startsWith` allows a maximum of 10 characters for search.
+- `contains` allows a maximum of 10 characters for search in the API query and up to the first 50 characters are indexed for a true `contains` search. However, if more than 10 characters are passed in, the search results are returned for an autocomplete search result and not a true `contains` search. In this situation, the autocomplete search is enabled on the entire attribute string and not just the first 50 characters.
+- You can paginate a maximum of 10,000 products for any `productSearch` query.
+- These new search capabilities are not available in PLP widgets or the Live Search adapter extension.
+
+For additional Live Search boundaries and limits, see [boundaries and limits](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/boundaries-limits) in the Live Search merchant guide.
+
+#### Filtering by categories
+
+Results can be filtered by categories defined in the Admin with the `categories` and `categoryPath` filters. They are slightly different in the type of facets returned:
+
+`categories` is preferred when selecting from a category filter. Filtering on `categories` with "women/bottoms-women" and the phrase `pants`, the category facets returned are "promotions/pants-all", "women/bottoms-women/pants-women", and similar.
+
+`categoryPath` is preferred when browsing by category. `categoryPath` returns the immediate subcategories of the category path being filtered. Filtering on `categoryPath` with "women/bottoms-women", the category facets returned are its children such as "women/bottoms-women/pants-women" and "women/bottoms-women/shorts-women".
+
+A `phrase` attribute is required but it may be an empty string if you are filtering by `category` or `categoryPath`.
+
+Pinned categories are always returned, regardless of the filtered category.
+
+<InlineAlert variant="info" slots="text"/>
+
+For search merchandising rules to apply correctly, the `productSearch` query should sort by relevance or pass no sort variables at all. For category merchandising rules to apply correctly, the `productSearch` query should sort by `position`, filter on `categoryPath` for browsing a category page (otherwise, no category rules will be applied), and `phrase` should be "empty".
+
+#### categoryPath
+
+This example shows how to filter returned facets when browsing a category page.
+
+`categoryPath` performs strict filtering, meaning that the facets returned are limited to the immediate children of the current category page.
+
+The following snippet corresponds to a shopper selecting **Women** > **Bottoms**.
+
+```graphql
+filter:[
+  {
+    attribute:"categoryPath",
+    eq: "women/bottoms-women"
+    }
+  ] 
+```
+
+#### categories
+
+`categories` can be used as a filter in a query when a category facet is selected in the layered navigation.
+This does not result in strict filtering when used by itself.
+
+```graphql
+filter: [
+  {
+    attribute:"categories", 
+    in: "women/bottoms-women"
+  },
+  {
+    attribute: "visibility",
+    in: ["Catalog", "Catalog, Search"]
+  },
+]
+```
+
+Category filters can be used together. Here, the shopper navigates to "Womens -> Bottoms" and filters on "pants". This query returns both "Pants" and "Shorts" as facets in the layered navigation.
+
+```graphql
+filter: [
+  {
+    attribute: "visibility",
+    in: ["Catalog", "Catalog, Search"]
+  },
+  {
+    attribute:"categoryPath",
+    eq: ["women/bottoms-women"]
+  },
+  {
+    attribute:"categories",
+    in: ["women/bottoms-women/pants-women"]
+  }
+]
+```
+
+## Define query output
+
+The response to the `productSearch` query can contain details about each product returned and information about the ordering of the results.
+
+### Facets
+
+[Facets](https://experienceleague.adobe.com/docs/commerce-merchant-services/live-search/live-search-admin/facets/facets.html) provide a method of high-performance filtering that uses multiple dimensions of attribute values as search criteria. Faceted search is similar, but considerably more advanced than the native layered navigation functionality.
+
+The `facets` object contains details about each facet that affects the search results. By default, Live Search provides static facets for the `categories` and `price` product attributes that are pinned to the top of the Filters list in the storefront. The merchant can also pin other attributes to this list.
+
+Dynamic facets appear only when relevant, and the selection changes according to the products returned. In the storefront Filters list, dynamic facets appear in alphabetic order after any pinned facets. To streamline search results, facets are set to `dynamic` by default.
+
+Intelligent dynamic facets measure the frequency that an attribute appears in the results list and its prevalence throughout the catalog. Live Search uses this information to determine the order of returned products. This makes it possible to return two types of dynamic facets: Those that are most significant, followed by those that are most popular.
+
+The `buckets` subobject divides the data into manageable groups. For the `price` and similar numeric attributes, each bucket defines a price range and counts the items within that price range. Meanwhile, the buckets associated with the `categories` attribute list details about each category a product is a member of. The contents of dynamic facet buckets vary.
+
+The following snippet returns all information about the applicable facets for a search:
+
+```graphql
+facets {
+    attribute
+    title
+    type
+    buckets {
+        title
+        ... on RangeBucket {
+          title
+          to
+          from
+          count
+        }
+        ... on ScalarBucket {
+          title
+          id
+          count
+        }
+        ... on StatsBucket {
+          title
+          min
+          max
+        }
+    }
+}
+```
+
+### Items list
+
+The `items` object primarily provides details about each item returned. The structure of this object varies between Catalog Service and Live Search. For Catalog Service, specify a `ProductSearchItem.productView` object. For Live Search, specify a `ProductSearchItem.product` object
+
+#### ProductSearchItem.product (Live Search)
+
+The following snippet returns relevant information about each item when Catalog Service is not installed or used:
+
+```graphql
+items {
+    product {
+        name
+        sku
+        price_range {
+          maximum_price {
+            final_price {
+              value
+              currency
+            }
+          }
+          minimum_price {
+            final_price {
+              value
+              currency
+            }
+          }
+        }
+    }
+}
+```
+
+#### ProductSearchItem.productView (Catalog Service)
+
+If [Catalog Service](https://experienceleague.adobe.com/docs/commerce-merchant-services/catalog-service/guide-overview.html) is installed, you can optionally use the `productView` field instead of the `product` field to return product details. Catalog Service uses [Catalog Sync](https://experienceleague.adobe.com/docs/commerce-merchant-services/user-guides/data-services/catalog-sync.html) to manage product data, resulting in query responses with less latency than is possible with the `ProductInterface`. With Catalog Service, the structure of the pricing information varies, depending on whether the product is designated as a `SimpleProduct` (simple, downloadable, gift card) or as a `ComplexProduct` (configurable, grouped, or bundle).
+
+The following Catalog Service snippet returns relevant information about each item:
+
+```graphql
+items {
+  productView {
+    name
+    sku
+    ... on SimpleProductView {
+      price {
+        final {
+          amount {
+            value
+            currency
+          }
+        }
+        regular {
+          amount {
+            value
+            currency
+          }
+        }
+      }
+    }
+    ... on ComplexProductView {
+      options {
+        id
+        title
+        required
+        values {
+          id
+          title
+        }
+      }
+      priceRange {
+        maximum {
+          final {
+            amount {
+              value
+              currency
+            }
+          }
+          regular {
+            amount {
+              value
+              currency
+            }
+          }
+        }
+        minimum {
+          final {
+            amount {
+              value
+              currency
+            }
+          }
+          regular {
+            amount {
+              value
+              currency
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The `items` object can also optionally return highlighted text that shows the matching search terms.
+
+### Other fields and objects
+
+The query response can also contain the following top-level fields and objects:
+
+- `page_info` - An object that lists the `page_size` and `current_page` input arguments and the total number of pages available.
+- `suggestions` - An array of strings that include the names of products and categories that exist in the catalog that are similar to the search query.
+- `total_count` - The number of products returned.
+
+## Endpoints
+
+import StorefrontAPIEndpoints from '/src/_includes/graphql/endpoints.md'
+
+<StorefrontAPIEndpoints />
+
+## Required headers
+
+You must specify the following HTTP headers to run this query.
+
+Header name| Description
+--- | -----
+`Magento-Customer-Group` | (**Catalog Service Only**) Specify the [customer group code](#find-the-customer-group-code) for the API request.
+`Magento-Environment-Id` | This value is displayed at **Stores** > **Configuration** > **Services** > **Magento Services** > **SaaS Environment** or can be obtained by running the `bin/magento config:show services_connector/services_id/environment_id` command.
+`Magento-Store-Code` | The code assigned to the store associated with the active store view. For example, `main_website_store`.
+`Magento-Store-View-Code` | The code assigned to the active store view. For example, `default`.
+`Magento-Website-Code` | The code assigned to the website associated with the active store view. For example, `base`.
+`X-Api-Key` | For Live Search queries, set this value to `search_gql`. For Catalog Service queries, set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
+
+###  Find the customer group code
+
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroupCode />
+
+## Example usage
+
+In the following sections provide examples for using Live Search and Catalog Service.
+
+### Live Search
+
+This is an example of using Live Search to retrieve and filter results. The query uses the core `ProductInterface` to access product information. As a result, the query has a longer response time than using [Catalog Service](https://experienceleague.adobe.com/docs/commerce-merchant-services/catalog-service/guide-overview.html) to retrieve this information.
+
+For an example of using Live Search with Catalog Service, see [Catalog Service productSearch query](#catalog-service). Other than returning the `productView` object, all other attributes are the same.
+
+In the example below, there is no search `phrase` passed and results are filtered on the "women/bottoms-women" category. In the response, two categories are returned:
+
+```json
+{
+  "title": "women/bottoms-women/shorts-women",
+  "__typename": "ScalarBucket",
+  "id": "28",
+  "count": 12
+},
+{
+  "title": "women/bottoms-women/pants-women",
+  "__typename": "ScalarBucket",
+  "id": "27",
+  "count": 13
+}
+```
+
+If the `phrase` "pants" is added, only one category is returned and "shorts" are not returned by the query:
+
+```json
+{
+  "title": "women/bottoms-women/pants-women",
+  "__typename": "ScalarBucket",
+  "id": "27",
+  "count": 13
+}
+```
+
+**Request:**
+
+```graphql
+{
+  productSearch(
+    phrase: ""
+    sort: [
+      { attribute: "price", direction: DESC }
+      { attribute: "name", direction: DESC }
+    ]
+    filter: [
+      { attribute: "categoryPath", in: ["women/bottoms-women"] }
+    ]
+    page_size: 9
+  ) {
+    total_count
+    page_info {
+      current_page
+      page_size
+      total_pages
+    }
+    facets {
+      attribute
+      title
+      type
+      buckets {
+        title
+        __typename
+        ... on RangeBucket {
+          title
+          to
+          from
+          count
+        }
+        ... on ScalarBucket {
+          title
+          id
+          count
+        }
+        ... on StatsBucket {
+          title
+          min
+          max
+        }
+      }
+    }
+    items {
+      product {
+        name
+        sku
+      }
+    }
+    suggestions
+  }
+}
+```
+
+**Response:**
+
+<details>
+<summary><b>Response</b></summary>
+
+```json
+"data": {
+  "productSearch": {
+    "total_count": 25,
+    "page_info": {
+      "current_page": 1,
+      "page_size": 9,
+      "total_pages": 3
+    },
+    "facets": [
+      {
+        "attribute": "categories",
+        "title": "Categories",
+        "type": "PINNED",
+        "buckets": [
+          {
+            "title": "women/bottoms-women/shorts-women",
+            "__typename": "ScalarBucket",
+            "id": "28",
+            "count": 12
+          },
+          {
+            "title": "women/bottoms-women/pants-women",
+            "__typename": "ScalarBucket",
+            "id": "27",
+            "count": 13
+          }
+        ]
+      },
+      {
+        "attribute": "price",
+        "title": "Price",
+        "type": "PINNED",
+        "buckets": [
+          {
+            "title": "0.0-25.0",
+            "__typename": "RangeBucket",
+            "to": 25,
+            "from": 0,
+            "count": 1
+          },
+          {
+            "title": "25.0-50.0",
+            "__typename": "RangeBucket",
+            "to": 50,
+            "from": 25,
+            "count": 20
+          },
+          {
+            "title": "50.0-75.0",
+            "__typename": "RangeBucket",
+            "to": 75,
+            "from": 50,
+            "count": 4
+          }
+        ]
+      },
+      {
+        "attribute": "material",
+        "title": "Material",
+        "type": "POPULAR",
+        "buckets": [
+          {
+            "title": "Organic Cotton",
+            "__typename": "ScalarBucket",
+            "id": "Organic Cotton",
+            "count": 13
+          },
+          {
+            "title": "Spandex",
+            "__typename": "ScalarBucket",
+            "id": "Spandex",
+            "count": 11
+          },
+          {
+            "title": "Polyester",
+            "__typename": "ScalarBucket",
+            "id": "Polyester",
+            "count": 7
+          },
+          {
+            "title": "Cotton",
+            "__typename": "ScalarBucket",
+            "id": "Cotton",
+            "count": 4
+          },
+          {
+            "title": "LumaTech&trade;",
+            "__typename": "ScalarBucket",
+            "id": "LumaTech&trade;",
+            "count": 5
+          },
+          {
+            "title": "CoolTech&trade;",
+            "__typename": "ScalarBucket",
+            "id": "CoolTech&trade;",
+            "count": 4
+          },
+          {
+            "title": "Mesh",
+            "__typename": "ScalarBucket",
+            "id": "Mesh",
+            "count": 3
+          },
+          {
+            "title": "Cocona&reg; performance fabric",
+            "__typename": "ScalarBucket",
+            "id": "Cocona&reg; performance fabric",
+            "count": 4
+          }
+        ]
+      },
+      {
+        "attribute": "new",
+        "title": "New",
+        "type": "POPULAR",
+        "buckets": [
+          {
+            "title": "no",
+            "__typename": "ScalarBucket",
+            "id": "no",
+            "count": 21
+          },
+          {
+            "title": "yes",
+            "__typename": "ScalarBucket",
+            "id": "yes",
+            "count": 4
+          }
+        ]
+      },
+      {
+        "attribute": "color",
+        "title": "Color",
+        "type": "POPULAR",
+        "buckets": [
+          {
+            "title": "Blue",
+            "__typename": "ScalarBucket",
+            "id": "Blue",
+            "count": 14
+          },
+          {
+            "title": "Black",
+            "__typename": "ScalarBucket",
+            "id": "Black",
+            "count": 12
+          },
+          {
+            "title": "Orange",
+            "__typename": "ScalarBucket",
+            "id": "Orange",
+            "count": 9
+          },
+          {
+            "title": "Green",
+            "__typename": "ScalarBucket",
+            "id": "Green",
+            "count": 8
+          },
+          {
+            "title": "Purple",
+            "__typename": "ScalarBucket",
+            "id": "Purple",
+            "count": 8
+          },
+          {
+            "title": "Gray",
+            "__typename": "ScalarBucket",
+            "id": "Gray",
+            "count": 8
+          },
+          {
+            "title": "Red",
+            "__typename": "ScalarBucket",
+            "id": "Red",
+            "count": 7
+          },
+          {
+            "title": "White",
+            "__typename": "ScalarBucket",
+            "id": "White",
+            "count": 5
+          }
+        ]
+      },
+      {
+        "attribute": "eco_collection",
+        "title": "Eco Collection",
+        "type": "POPULAR",
+        "buckets": [
+          {
+            "title": "no",
+            "__typename": "ScalarBucket",
+            "id": "no",
+            "count": 18
+          },
+          {
+            "title": "yes",
+            "__typename": "ScalarBucket",
+            "id": "yes",
+            "count": 7
+          }
+        ]
+      },
+      {
+        "attribute": "climate",
+        "title": "Climate",
+        "type": "POPULAR",
+        "buckets": [
+          {
+            "title": "Indoor",
+            "__typename": "ScalarBucket",
+            "id": "Indoor",
+            "count": 20
+          },
+          {
+            "title": "Hot",
+            "__typename": "ScalarBucket",
+            "id": "Hot",
+            "count": 16
+          },
+          {
+            "title": "Mild",
+            "__typename": "ScalarBucket",
+            "id": "Mild",
+            "count": 17
+          },
+          {
+            "title": "Warm",
+            "__typename": "ScalarBucket",
+            "id": "Warm",
+            "count": 15
+          },
+          {
+            "title": "All-Weather",
+            "__typename": "ScalarBucket",
+            "id": "All-Weather",
+            "count": 10
+          },
+          {
+            "title": "Spring",
+            "__typename": "ScalarBucket",
+            "id": "Spring",
+            "count": 7
+          },
+          {
+            "title": "Cool",
+            "__typename": "ScalarBucket",
+            "id": "Cool",
+            "count": 3
+          }
+        ]
+      },
+      {
+        "attribute": "size",
+        "title": "Size",
+        "type": "POPULAR",
+        "buckets": [
+          {
+            "title": "28",
+            "__typename": "ScalarBucket",
+            "id": "28",
+            "count": 25
+          },
+          {
+            "title": "29",
+            "__typename": "ScalarBucket",
+            "id": "29",
+            "count": 25
+          },
+          {
+            "title": "30",
+            "__typename": "ScalarBucket",
+            "id": "30",
+            "count": 7
+          },
+          {
+            "title": "31",
+            "__typename": "ScalarBucket",
+            "id": "31",
+            "count": 7
+          },
+          {
+            "title": "32",
+            "__typename": "ScalarBucket",
+            "id": "32",
+            "count": 7
+          }
+        ]
+      },
+      {
+        "attribute": "activity",
+        "title": "Activity",
+        "type": "POPULAR",
+        "buckets": []
+      },
+      {
+        "attribute": "custom_price",
+        "title": "Custom Price",
+        "type": "POPULAR",
+        "buckets": []
+      }
+    ],
+    "items": [
+      {
+        "product": {
+          "name": "Sahara Leggings",
+          "sku": "WP05"
+        }
+      },
+      {
+        "product": {
+          "name": "Cora Parachute Pant",
+          "sku": "WP04"
+        }
+      },
+      {
+        "product": {
+          "name": "Deirdre Relaxed-Fit Capri",
+          "sku": "WP12"
+        }
+      },
+      {
+        "product": {
+          "name": "Gwen Drawstring Bike Short",
+          "sku": "WSH03"
+        }
+      },
+      {
+        "product": {
+          "name": "Ina Compression Short",
+          "sku": "WSH11"
+        }
+      },
+      {
+        "product": {
+          "name": "Diana Tights",
+          "sku": "WP06"
+        }
+      },
+      {
+        "product": {
+          "name": "Erika Running Short",
+          "sku": "WSH12"
+        }
+      },
+      {
+        "product": {
+          "name": "Artemis Running Short",
+          "sku": "WSH04"
+        }
+      },
+      {
+        "product": {
+          "name": "Sybil Running Short",
+          "sku": "WSH08"
+        }
+      }
+    ],
+    "suggestions": []
+  }
+}
+```
+
+</details>
+
+### Catalog Service
+
+In the following example, the query returns information on the same products as the Live Search [`productSearch` items list](#items-list) example. However, it has been constructed to return item information inside the Catalog Service `productView` object instead of the core `product` object. Note that the pricing information varies, depending on the product type. For the sake of brevity, facet information is not shown.
+
+**Request:**
+
+```graphql
+{
+  productSearch(
+    phrase: "bag"
+    sort: [
+      {
+        attribute: "price"
+        direction: DESC }]
+    page_size: 9
+  ) {
+    page_info {
+      current_page
+      page_size
+      total_pages
+    }
+    items {
+      productView {
+        name
+        sku
+        ... on SimpleProductView {
+          price {
+            final {
+              amount {
+                value
+                currency
+              }
+            }
+            regular {
+              amount {
+                value
+                currency
+              }
+            }
+          }
+        }
+        ... on ComplexProductView {
+          options {
+            id
+            title
+            required
+            values {
+              id
+              title
+            }
+          }
+          priceRange {
+            maximum {
+              final {
+                amount {
+                  value
+                  currency
+                }
+              }
+              regular {
+                amount {
+                  value
+                  currency
+                }
+              }
+            }
+            minimum {
+              final {
+                amount {
+                  value
+                  currency
+                }
+              }
+              regular {
+                amount {
+                  value
+                  currency
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+<details>
+<summary><b>Response</b></summary>
+
+```json
+{
+  "data": {
+    "productSearch": {
+      "page_info": {
+        "current_page": 1,
+        "page_size": 9,
+        "total_pages": 3
+      },
+      "items": [
+        {
+          "productView": {
+            "name": "Impulse Duffle",
+            "sku": "24-UB02",
+            "price": {
+              "final": {
+                "amount": {
+                  "value": 74,
+                  "currency": "USD"
+                }
+              },
+              "regular": {
+                "amount": {
+                  "value": 74,
+                  "currency": "USD"
+                }
+              }
+            }
+          }
+        },
+        {
+          "productView": {
+            "name": "Fusion Backpack 567890",
+            "sku": "24-MB02",
+            "price": {
+              "final": {
+                "amount": {
+                  "value": 59,
+                  "currency": "USD"
+                }
+              },
+              "regular": {
+                "amount": {
+                  "value": 59,
+                  "currency": "USD"
+                }
+              }
+            }
+          }
+        },
+        {
+          "productView": {
+            "name": "Rival Field Messenger",
+            "sku": "24-MB06",
+            "price": {
+              "final": {
+                "amount": {
+                  "value": 45,
+                  "currency": "USD"
+                }
+              },
+              "regular": {
+                "amount": {
+                  "value": 45,
+                  "currency": "USD"
+                }
+              }
+            }
+          }
+        },
+        {
+          "productView": {
+            "name": "Push It Messenger Bag",
+            "sku": "24-WB04",
+            "price": {
+              "final": {
+                "amount": {
+                  "value": 45,
+                  "currency": "USD"
+                }
+              },
+              "regular": {
+                "amount": {
+                  "value": 45,
+                  "currency": "USD"
+                }
+              }
+            }
+          }
+        },
+        {
+          "productView": {
+            "name": "Overnight Duffle",
+            "sku": "24-WB07",
+            "price": {
+              "final": {
+                "amount": {
+                  "value": 45,
+                  "currency": "USD"
+                }
+              },
+              "regular": {
+                "amount": {
+                  "value": 45,
+                  "currency": "USD"
+                }
+              }
+            }
+          }
+        },
+        {
+          "productView": {
+            "name": "Wayfarer Messenger Bag 987",
+            "sku": "24-MB05",
+            "price": {
+              "final": {
+                "amount": {
+                  "value": 44,
+                  "currency": "USD"
+                }
+              },
+              "regular": {
+                "amount": {
+                  "value": 44,
+                  "currency": "USD"
+                }
+              }
+            }
+          }
+        },
+        {
+          "productView": {
+            "name": "Driven Backpack",
+            "sku": "24-WB03",
+            "price": {
+              "final": {
+                "amount": {
+                  "value": 36,
+                  "currency": "USD"
+                }
+              },
+              "regular": {
+                "amount": {
+                  "value": 36,
+                  "currency": "USD"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+</details>
+
+## Input fields
+
+The `productSearch` query accepts the following fields as input:
+
+Field | Data Type | Description
+--- | --- | ---
+`context` | [[QueryContextInput!]](#querycontextinput-data-type) | Query context that allows customized search results to be returned based on the context passed
+`current_page` | Int | Specifies which page of results to return. Default value: 1
+`filter` | [[SearchClauseInput!]](#searchclauseinput-data-type) | Identifies which attributes to search for and return
+`page_size` | Int | Specifies the maximum number of results to return at once. Default value: 20
+`phrase` | String! | The text to filter on. Can be an empty string.
+`sort` | [[ProductSearchSortInput!]](#productsearchsortinput-data-type) | Specifies which attribute to sort on, and whether to return the results in ascending or descending order
+
+### SearchClauseInput data type
+
+The `SearchClauseInput` object can contain the following fields:
+
+Field | Data Type | Description
+--- | --- | ---
+`attribute` | String! | The attribute code of a product attribute
+`eq` | String | A string value to filter on
+`in` | [String] | An array of string values to filter on
+`range` | [SearchRangeInput](#searchrangeinput-data-type) | A range of numeric values to filter on
+`contains` | String | A string that searches for products containing specific attribute values
+`startsWith` | String | A string that searches for products where the attribute value starts with a particular string
+
+### SearchRangeInput data type
+
+The `SearchRangeInput` object can contain the following fields:
+
+Field | Data Type | Description
+--- | --- | ---
+`from` | Float | The minimum value to filter on. If not specified, the value of `0` is applied
+`to` | Float | The maximum value to filter on
+
+### ProductSearchSortInput data type
+
+The `ProductSearchSortInput` object can contain the following fields.
+
+Field | Data Type | Description
+--- | --- | ---
+`attribute` | String! | The attribute code of a product attribute
+`direction` | SortEnum! | ASC (ascending) or DESC (descending)
+
+### QueryContextInput data type
+
+The `QueryContextInput` object can contain the following fields.
+
+Field | Data Type | Description
+--- | --- | ---
+`customerGroup` | String! | The customer group code. For storefront clients, this value is available in the `dataservices_customer_group` cookie.
+`userViewHistory` | [ViewHistoryInput!](#viewhistoryinput-data-type) | List of SKUs with timestamps. Used in "Recommended for you" ranking.
+
+### ViewHistoryInput data type
+
+The `ViewHistoryInput` object can contain the following fields.
+
+Field | Data Type | Description
+--- | --- | ---
+`dateTime` | String! | Timestamps when the SKU was viewed
+`sku` | String! | The SKU of the view history being requested
+
+## Output fields
+
+The `productSearchResponse` return object can contain the following fields:
+
+### Common fields
+
+Field | Data Type | Description
+--- | --- | ---
+`facets` | [[Aggregation]](#aggregation-data-type) | Provides details about the static and dynamic facets relevant to the search
+`items` | [[ProductSearchItem]](#productsearchitem-data-type) | An array of products returned by the query
+`page_info` | [SearchResultPageInfo](#searchresultpageinfo-data-type) | Contains information for rendering pages of search results
+`related_terms` | [String] | Reserved for future use
+`suggestions` | [String] | An array of product URL keys that are similar to the search query. A maximum of five items are returned
+`total_count` | Int | The total number of items returned
+
+#### Aggregation data type
+
+Field | Data Type | Description
+--- | --- | ---
+`attribute` | String! | The attribute code of the filter item
+`buckets` | [[Bucket]!](#bucket-data-type) | A container that divides the data into manageable groups. For example, attributes that can have numeric values might have buckets that define price ranges
+`title` | String! | The filter name displayed in layered navigation
+`type` | AggregationType | Identifies the data type as one of the following: `INTELLIGENT`, `PINNED`, or `POPULAR`
+
+#### Bucket data type
+
+The `Bucket` object defines one field, `title`. However, the object has three implementations that can be used to provide greater detail.
+
+Field | Data Type | Description
+--- | --- | ---
+`title` | String! | A human-readable name of a bucket
+
+#### RangeBucket implementation
+
+Implement `RangeBucket` on numeric product fields.
+
+Field | Data Type | Description
+--- | --- | ---
+`count` | Int! | The number of items in the bucket
+`from` | Float! | The minimum amount in a price range
+`title` | String! | The display text defining the price range
+`to` | Float | The maximum amount in a price range
+
+#### ScalarBucket implementation
+
+Implement `ScalarBucket` on string and other scalar product fields.
+
+Field | Data Type | Description
+--- | --- | ---
+`count` | Int! | The number of items in the bucket
+`id` | ID! | An identifier that can be used for filtering and may contain non-human readable data
+`title` | String! | The display text that defines the scalar value
+
+#### StatsBucket implementation
+
+Implement `StatsBucket` to retrieve statistics across multiple buckets.
+
+Field | Data Type | Description
+--- | --- | ---
+`max` | Float! | The maximum value
+`min` | Float! | The minimum value
+`title` | String! | The display text defining the bucket
+
+#### ProductSearchItem data type
+
+The `ProductSearchItem` data type can contain the following fields:
+
+Field | Data Type | Description
+--- | --- | ---
+`appliedQueryRule` | AppliedQueryRule | The query rule type that was applied to this product, if any (in preview mode only, returns null otherwise). Possible values: `BOOST`, `BURY`, and `PIN`
+
+#### SearchResultPageInfo data type
+
+The `SearchResultPageInfo` data type can contain the following fields:
+
+Field | Data Type | Description
+--- | --- | ---
+`current_page` | Int | Specifies which page of results to return
+`page_size` | Int | Specifies the maximum number of items to return
+`total_pages` | Int | Specifies the total number of pages returned
+
+### Live Search fields
+
+Live Search contains information about the product within the [ProductInterface!](https://developer.adobe.com/commerce/webapi/graphql/schema/products/interfaces/attributes/) attribute.
+
+### Catalog Service fields
+
+import Docs2 from '/src/_includes/graphql/catalog-service/product-view.md'
+
+<Docs2 />

--- a/src/pages/graphql/schema/live-search/queries/product-search.md
+++ b/src/pages/graphql/schema/live-search/queries/product-search.md
@@ -189,7 +189,7 @@ This beta supports three new capabilities:
 
     - Searching for a query within a larger string. For example, if a shopper searches for the product number "PE-123" in the string "HAPE-123".
 
-        - Note: This search type is different from the existing [phrase search](https://developer.adobe.com/commerce/services/graphql/live-search/product-search/#phrase), which performs an autocomplete search. For example, if your product attribute value is "outdoor pants", a phrase search returns a response for "out pan", but does not return a response for "oor ants". A contains search, however, does return a response for "oor ants".
+        - Note: This search type is different from the existing [phrase search](#phrase), which performs an autocomplete search. For example, if your product attribute value is "outdoor pants", a phrase search returns a response for "out pan", but does not return a response for "oor ants". A contains search, however, does return a response for "oor ants".
 
 Refer to the following examples to learn how to implement these new search capabilities in your Live Search API.
 

--- a/src/pages/graphql/schema/live-search/queries/product-search.md
+++ b/src/pages/graphql/schema/live-search/queries/product-search.md
@@ -11,7 +11,7 @@ keywords:
 
 This article discusses the `productSearch` query that is available in the Live Search and Catalog Service extension. While similar in structure and functionality, there are differences in what they output.
 
-See [Boundaries and Limits](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/boundaries-limits) for the latest recommendations for creating performant queries.
+See [Boundaries and Limits](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/boundaries-limits) in the *Live Search Guide* for the latest recommendations for creating performant queries.
 
 ## Syntax
 
@@ -1432,7 +1432,7 @@ Field | Data Type | Description
 
 ### Live Search fields
 
-Live Search contains information about the product within the [ProductInterface!](https://developer.adobe.com/commerce/webapi/graphql/schema/products/interfaces/attributes/) attribute.
+Live Search returns product information using the [ProductInterface!](https://developer.adobe.com/commerce/webapi/graphql/schema/products/interfaces/attributes/).
 
 ### Catalog Service fields
 

--- a/src/pages/graphql/schema/product-recommendations/index.md
+++ b/src/pages/graphql/schema/product-recommendations/index.md
@@ -1,0 +1,15 @@
+---
+title: Product Recommendations
+description: Learn how Product Recommendations implements GraphQL.
+keywords:
+  - GraphQL
+  - Services
+---
+
+# Product Recommendations
+
+Product Recommendations is a service that suggests products based on the browsing patterns of other shoppers. Product recommendations are surfaced on the storefront as units with labels, such as "Customers who viewed this product also viewed" or "Customers who bought this product also bought". You can create, manage, and deploy recommendations across your store views directly from the Adobe Commerce Admin.
+
+The `recommendations` query returns recommended products based on the provided SKU.
+
+Read more in the [Introduction to Product Recommendations](https://experienceleague.adobe.com/docs/commerce-merchant-services/product-recommendations/overview.html).

--- a/src/pages/graphql/schema/product-recommendations/queries/index.md
+++ b/src/pages/graphql/schema/product-recommendations/queries/index.md
@@ -1,0 +1,11 @@
+---
+title: Product Recommendations query
+description: Learn how Product Recommendations implements GraphQL.
+keywords:
+  - GraphQL
+  - Services
+---
+
+# Product Recommendations query
+
+The [`recommendations`](./recommendations.md) query returns recommended products based on the provided SKU.

--- a/src/pages/graphql/schema/product-recommendations/queries/recommendations.md
+++ b/src/pages/graphql/schema/product-recommendations/queries/recommendations.md
@@ -1,0 +1,225 @@
+---
+title: recommendations query | GraphQL Developer Guide
+description: Describes how to construct and use the Product Recommendations recommendations query.
+keywords:
+  - GraphQL
+  - Services
+---
+
+# recommendations query
+
+The `recommendations` query returns information about product recommendation blocks for a given SKU.
+
+Merchants must have both Product Recommendations and Catalog Service (v2.2.0+) installed to get complete data through the storefront gateway.
+
+<InlineAlert variant="info" slots="text" />
+
+The `recommendations` query does not support the `alternateEnvironmentId` attribute.
+
+The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) provides a sample `recommendations` query that you can run against a live instance of Adobe Commerce with Luma sample data. Note that the responses may vary, depending on the configuration of the Commerce instance.
+
+## Required headers
+
+You must specify the following HTTP headers to run this query.
+
+import Docs from '/src/_includes/graphql/catalog-service/headers.md'
+
+<Docs />
+
+###  Find the customer group code
+
+import CustomerGroupCode from '/src/_includes/graphql/customer-group-code.md'
+
+<CustomerGroupCode />
+
+## Syntax
+
+```graphql
+recommendations(
+    currentSku: String,
+    userPurchaseHistory: [PurchaseHistory],
+    userViewHistory: [ViewHistory],
+    cartSkus: [String],
+    category: String,
+    pageType: PageType
+): Recommendations
+```
+
+## Example usage
+
+The following query returns product recommendations for SKU `MP01`.
+
+**Request:**
+
+```graphql
+{
+recommendations(currentSku: "MP01", pageType: Product) {
+    totalResults
+    results {
+        unitId
+        unitName
+        totalProducts
+        pageType
+        typeId
+        storefrontLabel
+        displayOrder
+        productsView {
+            sku
+            rank
+            score
+            queryType
+            categories
+            visibility
+        }
+    }
+}
+}
+```
+
+**Response:**
+
+```json
+"data": {
+    "recommendations": {
+        "totalResults": 1,
+        "results": [
+            {
+                "unitId": "6401de2a-7499-4648-847c-b1d62f6ee947",
+                "unitName": "PDMLT",
+                "totalProducts": 5,
+                "pageType": "Product",
+                "typeId": "more-like-this",
+                "storefrontLabel": "PDMLT",
+                "displayOrder": 2,
+                "productsView": [
+                    {
+                        "sku": "MP08",
+                        "rank": 1,
+                        "score": 80.98603,
+                        "queryType": "primary",
+                        "categories": [
+                            "collections/yoga-new",
+                            "men/bottoms-men",
+                            "men/bottoms-men/pants-men",
+                            "promotions/pants-all",
+                            "sale"
+                        ],
+                        "visibility": "Catalog, Search"
+                    },
+                    {
+                        "sku": "WP05",
+                        "rank": 2,
+                        "score": 47.418564,
+                        "queryType": "primary",
+                        "categories": [
+                            "women/bottoms-women",
+                            "women/bottoms-women/pants-women",
+                            "promotions/pants-all",
+                            "collections/erin-recommends"
+                        ],
+                        "visibility": "Catalog, Search"
+                    },
+                    {
+                        "sku": "WP04",
+                        "rank": 3,
+                        "score": 46.906868,
+                        "queryType": "primary",
+                        "categories": [
+                            "women/bottoms-women",
+                            "women/bottoms-women/pants-women",
+                            "promotions/pants-all"
+                        ],
+                        "visibility": "Catalog, Search"
+                    },
+                    {
+                        "sku": "WP02",
+                        "rank": 4,
+                        "score": 44.674534,
+                        "queryType": "primary",
+                        "categories": [
+                            "women/bottoms-women",
+                            "women/bottoms-women/pants-women",
+                            "promotions/pants-all",
+                            "collections/performance-fabrics"
+                        ],
+                        "visibility": "Catalog, Search"
+                    },
+                    {
+                        "sku": "WP01",
+                        "rank": 5,
+                        "score": 41.731136,
+                        "queryType": "primary",
+                        "categories": [
+                            "women/bottoms-women",
+                            "women/bottoms-women/pants-women",
+                            "promotions/pants-all",
+                            "collections/performance-fabrics"
+                        ],
+                        "visibility": "Catalog, Search"
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+## Input fields
+
+Field | Data type | Description
+--- | --- | ---
+`cartSKUs` | [String] | SKUs of the products in the cart.
+`category` | String | The category currently being viewed.
+`currentSKU` | String |  SKU of the product currently being viewed on the product detail page.
+`pageType` | PageType  | An enum indicating the type of page on which recommendations are requested. Possible values are Cart, Category, Checkout, CMS, PageBuilder and Product.
+`userPurchaseHistory` | [PurchaseHistory] | User purchase history with timestamp.
+`userViewHistory` | [ViewHistory] | User view history with timestamp.
+
+### PurchasedHistory
+
+Field | Data type | Description
+--- | --- | ---
+`date` | DateTime | Date of purchase
+`items` | [String]! | A list of items purchased
+
+### ViewHistory
+
+Field | Data type | Description
+--- | --- | ---
+`date` | DateTime | The time the items were viewed
+`sku` | [String]! | A list of SKUs viewed
+
+## Output fields
+
+The `Recommendations` object contains details about recommended products for a given SKU. It contains the following attributes.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`results` | [RecommendationUnit] | Array of recommendation units for recommended products
+`totalResults` | Int | Total number of recommendation units for returned recommendation
+
+### RecommendationUnit attributes
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`displayOrder` | Int | Order in which recommendation units are displayed
+`pageType` | String | Page Type
+`productsView` | [ProductView] | List of product view
+`storefrontLabel` | String | Storefront label to be displayed on the storefront
+`totalProducts` | Int | Total number of products returned for a recommendation
+`typeId` | String | Type of recommendation
+`unitId` | String | Id of the preconfigured unit
+`unitName` | String | Name of the preconfigured unit
+
+### ProductView interface
+
+The `ProductView` return object is an interface that can contain the following fields. It is implemented by the `SimpleProductView` and `ComplexProductView` types. Both these types contain the same set of fields as `ProductView`.
+
+Attribute |  Data Type | Description
+--- | --- | ---
+`categories` | [String] | List of categories to which the product belongs
+`rank` | Int | Rank given to a product
+`queryType` | String | Indicates if the product was retrieved from the primary or backup query
+`score` | Float | Score indicating relevance of the product to the recommendation type
+`sku` | String! | The product SKU
+`visibility` | String | Visibility setting of the product

--- a/src/pages/graphql/schema/products/queries/categories.md
+++ b/src/pages/graphql/schema/products/queries/categories.md
@@ -7,7 +7,7 @@ edition: paas
 
 <InlineAlert variant="important" slots="text" />
 
-Adobe Commerce as a Cloud Service does not support the `categories` query. Use the Catalog Service [`categories` query](https://developer.adobe.com/commerce/services/graphql/catalog-service/categories/) instead.
+Adobe Commerce as a Cloud Service does not support the `categories` query. Use the Catalog Service [`categories` query](../../catalog-service/queries/categories.md) instead.
 
 The `categories` query returns a list of categories that match the specified filter. This query differs from the `categoryList` query in that it supports pagination.
 

--- a/src/pages/graphql/schema/products/queries/products.md
+++ b/src/pages/graphql/schema/products/queries/products.md
@@ -11,7 +11,7 @@ The `products` query allows you to search for catalog items.
 
 <InlineAlert variant="important" slots="text" />
 
-Adobe Commerce as a Cloud Service does not support the `products` query. Use the Catalog Service [`products` query](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/) instead.
+Adobe Commerce as a Cloud Service does not support the `products` query. Use the Catalog Service [`products` query](../../catalog-service/queries/products.md) instead.
 
 ## Syntax
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) moves the Catalog Service, Live Search, and Recommendatoins queries from the services repo. This essentially reverts #222.

This PR cannot be merged until we get word from the Devsite team that the redirects implemented for [DEVSITE-956](https://jira.corp.adobe.com/browse/DEVSITE-956) have been reversed.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
