### PR TITLE
Add routes for ACCS Async/bulk REST APIs

### DIFF
--- a/src/pages/rest/use-rest/asynchronous-web-endpoints.md
+++ b/src/pages/rest/use-rest/asynchronous-web-endpoints.md
@@ -14,7 +14,7 @@ An asynchronous web endpoint intercepts messages to a Web API and writes them to
 
 <InlineAlert variant="success" slots="text"/>
 
-Use the `bin/magento queue:consumers:start async.operations.all` command to start the consumer that handles asynchronous and bulk API messages.
+&#8203;<Edition name="paas" /> Use the `bin/magento queue:consumers:start async.operations.all` command to start the consumer that handles asynchronous and bulk API messages.
 
 Commerce supports the following types of asynchronous requests:
 
@@ -27,16 +27,21 @@ Commerce supports the following types of asynchronous requests:
 
 GET requests are not supported. Although Commerce does not currently implement any PATCH requests, they are supported in custom extensions.
 
-The route to all asynchronous calls contains the prefix `/async`, added before `/V1` of a standard synchronous endpoint. For example:
+The route to all asynchronous calls varies between platforms:
+
+&#8203;<Edition name="paas" /> In Adobe Commerce on Cloud and on-premises projects, the route contains the prefix `/async`, added before `/V1` of a standard synchronous endpoint. For example:
 
 ```http
-POST /async/V1/products
-PUT /async/V1/products/:sku
+POST https://<host>/rest/<store-view-code>/async/V1/products
+PUT https://<host>/rest/<store-view-code>/async/V1/products/:sku
 ```
 
-<Vars.sitedatavarce/> and <Vars.sitedatavaree/> installations support asynchronous web endpoints.
+&#8203;<Edition name="saas" /> In Adobe Commerce as a Cloud Service,  the `/async` segment occurs after the `V1` segment of the route. For example:
 
-The [REST API documentation](/rest/) provides a list of all current synchronous Commerce API routes.
+```http
+POST https://<server>.api.commerce.adobe.com/<tenant-id>/V1/async/products
+PUT https://<server>.api.commerce.adobe.com/<tenant-id>/V1/async/products/:sku
+```
 
 The response of an asynchronous request contains the following fields:
 
@@ -53,9 +58,8 @@ Field name | Data type | Description
 
 The following call asynchronously changes the price of the product that has a `sku` of `24-MB01`:
 
-```http
-PUT <host>/rest/<store_code>/async/V1/products/24-MB01
-```
+&#8203;<Edition name="paas" /> `PUT https://<host>/rest/<store-view-code>/async/V1/products/24-MB01`
+&#8203;<Edition name="saas" /> `PUT https://<server>.api.commerce.adobe.com/<tenant-id>/V1/async/products/24-MB01`
 
 ### Payload
 
@@ -86,6 +90,8 @@ Commerce generates a `bulk_uuid` for each asynchronous request. Use the `bulk_uu
 ```
 
 ## Store scopes
+
+<Edition name="paas" />
 
 You can specify a store code (which is labeled in the Admin as store view code) in the route of an asynchronous endpoint so that it operates on a specific store, as shown below:
 

--- a/src/pages/rest/use-rest/bulk-endpoints.md
+++ b/src/pages/rest/use-rest/bulk-endpoints.md
@@ -21,9 +21,18 @@ Before using the Bulk API to process messages, you must install and configure Ra
 
 To call a bulk endpoint, add the prefix `/async/bulk` before the `/V1` of a synchronous endpoint route. For example:
 
