### PR TITLE
Add 2 mutations to left nav

### DIFF
--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -240,6 +240,14 @@ module.exports = [
                 path: "/graphql/schema/cart/mutations/create-guest-cart/",
               },
               {
+                title: "estimateShippingMethods",
+                path: "/graphql/schema/cart/mutations/estimate-shipping-methods/",
+              },
+              {
+                title: "estimateTotals",
+                path: "/graphql/schema/cart/mutations/estimate-totals/",
+              },
+              {
                 title: "mergeCarts",
                 path: "/graphql/schema/cart/mutations/merge/",
               },


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the `estimateShippingMethods` and `estimateTotals` mutations to the left navigation.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
Added the `estimateShippingMethods` and `estimateTotals` mutations to the left navigation.