### PR TITLE
Add badging to GraphQL tutorial

### DIFF
--- a/src/pages/graphql/schema/customer/mutations/create-v2.md
+++ b/src/pages/graphql/schema/customer/mutations/create-v2.md
@@ -22,7 +22,7 @@ The [`createCustomerV2`](https://developer.adobe.com/commerce/webapi/graphql-api
 
 ## Example usage
 
-<TabsBlock orientation="horizontal" slots="heading, content" repeat="2" theme="light"/>
+The following examples demonstrate the `createCustomerV2` mutation.
 
 ### Create a customer
 
@@ -56,7 +56,7 @@ mutation {
 ```json
 {
   "data": {
-    "createCustomer": {
+    "createCustomerV2": {
       "customer": {
         "firstname": "Bob",
         "lastname": "Loblaw",

--- a/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
+++ b/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
@@ -3,6 +3,7 @@ title: Step 3. Add products to the cart
 description: Learn how to add products to a cart with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout

--- a/src/pages/graphql/tutorials/checkout/apply-coupon.md
+++ b/src/pages/graphql/tutorials/checkout/apply-coupon.md
@@ -3,6 +3,7 @@ title: Step 7. Apply a coupon
 description: Learn how to set a apply a coupon to an order with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout

--- a/src/pages/graphql/tutorials/checkout/create-cart.md
+++ b/src/pages/graphql/tutorials/checkout/create-cart.md
@@ -3,6 +3,7 @@ title: Step 2. Create an empty cart
 description: Learn how to create a cart with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout

--- a/src/pages/graphql/tutorials/checkout/create-customer.md
+++ b/src/pages/graphql/tutorials/checkout/create-customer.md
@@ -3,6 +3,7 @@ title: Step 1. Create a customer
 description: Learn how to create a customer with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout
@@ -20,7 +21,7 @@ Use the `createCustomer` mutation to register the new customer account in the st
 
 ```graphql
 mutation {
-  createCustomer(
+  createCustomerV2(
     input: {
       firstname: "John"
       lastname: "Doe"
@@ -44,11 +45,11 @@ mutation {
 ```json
 {
   "data": {
-    "createCustomer": {
+    "createCustomerV2": {
       "customer": {
-        "firstname": "John",
-        "lastname": "Doe",
-        "email": "john.doe@example.com",
+        "firstname": "Bob",
+        "lastname": "Loblaw",
+        "email": "bobloblaw@example.com",
         "is_subscribed": true
       }
     }

--- a/src/pages/graphql/tutorials/checkout/index.md
+++ b/src/pages/graphql/tutorials/checkout/index.md
@@ -3,6 +3,7 @@ title: GraphQL checkout tutorial
 description: Learn how to place an order with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout

--- a/src/pages/graphql/tutorials/checkout/place-order.md
+++ b/src/pages/graphql/tutorials/checkout/place-order.md
@@ -3,6 +3,7 @@ title: Step 10. Place the order
 description: Learn how to place an order with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout

--- a/src/pages/graphql/tutorials/checkout/set-billing-address.md
+++ b/src/pages/graphql/tutorials/checkout/set-billing-address.md
@@ -3,6 +3,7 @@ title: Step 5. Set billing address
 description: Learn how to set a billing address for an order with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout

--- a/src/pages/graphql/tutorials/checkout/set-delivery-method.md
+++ b/src/pages/graphql/tutorials/checkout/set-delivery-method.md
@@ -3,6 +3,7 @@ title: Step 6. Set the delivery method
 description: Learn how to set a delivery method for an order with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout

--- a/src/pages/graphql/tutorials/checkout/set-email-address.md
+++ b/src/pages/graphql/tutorials/checkout/set-email-address.md
@@ -3,6 +3,7 @@ title: Step 8. Set email on the cart
 description: Learn how to set a an email address for an order with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout

--- a/src/pages/graphql/tutorials/checkout/set-payment-method.md
+++ b/src/pages/graphql/tutorials/checkout/set-payment-method.md
@@ -3,6 +3,7 @@ title: Step 9. Set the payment method
 description: Learn how to set a payment method for an order with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout

--- a/src/pages/graphql/tutorials/checkout/set-shipping-address.md
+++ b/src/pages/graphql/tutorials/checkout/set-shipping-address.md
@@ -3,6 +3,7 @@ title: Step 4. Set the shipping address
 description: Learn how to set a shipping address for an order with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout

--- a/src/pages/graphql/tutorials/checkout/set-shipping-method.md
+++ b/src/pages/graphql/tutorials/checkout/set-shipping-method.md
@@ -3,6 +3,7 @@ title: Step 6. Set the delivery method
 description: Learn how to set a shipping method for an order with the GraphQL API.
 contributor_name: Atwix
 contributor_link: https://www.atwix.com/
+edition: paas
 keywords:
   - GraphQL
   - Checkout


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds badging to the GraphQL tutorial. I also updated the tutorial to use the `createCustomerV2` mutation instead of the deprecated `createCustomer`. 

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