-```http
-POST /async/bulk/V1/products
-POST /async/bulk/V1/customers
+<Edition name="paas" />
+
+```text
+POST https://<host>/rest/<store-view-code>/async/bulk/V1/products
+POST https://<host>/rest/<store-view-code>/async/bulk/V1/customers
+```
+
+<Edition name="saas" />
+
+```text
+POST https://<server>.api.commerce.adobe.com/<tenant-id>/async/bulk/V1/products
+POST https://<server>.api.commerce.adobe.com/<tenant-id>/async/bulk/V1/customers
 ```
 
 Endpoint routes that contain input parameters require additional changes. For example, `PUT /V1/products/:sku/media/:entryId` contains the `:sku` and `:entryId` input parameters. The route of a bulk request cannot contain input parameters, so you must change the route so that it does not contain any. To do this, replace the colon (`:`) with `by` and change the first letter of the parameter to uppercase.
@@ -32,8 +41,8 @@ The following table provides several examples:
 
 Synchronous route | Bulk route
 --- | ---
-`PUT /V1/products/:sku/media/:entryId` | `PUT async/bulk/V1/products/bySku/media/byEntryId`
-`POST /V1/carts/:quoteId/items` | `POST async/bulk/V1/carts/byQuoteId/items`
+`PUT <server-path>/V1/products/:sku/media/:entryId` | `PUT <server-path>/async/bulk/V1/products/bySku/media/byEntryId`
+`POST <server-path>/V1/carts/:quoteId/items` | `POST <server-path>/async/bulk/V1/carts/byQuoteId/items`
 
 <InlineAlert variant="info" slots="text"/>
 
@@ -41,7 +50,7 @@ GET requests are not supported.
 
 ## Payloads
 
-The payload of a bulk request contains an array of request bodies. For example, the minimal payload for creating four customers with `POST /async/bulk/V1/customers` would be structured as follows:
+The payload of a bulk request contains an array of request bodies. For example, the minimal payload for creating four customers with `POST <server-path>/async/bulk/V1/customers` would be structured as follows:
 
 ```json
 [{
@@ -121,7 +130,7 @@ The response contains an array that indicates whether the call successfully adde
 The following call asynchronously deletes CMS blocks with IDs `1` and `2`:
 
 ```http
-DELETE <host>/rest/async/bulk/V1/cmsPage/byPageId
+DELETE <server-path>/async/bulk/V1/cmsPage/byPageId
 ```
 
 ### DELETE request payload
@@ -138,6 +147,8 @@ DELETE <host>/rest/async/bulk/V1/cmsPage/byPageId
 ```
 
 ## Store scopes
+
+<edition name="paas" />
 
 You can specify a store code (which is labeled in the Admin as store view code) in the route of an asynchronous endpoint so that it operates on a specific store, as shown below:
 
@@ -157,6 +168,9 @@ PUT /all/async/bulk/V1/products/bySku
 
 ## Fallback and creating/updating objects when setting store scopes
 
+<edition name="paas" />
+
+When you create or update an object, such as a product, you can specify the store code in the request. If you do not specify a store code, Commerce uses the default store scope.
 The following rules apply when you create or update an object, such as a product.
 
 *  If you do not set the store code while creating a new product, Commerce creates a new object with all values set globally for each scope.

--- a/src/pages/rest/use-rest/bulk-endpoints.md
+++ b/src/pages/rest/use-rest/bulk-endpoints.md
@@ -135,6 +135,10 @@ The response contains an array that indicates whether the call successfully adde
 
 ## DELETE requests
 
+<InlineAlert variant="info" slots="text"/>
+
+The following example is PaaS-specific. Adobe Commerce as a Cloud Service does not support the `DELETE V1/cmsPage` endpoint or its bulk and asynchronous counterparts.
+
 The following call asynchronously deletes CMS blocks with IDs `1` and `2`:
 
 ```http

--- a/src/pages/rest/use-rest/bulk-endpoints.md
+++ b/src/pages/rest/use-rest/bulk-endpoints.md
@@ -30,7 +30,7 @@ POST https://<host>/rest/<store-view-code>/async/bulk/V1/products
 PUT https://<host>/rest/<store-view-code>/async/bulk/V1/products/:sku
 ```
 
-&#8203;<Edition name="saas" /> In Adobe Commerce as a Cloud Service,  the `/async/bulk` segment occurs after the `V1` segment of the route. For example:
+&#8203;<Edition name="saas" /> In Adobe Commerce as a Cloud Service, the `/async/bulk` segment occurs after the `V1` segment of the route. For example:
 
 ```http
 POST https://<server>.api.commerce.adobe.com/<tenant-id>/V1/async/bulk/products

--- a/src/pages/rest/use-rest/operation-status-endpoints.md
+++ b/src/pages/rest/use-rest/operation-status-endpoints.md
@@ -17,7 +17,7 @@ Adobe Commerce generates a `bulk_uuid` each time it executes an [asynchronous AP
 
 ## Get the status summary
 
-The `GET <host>/rest/<store_code>/V1/bulk/:bulkUuid/status` endpoint returns the abbreviated status of the specified operation:
+The `GET /V1/bulk/:bulkUuid/status` endpoint returns the abbreviated status of the specified operation:
 
 Field name | Data type | Description
 --- | --- | ---
@@ -33,7 +33,12 @@ Field name | Data type | Description
 `user_id` | Integer | The user ID that executed the request.
 `operation_count` | Integer | The number of operations processed in the request.
 
-**Response:**
+**Request**:
+
+&#8203;<Edition name="paas" /> `GET https://<host>/rest/<store-view-code>/V1/bulk/:bulkUuid/status`
+&#8203;<Edition name="saas" /> `GET https://<server>.api.commerce.adobe.com/<tenant-id>/V1/bulk/:bulkUuid/status`
+
+**Response**:
 
 ```json
 {
@@ -56,7 +61,7 @@ Field name | Data type | Description
 
 ## Get operations count by bulk uuid and status
 
-The `GET <host>/rest/<store_code>/V1/bulk/:bulkUuid/operation-status/:status` endpoint returns the number of operations from the bulk batch that have the specified status.
+The `GET /V1/bulk/:bulkUuid/operation-status/:status` endpoint returns the number of operations from the bulk batch that have the specified status.
 
 Status | Description
 --- | ---
@@ -66,7 +71,12 @@ Status | Description
 `4` | Open
 `5` | Rejected
 
-**Response:**
+**Request**:
+
+&#8203;<Edition name="paas" /> `GET https://<host>/rest/<store-view-code>/V1/bulk/:bulkUuid/operation-status/:status`
+&#8203;<Edition name="saas" /> `GET https://<server>.api.commerce.adobe.com/<tenant-id>/V1/bulk/:bulkUuid/operation-status/:status`
+
+**Response**:
 
 ```json
 0
@@ -75,10 +85,6 @@ Status | Description
 ## Get the detailed status
 
 The `GET /V1/bulk/:bulkUuid/detailed-status` endpoint returns detailed information about status of a specified operation. It is similar to the `GET /V1/bulk/:bulkUuid/status` endpoint, except that the `operations_list` array also contains the message queue topic name and serialized data for each operation.
-
-```http
-GET <host>/rest/<store_code>/V1/bulk/:bulkUuid/detailed-status
-```
 
 Field name | Data type | Description
 --- | --- | ---
@@ -98,7 +104,12 @@ Field name | Data type | Description
 `user_id` | Integer | The user ID that executed the request.
 `operation_count` | Integer | The number of operations processed in the request.
 
-**Response:**
+**Request**:
+
+&#8203;<Edition name="paas" /> `GET https://<host>/rest/<store-view-code>/V1/bulk/:bulkUuid/detailed-status`
+&#8203;<Edition name="saas" /> `GET https://<server>.api.commerce.adobe.com/<tenant-id>/V1/bulk/:bulkUuid/detailed-status`
+
+**Response**:
 
 ```json
 {

--- a/src/pages/rest/use-rest/operation-status-search.md
+++ b/src/pages/rest/use-rest/operation-status-search.md
@@ -27,12 +27,15 @@ You can specify any of the following fields to filter on operation statuses:
 
 The following call returns bulk operations that contain an error that cannot be retried.
 
-```http
-GET <host>/rest/<store_code>/V1/bulk/?
+&#8203;<Edition name="paas" /> `GET <host>/rest/<store_code>/V1/bulk/?
 searchCriteria[filter_groups][0][filters][0][field]=status&
 searchCriteria[filter_groups][0][filters][0][value]=3&
-searchCriteria[filter_groups][0][filters][0][condition_type]=eq
-```
+searchCriteria[filter_groups][0][filters][0][condition_type]=eq`
+
+&#8203;<Edition name="saas" /> `GET https://<server>.api.commerce.adobe.com/<tenant-id>/V1/bulk/?
+searchCriteria[filter_groups][0][filters][0][field]=status&
+searchCriteria[filter_groups][0][filters][0][value]=3&
+searchCriteria[filter_groups][0][filters][0][condition_type]=eq`
 
 See [Search using REST APIs](/rest/use-rest/performing-searches/) for more information about the syntax of search requests.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the docs for the asynchronous and bulk REST APIs to include routes for ACCS

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
