### PR TITLE
CEXT-5060: Extend REST API by adding custom attributes to /V1/carts endpoint

### DIFF
--- a/src/pages/rest/modules/custom-attributes.md
+++ b/src/pages/rest/modules/custom-attributes.md
@@ -31,7 +31,7 @@ Adobe Commerce as a Cloud Service does not support REST endpoints that modify th
 
 When the quote is converted to an order, the custom attributes are copied to the order.
 
-The following example shows how to set custom attributes on a cart. The `quote` object contains the `custom_attributes` array, which includes the custom attributes to set.
+The following example shows how to set custom attributes on a cart when assigning a customer to a cart. The `quote` object contains the `custom_attributes` array, which includes the custom attributes to set.
 
 ```curl
 curl -i -X PUT \
@@ -56,7 +56,30 @@ curl -i -X PUT \
     ]
   }
 }' \
- 'https://<COMMERCE_URL>/rest/all/V1/carts/'
+ 'https://<COMMERCE_URL>/rest/all/V1/carts/{cartId}'
+```
+
+The `POST /V1/carts/{cartId}/customAttributes` endpoint allows you to set or update custom attributes on already existing carts. The request body must include the `cart_id` and an array of `custom_attributes`.
+
+```curl
+curl -i -X POST \
+   -H "Content-Type:application/json" \
+   -H "Authorization:Bearer <TOKEN>" \
+   -d \
+'{
+  "cart_id": "20",
+  "custom_attributes":[       
+    {
+       "attribute_code": "attr_one",
+       "value": "value_one"
+    },
+    {
+       "attribute_code": "attr_two",
+       "value": "value_two"
+    }
+  ]
+}' \
+ 'https://<COMMERCE_URL>/rest/all/V1/carts/{cartId}/customAttributes'
 ```
 
 A quote item with custom attributes can be added/updated using `PUT /V1/carts/{cartId}/items/:itemId`.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds an example of how to set custom attributes on a cart. This is added in the 0.4.0 release of custom attributes.
https://jira.corp.adobe.com/browse/CEXT-5060

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi/rest/modules/custom-attributes/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
