### PR TITLE
Add PaaS only badge to API key header

### DIFF
--- a/src/_includes/graphql/catalog-service/headers.md
+++ b/src/_includes/graphql/catalog-service/headers.md
@@ -5,4 +5,4 @@ Header | Description
 `Magento-Store-Code`| The code assigned to the store associated with the active store view. For example, `main_website_store`.
 `Magento-Store-View-Code`| The code assigned to the active store view. For example, `default`.
 `Magento-Website-Code`| The code assigned to the website associated with the active store view. For example, `base`.
-`X-Api-Key` | Set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.
+`X-Api-Key` |  &#8203;<Edition name="paas" /> Set this value to the [unique API key](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas#genapikey) generated for your Commerce environment.


### PR DESCRIPTION
## Purpose of this pull request

Add a `paas only` badge to the X-API-Key header for Catalog Service and Product Recommendations GraphQL queries.

## Affected pages

- https://developer.adobe.com/commerce/webapi/graphql/schema/catalog-service/queries/categories/
- https://developer.adobe.com/commerce/webapi/graphql/schema/catalog-service/queries/products/
- https://developer.adobe.com/commerce/webapi/graphql/schema/catalog-service/queries/refine-product/
- https://developer.adobe.com/commerce/webapi/graphql/schema/catalog-service/queries/product-variants/
- https://developer.adobe.com/commerce/webapi/graphql/schema/product-recommendations/queries/recommendations/

