### PR TITLE
Remove try it button

### DIFF
--- a/src/openapi/.redocly.yaml
+++ b/src/openapi/.redocly.yaml
@@ -1,5 +1,6 @@
 # See https://docs.redoc.ly/cli/configuration/ for more information.
 organization: adobe-developers
+hideTryItPanel: true
 extends:
     - minimal
 apis:


### PR DESCRIPTION
This PR attempts to fix the undesired inclusion of the "Try it" button. It adds the schema names to the configuration file, in hopes that this change will cause the schemas to respect the settings that hide the button.

I've also changed some manual settings in Redocly.