### PR TITLE
ACP2E-4064: [Documentation] Update public docs regarding credit cards saved in Vault for PayPal PayFlow Pro for more than 12 months

### DIFF
--- a/src/pages/graphql/payment-methods/payflow-pro-vault.md
+++ b/src/pages/graphql/payment-methods/payflow-pro-vault.md
@@ -18,6 +18,8 @@ The following conditions must be true to use this payment method:
 
 You cannot use this payment method if the customer decides to use a credit or debit card that is not stored in the vault.
 
+PayPal PayFlow Pro transaction IDs (PNREFs) are valid for use in Reference Transactions for a fixed period of 12 months. Once expired, the saved card will no longer be displayed and must be added again.
+
 If the customer's stored payment information becomes outdated, use the [deletePaymentToken mutation](../schema/checkout/mutations/delete-payment-token.md) to remove the token. Then perform the actions described in the [PayPal Payflow Pro payment method](../payment-methods/payflow-pro.md) to generate a new token and process the order.
 
 <InlineAlert variant="info" slots="text" />


### PR DESCRIPTION
Updated according to the changes in ACP2E-4064

## Purpose of this pull request

This pull request (PR) adds information according to the changes in ACP2E-4064

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://developer.adobe.com/commerce/webapi/graphql/payment-methods/payflow-pro-vault/

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
