### PR TITLE
Add separate links to PaaS and SaaS schemas

### DIFF
--- a/src/data/navigation/sections/graphql.js
+++ b/src/data/navigation/sections/graphql.js
@@ -212,7 +212,7 @@ module.exports = [
                 path: "/graphql/schema/cart/mutations/apply-coupons/"
               },
               {
-                title: "applyGiftCartToCart",
+                title: "applyGiftCardToCart",
                 path: "/graphql/schema/cart/mutations/apply-giftcard/",
               },
               {

--- a/src/pages/graphql/schema/attributes/interfaces/index.md
+++ b/src/pages/graphql/schema/attributes/interfaces/index.md
@@ -8,18 +8,27 @@ import CustomerS3Download from '/src/_includes/graphql/examples/customer-s3-down
 
 # Attribute interfaces and implementations
 
-Adobe Commerce provides the following interfaces to access system attributes and custom attributes defined by the merchant.
+Adobe Commerce on cloud and on-premises (PaaS) provides the following interfaces to access system attributes and custom attributes defined by the merchant.
 
 Interface | Implementations
 --- | ---
 [`AttributeSelectedOptionInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-AttributeSelectedOptionInterface) | [`AttributeSelectedOption`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-AttributeSelectedOption)
-[`AttributeValueInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-AttributeValueInterface) | [`AttributeValue`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-AttributeValue) <br/>[`AttributeSelectedOptions`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-AttributeSelectedOptions) <br/>`AttributeFile` (SaaS only) <br/>`AttributeImage` (SaaS only)
+[`AttributeValueInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-AttributeValueInterface) | [`AttributeValue`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-AttributeValue) <br/>[`AttributeSelectedOptions`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-AttributeSelectedOptions)
 [`CustomAttributeMetadataInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CustomerAttributeMetadata) | [`AttributeMetadata`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-AttributeMetadata)
 [`CustomAttributeOptionInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CustomAttributeOptionInterface) | [`AttributeOptionMetadata`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-AttributeOptionMetadata).
 
+The following table lists the same interfaces and implementations with links to the **Adobe Commerce as a Cloud Service (SaaS)** GraphQL reference.
+
+Interface | Implementations
+--- | ---
+[`AttributeSelectedOptionInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-AttributeSelectedOptionInterface) | [`AttributeSelectedOption`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-AttributeSelectedOption)
+[`AttributeValueInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-AttributeValueInterface) | [`AttributeValue`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-AttributeValue) <br/>[`AttributeSelectedOptions`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-AttributeSelectedOptions) <br/>[`AttributeFile`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-AttributeFile) <br/>[`AttributeImage`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-AttributeImage)
+[`CustomAttributeMetadataInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-CustomerAttributeMetadata) | [`AttributeMetadata`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-AttributeMetadata)
+[`CustomAttributeOptionInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-CustomAttributeOptionInterface) | [`AttributeOptionMetadata`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-AttributeOptionMetadata).
+
 <InlineAlert variant="info" slots="text"/>
 
-Adobe Commerce as a Cloud Service (SaaS) provides two additional implementations of the `AttributeValueInterface` interface (`AttributeFile` and `AttributeImage`) to handle files and images uploaded to Amazon S3. If you are migrating from Adobe Commerce on Cloud Infrastructure or on-premise, these changes represent a backward incompatible change. If your project uses custom attributes for files or images, you must update your code to use the new implementations.
+SaaS provides two additional implementations of the `AttributeValueInterface` interface (`AttributeFile` and `AttributeImage`) to handle files and images uploaded to Amazon S3. If you are migrating from Adobe Commerce on Cloud Infrastructure or on-premise, these changes represent a backward incompatible change. If your project uses custom attributes for files or images, you must update your code to use the new implementations.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/mutations/set-custom-cart-item.md
+++ b/src/pages/graphql/schema/attributes/mutations/set-custom-cart-item.md
@@ -28,7 +28,9 @@ mutation {
 
 ## Reference
 
-The [`setCustomAttributesOnCartItem`](/graphql-api/saas/index.html#mutation-setCustomAttributesOnCartItem) reference provides detailed information about the types and fields defined in this mutation.
+The `setCustomAttributesOnCartItem` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnCartItem)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/mutations/set-custom-cart.md
+++ b/src/pages/graphql/schema/attributes/mutations/set-custom-cart.md
@@ -28,7 +28,9 @@ mutation {
 
 ## Reference
 
-The [`setCustomAttributesOnCart`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnCart) reference provides detailed information about the types and fields defined in this mutation.
+The `setCustomAttributesOnCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/mutations/set-custom-credit-memo-item.md
+++ b/src/pages/graphql/schema/attributes/mutations/set-custom-credit-memo-item.md
@@ -26,7 +26,9 @@ mutation {
 
 ## Reference
 
-The [`setCustomAttributesOnCreditMemoItem`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnCreditMemoItem) reference provides detailed information about the types and fields defined in this mutation.
+The `setCustomAttributesOnCreditMemoItem` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnCreditMemoItem)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/mutations/set-custom-credit-memo.md
+++ b/src/pages/graphql/schema/attributes/mutations/set-custom-credit-memo.md
@@ -26,7 +26,9 @@ mutation {
 
 ## Reference
 
-The [`setCustomAttributesOnCreditMemo`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnCreditMemo) reference provides detailed information about the types and fields defined in this mutation.
+The `setCustomAttributesOnCreditMemo` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnCreditMemo)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/mutations/set-custom-invoice-item.md
+++ b/src/pages/graphql/schema/attributes/mutations/set-custom-invoice-item.md
@@ -26,7 +26,9 @@ mutation {
 
 ## Reference
 
-The [`setCustomAttributesOnInvoiceItem`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnInvoiceItem) reference provides detailed information about the types and fields defined in this mutation.
+The `setCustomAttributesOnInvoiceItem` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnInvoiceItem)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/mutations/set-custom-invoice.md
+++ b/src/pages/graphql/schema/attributes/mutations/set-custom-invoice.md
@@ -26,7 +26,9 @@ mutation {
 
 ## Reference
 
-The [`setCustomAttributesOnInvoice`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnInvoice) reference provides detailed information about the types and fields defined in this mutation.
+The `setCustomAttributesOnInvoice` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setCustomAttributesOnInvoice)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/queries/attributes-form.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-form.md
@@ -31,7 +31,11 @@ You cannot query on the Admin Checkout form.
 
 ## Reference
 
-The [`attributesForm`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-attributesForm) reference provides detailed information about the types and fields defined in this query.
+The `attributesForm` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-attributesForm)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-attributesForm)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/queries/attributes-list.md
+++ b/src/pages/graphql/schema/attributes/queries/attributes-list.md
@@ -14,7 +14,11 @@ The possible values for this attribute are populated by the modules introducing 
 
 ## Reference
 
-The [`attributesList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-attributesList) reference provides detailed information about the types and fields defined in this query.
+The `attributesList` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-attributesList)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-attributesList)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata-v2.md
+++ b/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata-v2.md
@@ -21,9 +21,9 @@ This new query has several features that were not available in the deprecated qu
 
 The `customAttributeMetadataV2` reference provides detailed information about the types and fields defined in this query.
 
-* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-customAttributeMetadataV2)
+- &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-customAttributeMetadataV2)
 
-* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customAttributeMetadataV2)
+- &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customAttributeMetadataV2)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata-v2.md
+++ b/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata-v2.md
@@ -19,7 +19,11 @@ This new query has several features that were not available in the deprecated qu
 
 ## Reference
 
-The [`customAttributeMetadataV2`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customAttributeMetadataV2) reference provides detailed information about the types and fields defined in this query.
+The `customAttributeMetadataV2` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-customAttributeMetadataV2)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customAttributeMetadataV2)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata.md
+++ b/src/pages/graphql/schema/attributes/queries/custom-attribute-metadata.md
@@ -18,7 +18,9 @@ The `StorefrontProperties` output object returns information about a product att
 
 ## Reference
 
-The [`customAttributeMetadata`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customAttributeMetadata) reference provides detailed information about the types and fields defined in this query.
+The `customAttributeMetadata` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customAttributeMetadata)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/create-role.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create-role.md
@@ -36,7 +36,11 @@ mutation {
 
 ## Reference
 
-The [`createCompanyRole`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompanyRole) reference provides detailed information about the types and fields defined in this mutation.
+The `createCompanyRole` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createCompanyRole)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompanyRole)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/create-team.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create-team.md
@@ -34,7 +34,11 @@ mutation {
 
 ## Reference
 
-The [`createCompanyTeam`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompanyTeam) reference provides detailed information about the types and fields defined in this mutation.
+The `createCompanyTeam` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createCompanyTeam)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompanyTeam)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/create-user.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create-user.md
@@ -40,7 +40,11 @@ mutation {
 
 ## Reference
 
-The [`createCompanyUser`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompanyUser) reference provides detailed information about the types and fields defined in this mutation.
+The `createCompanyUser` reference provides detailed information about the types and fields defined in this mutation.
+
+- &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createCompanyUser)
+
+- &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompanyUser)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/create.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create.md
@@ -28,7 +28,11 @@ mutation {
 
 ## Reference
 
-The [`createCompany`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompany) reference provides detailed information about the types and fields defined in this mutation.
+The `createCompany` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createCompany)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompany)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/delete-role.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/delete-role.md
@@ -32,7 +32,11 @@ mutation {
 
 ## Reference
 
-The [`deleteCompanyRole`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCompanyRole) reference provides detailed information about the types and fields defined in this mutation.
+The `deleteCompanyRole` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deleteCompanyRole)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCompanyRole)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/delete-team.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/delete-team.md
@@ -30,7 +30,11 @@ mutation {
 
 ## Reference
 
-The [`deleteCompanyTeam`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCompanyTeam) reference provides detailed information about the types and fields defined in this mutation.
+The `deleteCompanyTeam` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deleteCompanyTeam)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCompanyTeam)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/update-role.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-role.md
@@ -42,7 +42,11 @@ mutation {
 
 ## Reference
 
-The [`updateCompanyRole`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyRole) reference provides detailed information about the types and fields defined in this mutation.
+The `updateCompanyRole` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCompanyRole)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyRole)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/update-structure.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-structure.md
@@ -30,7 +30,11 @@ mutation {
 
 ## Reference
 
-The [`updateCompanyStructure`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyStructure) reference provides detailed information about the types and fields defined in this mutation.
+The `updateCompanyStructure` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCompanyStructure)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyStructure)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/update-team.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-team.md
@@ -30,7 +30,11 @@ mutation {
 
 ## Reference
 
-The [`updateCompanyTeam`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyTeam) reference provides detailed information about the types and fields defined in this mutation.
+The `updateCompanyTeam` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCompanyTeam)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyTeam)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/update-user.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-user.md
@@ -32,7 +32,11 @@ mutation {
 
 ## Reference
 
-The [`updateCompanyUser`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyUser) reference provides detailed information about the types and fields defined in this mutation.
+The `updateCompanyUser` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCompanyUser)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompanyUser)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/update.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update.md
@@ -28,7 +28,11 @@ mutation {
 
 ## Reference
 
-The [`updateCompany`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompany) reference provides detailed information about the types and fields defined in this mutation.
+The `updateCompany` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCompany)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCompany)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/queries/company.md
+++ b/src/pages/graphql/schema/b2b/company/queries/company.md
@@ -24,7 +24,11 @@ This query requires a valid [customer authentication token](../../../customer/mu
 
 ## Reference
 
-The [`company`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-company) reference provides detailed information about the types and fields defined in this query.
+The `company` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-company)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-company)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/queries/is-company-admin-email-available.md
+++ b/src/pages/graphql/schema/b2b/company/queries/is-company-admin-email-available.md
@@ -20,7 +20,11 @@ This query requires a valid [customer authentication token](../../../customer/mu
 
 ## Reference
 
-The [`isCompanyAdminEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyAdminEmailAvailable) reference provides detailed information about the types and fields defined in this query.
+The `isCompanyAdminEmailAvailable` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-isCompanyAdminEmailAvailable)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyAdminEmailAvailable)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/queries/is-company-email-available.md
+++ b/src/pages/graphql/schema/b2b/company/queries/is-company-email-available.md
@@ -20,7 +20,11 @@ This query requires a valid [customer authentication token](../../../customer/mu
 
 ## Reference
 
-The [`isCompanyEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyEmailAvailable) reference provides detailed information about the types and fields defined in this query.
+The `isCompanyEmailAvailable` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-isCompanyEmailAvailable)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyEmailAvailable)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/queries/is-company-role-name-available.md
+++ b/src/pages/graphql/schema/b2b/company/queries/is-company-role-name-available.md
@@ -32,7 +32,11 @@ This query requires a valid [customer authentication token](../../../customer/mu
 
 ## Reference
 
-The [`isCompanyRoleNameAvailable`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyRoleNameAvailable) reference provides detailed information about the types and fields defined in this query.
+The `isCompanyRoleNameAvailable` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-isCompanyRoleNameAvailable)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyRoleNameAvailable)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/queries/is-company-user-email-available.md
+++ b/src/pages/graphql/schema/b2b/company/queries/is-company-user-email-available.md
@@ -20,7 +20,11 @@ This query requires a valid [customer authentication token](../../../customer/mu
 
 ## Reference
 
-The [`isCompanyUserEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyUserEmailAvailable) reference provides detailed information about the types and fields defined in this query.
+The `isCompanyUserEmailAvailable` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-isCompanyUserEmailAvailable)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isCompanyUserEmailAvailable)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/unions/structure-entity.md
+++ b/src/pages/graphql/schema/b2b/company/unions/structure-entity.md
@@ -16,6 +16,14 @@ See the GraphQL specification for more details about [unions](https://graphql.or
 
 The `CompanyStructureEntity` union provides details about a node in a company structure.
 
+## Reference
+
+The `CompanyStructureEntity` reference provides detailed information about the types and fields defined in this union.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-CompanyStructureEntity)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CompanyStructureEntity)
+
 **Possible types:**
 
 *  `CompanyTeam`

--- a/src/pages/graphql/schema/b2b/negotiable-quote/interfaces/index.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/interfaces/index.md
@@ -12,6 +12,32 @@ import CommerceOnly from '/src/_includes/commerce-only.md'
 
 Negotiable quote queries and mutations can access the following interfaces:
 
-* [`NegotiableQuoteAddressInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-NegotiableQuoteAddressInterface). It is implemented by [`NegotiableQuoteShippingAddress`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-NegotiableQuoteShippingAddress) and  [`NegotiableQuoteBillingAddress`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-NegotiableQuoteBillingAddress).
+* `NegotiableQuoteAddressInterface`
 
-* [`NegotiableQuoteUidNonFatalResultInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-NegotiableQuoteUidNonFatalResultInterface). It is implemented by [`NegotiableQuoteUidOperationSuccess`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-NegotiableQuoteUidOperationSuccess).
+  * &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-NegotiableQuoteAddressInterface)
+
+  * &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-NegotiableQuoteAddressInterface)
+
+  It is implemented by `NegotiableQuoteShippingAddress`
+
+  * &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-NegotiableQuoteShippingAddress)
+
+  * &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-NegotiableQuoteShippingAddress)
+
+  and  `NegotiableQuoteBillingAddress`
+
+  * &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-NegotiableQuoteBillingAddress)
+
+  * &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-NegotiableQuoteBillingAddress)
+
+* `NegotiableQuoteUidNonFatalResultInterface`
+
+  * &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-NegotiableQuoteUidNonFatalResultInterface)
+
+  * &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-NegotiableQuoteUidNonFatalResultInterface)
+
+  It is implemented by `NegotiableQuoteUidOperationSuccess`
+  
+  * &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-NegotiableQuoteUidOperationSuccess)
+
+  * &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-NegotiableQuoteUidOperationSuccess)

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/close.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/close.md
@@ -32,7 +32,11 @@ This mutation requires a valid [customer authentication token](../../../customer
 
 ## Reference
 
-The [`closeNegotiableQuotes`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-closeNegotiableQuotes) reference provides detailed information about the types and fields defined in this mutation.
+The `closeNegotiableQuotes` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-closeNegotiableQuotes)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-closeNegotiableQuotes)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/delete.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/delete.md
@@ -33,7 +33,11 @@ deleteNegotiableQuotes(
 
 ## Reference
 
-The [`deleteNegotiableQuotes`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteNegotiableQuotes) reference provides detailed information about the types and fields defined in this mutation.
+The `deleteNegotiableQuotes` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deleteNegotiableQuotes)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteNegotiableQuotes)
 
 The [`DeleteNegotiableQuoteOperationResult` union](../unions/index.md) is an output object that provides details about the result of a request to delete a negotiable quote. To return these details, specify fragments on the `DeleteNegotiableQuoteOperationFailure` and `NegotiableQuoteUidOperationSuccess` objects. Specify the `__typename` attribute to distinguish the object types in the response.
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/place-order.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/place-order.md
@@ -50,7 +50,11 @@ mutation {
 
 ## Reference
 
-The [`placeNegotiableQuoteOrder`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-placeNegotiableQuoteOrder) reference provides detailed information about the types and fields defined in this mutation.
+The `placeNegotiableQuoteOrder` reference provides detailed information about the types and fields defined in this mutation.
+
+- &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-placeNegotiableQuoteOrder)
+
+- &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-placeNegotiableQuoteOrder)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/remove-items.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/remove-items.md
@@ -28,7 +28,11 @@ This mutation requires a valid [customer authentication token](../../../customer
 
 ## Reference
 
-The [`removeNegotiableQuoteItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeNegotiableQuoteItems) reference provides detailed information about the types and fields defined in this mutation.
+The `removeNegotiableQuoteItems` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeNegotiableQuoteItems)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeNegotiableQuoteItems)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/request.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/request.md
@@ -32,7 +32,11 @@ requestNegotiableQuote(
 
 ## Reference
 
-The [`requestNegotiableQuote`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestNegotiableQuote) reference provides detailed information about the types and fields defined in this mutation.
+The `requestNegotiableQuote` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-requestNegotiableQuote)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestNegotiableQuote)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/send-for-review.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/send-for-review.md
@@ -24,7 +24,11 @@ sendNegotiableQuoteForReview(
 
 ## Reference
 
-The [`sendNegotiableQuoteForReview`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-sendNegotiableQuoteForReview) reference provides detailed information about the types and fields defined in this mutation.
+The `sendNegotiableQuoteForReview` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-sendNegotiableQuoteForReview)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-sendNegotiableQuoteForReview)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/set-billing-address.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/set-billing-address.md
@@ -28,7 +28,11 @@ This query requires a valid [customer authentication token](../../../customer/mu
 
 ## Reference
 
-The [`setNegotiableQuoteBillingAddress`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setNegotiableQuoteBillingAddress) reference provides detailed information about the types and fields defined in this mutation.
+The `setNegotiableQuoteBillingAddress` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setNegotiableQuoteBillingAddress)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setNegotiableQuoteBillingAddress)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/set-payment-method.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/set-payment-method.md
@@ -48,7 +48,11 @@ This mutation requires a valid [customer authentication token](../../../customer
 
 ## Reference
 
-The [`setNegotiableQuotePaymentMethod`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setNegotiableQuotePaymentMethod) reference provides detailed information about the types and fields defined in this mutation.
+The `setNegotiableQuotePaymentMethod` reference provides detailed information about the types and fields defined in this mutation.
+
+- &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setNegotiableQuotePaymentMethod)
+
+- &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setNegotiableQuotePaymentMethod)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/set-shipping-address.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/set-shipping-address.md
@@ -28,7 +28,11 @@ This query requires a valid [customer authentication token](../../../customer/mu
 
 ## Reference
 
-The [`setNegotiableQuoteShippingAddress`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setNegotiableQuoteShippingAddress) reference provides detailed information about the types and fields defined in this mutation.
+The `setNegotiableQuoteShippingAddress` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setNegotiableQuoteShippingAddress)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setNegotiableQuoteShippingAddress)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/set-shipping-methods.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/set-shipping-methods.md
@@ -36,7 +36,11 @@ setNegotiableQuoteShippingMethods(
 
 ## Reference
 
-The [`setNegotiableQuoteShippingMethods`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setNegotiableQuoteShippingMethods) reference provides detailed information about the types and fields defined in this mutation.
+The `setNegotiableQuoteShippingMethods` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setNegotiableQuoteShippingMethods)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setNegotiableQuoteShippingMethods)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/mutations/update-quantities.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/mutations/update-quantities.md
@@ -28,7 +28,11 @@ updateNegotiableQuoteQuantities(
 
 ## Reference
 
-The [`updateNegotiableQuoteQuantities`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateNegotiableQuoteQuantities) reference provides detailed information about the types and fields defined in this mutation.
+The `updateNegotiableQuoteQuantities` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateNegotiableQuoteQuantities)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateNegotiableQuoteQuantities)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/queries/quote.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/queries/quote.md
@@ -22,7 +22,11 @@ negotiableQuote (uid ID!): NegotiableQuote
 
 ## Reference
 
-The [`negotiableQuote`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-negotiableQuote) reference provides detailed information about the types and fields defined in this query.
+The `negotiableQuote` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-negotiableQuote)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-negotiableQuote)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/queries/quotes.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/queries/quotes.md
@@ -28,7 +28,11 @@ This query requires a valid [customer authentication token](../../../customer/mu
 
 ## Reference
 
-The [`negotiableQuotes`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-negotiableQuotes) reference provides detailed information about the types and fields defined in this query.
+The `negotiableQuotes` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-negotiableQuotes)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-negotiableQuotes)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/queries/templates.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/queries/templates.md
@@ -1,6 +1,5 @@
 ---
 title: negotiableQuoteTemplates query  
-edition: saas
 keywords:
   - B2B
 ---
@@ -30,7 +29,11 @@ This query requires a valid [customer authentication token](../../../customer/mu
 
 ## Reference
 
-The [`negotiableQuoteTemplates`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-negotiableQuoteTemplates) reference provides detailed information about the types and fields defined in this query.
+The `negotiableQuoteTemplates` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-negotiableQuoteTemplates)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-negotiableQuoteTemplates)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/negotiable-quote/unions/index.md
+++ b/src/pages/graphql/schema/b2b/negotiable-quote/unions/index.md
@@ -16,7 +16,11 @@ See the GraphQL specification for more details about [unions](https://graphql.or
 
 ## CloseNegotiableQuoteError union
 
-The [`CloseNegotiableQuoteError`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CloseNegotiableQuoteError) union provides details about failed attempts to close one or more negotiable quotes.
+The `CloseNegotiableQuoteError` union provides details about failed attempts to close one or more negotiable quotes.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-CloseNegotiableQuoteError)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CloseNegotiableQuoteError)
 
 **Possible types:**
 
@@ -30,7 +34,11 @@ The [`CloseNegotiableQuoteError`](https://developer.adobe.com/commerce/webapi/gr
 
 ## CloseNegotiableQuoteOperationResult union
 
-The [`CloseNegotiableQuoteOperationResult`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CloseNegotiableQuoteOperationResult) union provides details about the result of a request to close a negotiable quote.
+The `CloseNegotiableQuoteOperationResult` union provides details about the result of a request to close a negotiable quote.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-CloseNegotiableQuoteOperationResult)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CloseNegotiableQuoteOperationResult)
 
 **Possible types:**
 
@@ -43,7 +51,11 @@ The [`CloseNegotiableQuoteOperationResult`](https://developer.adobe.com/commerce
 
 ## CompanyStructureEntity union
 
-The [`CompanyStructureEntity`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CompanyStructureEntity) union provides details about a node in a company structure.
+The `CompanyStructureEntity` union provides details about a node in a company structure.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-CompanyStructureEntity)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CompanyStructureEntity)
 
 **Possible types:**
 
@@ -56,7 +68,11 @@ The [`CompanyStructureEntity`](https://developer.adobe.com/commerce/webapi/graph
 
 ## DeleteNegotiableQuoteError union
 
-The [`DeleteNegotiableQuoteError`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-DeleteNegotiableQuoteError) union provides details about failed attempts to delete one or more negotiable quotes.
+The `DeleteNegotiableQuoteError` union provides details about failed attempts to delete one or more negotiable quotes.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-DeleteNegotiableQuoteError)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-DeleteNegotiableQuoteError)
 
 **Possible types:**
 
@@ -70,7 +86,11 @@ The [`DeleteNegotiableQuoteError`](https://developer.adobe.com/commerce/webapi/g
 
 ## DeleteNegotiableQuoteOperationResult union
 
-The [`DeleteNegotiableQuoteOperationResult`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-DeleteNegotiableQuoteOperationResult) union provides details about the result of a request to delete a negotiable quote.
+The `DeleteNegotiableQuoteOperationResult` union provides details about the result of a request to delete a negotiable quote.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-DeleteNegotiableQuoteOperationResult)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-DeleteNegotiableQuoteOperationResult)
 
 **Possible types:**
 

--- a/src/pages/graphql/schema/b2b/purchase-order-rule/interfaces/index.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/interfaces/index.md
@@ -10,10 +10,25 @@ import CommerceOnly from '/src/_includes/commerce-only.md'
 
 # PurchaseOrderApprovalRuleConditionInterface attributes and implementations
 
-[`PurchaseOrderApprovalRuleConditionInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-PurchaseOrderApprovalRuleConditionInterface) provides details about the approval rule conditions. It has the following implementations:
+`PurchaseOrderApprovalRuleConditionInterface` provides details about the approval rule conditions.
 
-*  [`PurchaseOrderApprovalRuleConditionAmount`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-PurchaseOrderApprovalRuleConditionAmount)
-*  [`PurchaseOrderApprovalRuleConditionQuantity`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-PurchaseOrderApprovalRuleConditionQuantity)
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-PurchaseOrderApprovalRuleConditionInterface)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-PurchaseOrderApprovalRuleConditionInterface)
+
+It has the following implementations:
+
+*  `PurchaseOrderApprovalRuleConditionAmount`
+
+   * &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-PurchaseOrderApprovalRuleConditionAmount)
+
+   * &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-PurchaseOrderApprovalRuleConditionAmount)
+
+*  `PurchaseOrderApprovalRuleConditionQuantity`
+
+   * &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-PurchaseOrderApprovalRuleConditionQuantity)
+
+   * &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-PurchaseOrderApprovalRuleConditionQuantity)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/create.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/create.md
@@ -38,7 +38,11 @@ mutation {
 
 ## Reference
 
-The [`createPurchaseOrderApprovalRule`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createPurchaseOrderApprovalRule) reference provides detailed information about the types and fields defined in this mutation.
+The `createPurchaseOrderApprovalRule` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createPurchaseOrderApprovalRule)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createPurchaseOrderApprovalRule)
 
 ## Headers
 

--- a/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/delete.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/delete.md
@@ -30,7 +30,11 @@ mutation {
 
 ## Reference
 
-The [`deletePurchaseOrderApprovalRule`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deletePurchaseOrderApprovalRule) reference provides detailed information about the types and fields defined in this mutation.
+The `deletePurchaseOrderApprovalRule` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deletePurchaseOrderApprovalRule)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deletePurchaseOrderApprovalRule)
 
 ## Headers
 

--- a/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/update.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/update.md
@@ -30,7 +30,11 @@ mutation {
 
 ## Reference
 
-The [`updatePurchaseOrderApprovalRule`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updatePurchaseOrderApprovalRule) reference provides detailed information about the types and fields defined in this mutation.
+The `updatePurchaseOrderApprovalRule` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updatePurchaseOrderApprovalRule)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updatePurchaseOrderApprovalRule)
 
 ## Headers
 

--- a/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/validate.md
+++ b/src/pages/graphql/schema/b2b/purchase-order-rule/mutations/validate.md
@@ -28,7 +28,11 @@ mutation {
 
 ## Reference
 
-The [`validatePurchaseOrders`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-validatePurchaseOrders) reference provides detailed information about the types and fields defined in this mutation.
+The `validatePurchaseOrders` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-validatePurchaseOrders)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-validatePurchaseOrders)
 
 ## Headers
 

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/add-comment.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/add-comment.md
@@ -26,7 +26,11 @@ mutation {
 
 ## Reference
 
-The [`addPurchaseOrderComment`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addPurchaseOrderComment) reference provides detailed information about the types and fields defined in this mutation.
+The `addPurchaseOrderComment` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addPurchaseOrderComment)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addPurchaseOrderComment)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/add-items-to-cart.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/add-items-to-cart.md
@@ -26,7 +26,11 @@ mutation {
 
 ## Reference
 
-The [`addPurchaseOrderItemsToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addPurchaseOrderItemsToCart) reference provides detailed information about the types and fields defined in this mutation.
+The `addPurchaseOrderItemsToCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addPurchaseOrderItemsToCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addPurchaseOrderItemsToCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/approve.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/approve.md
@@ -26,7 +26,11 @@ mutation {
 
 ## Reference
 
-The [`approvePurchaseOrders`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-approvePurchaseOrders) reference provides detailed information about the types and fields defined in this mutation.
+The `approvePurchaseOrders` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-approvePurchaseOrders)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-approvePurchaseOrders)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/cancel.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/cancel.md
@@ -26,7 +26,11 @@ mutation {
 
 ## Reference
 
-The [`cancelPurchaseOrders`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-cancelPurchaseOrders) reference provides detailed information about the types and fields defined in this mutation.
+The `cancelPurchaseOrders` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-cancelPurchaseOrders)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-cancelPurchaseOrders)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/place-order.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/place-order.md
@@ -30,7 +30,11 @@ mutation {
 
 ## Reference
 
-The [`placeOrderForPurchaseOrder`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-placeOrderForPurchaseOrder) reference provides detailed information about the types and fields defined in this mutation.
+The `placeOrderForPurchaseOrder` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-placeOrderForPurchaseOrder)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-placeOrderForPurchaseOrder)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/place-purchase-order.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/place-purchase-order.md
@@ -30,7 +30,11 @@ mutation {
 
 ## Reference
 
-The [`placePurchaseOrder`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-placePurchaseOrder) reference provides detailed information about the types and fields defined in this mutation.
+The `placePurchaseOrder` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-placePurchaseOrder)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-placePurchaseOrder)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/purchase-order/mutations/reject.md
+++ b/src/pages/graphql/schema/b2b/purchase-order/mutations/reject.md
@@ -26,7 +26,11 @@ mutation {
 
 ## Reference
 
-The [`rejectPurchaseOrders`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-rejectPurchaseOrders) reference provides detailed information about the types and fields defined in this mutation.
+The `rejectPurchaseOrders` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-rejectPurchaseOrders)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-rejectPurchaseOrders)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/add-items-to-cart.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/add-items-to-cart.md
@@ -34,7 +34,11 @@ mutation {
 
 ## Reference
 
-The [`addRequisitionListItemsToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addRequisitionListItemsToCart) reference provides detailed information about the types and fields defined in this mutation.
+The `addRequisitionListItemsToCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addRequisitionListItemsToCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addRequisitionListItemsToCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/add-products.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/add-products.md
@@ -34,7 +34,11 @@ mutation {
 
 ## Reference
 
-The [`addProductsToRequisitionList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addProductsToRequisitionList) reference provides detailed information about the types and fields defined in this mutation.
+The `addProductsToRequisitionList` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addProductsToRequisitionList)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addProductsToRequisitionList)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/clear-customer-cart.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/clear-customer-cart.md
@@ -33,7 +33,11 @@ mutation {
 
 ## Reference
 
-The [`clearCustomerCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-clearCustomerCart) reference provides detailed information about the types and fields defined in this mutation.
+The `clearCustomerCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-clearCustomerCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-clearCustomerCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/copy-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/copy-items.md
@@ -35,7 +35,11 @@ mutation {
 
 ## Reference
 
-The [`copyItemsBetweenRequisitionLists`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-copyItemsBetweenRequisitionLists) reference provides detailed information about the types and fields defined in this mutation.
+The `copyItemsBetweenRequisitionLists` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-copyItemsBetweenRequisitionLists)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-copyItemsBetweenRequisitionLists)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/create.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/create.md
@@ -35,7 +35,11 @@ mutation {
 
 ## Reference
 
-The [`createRequisitionList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createRequisitionList) reference provides detailed information about the types and fields defined in this mutation.
+The `createRequisitionList` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createRequisitionList)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createRequisitionList)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/delete-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/delete-items.md
@@ -34,7 +34,11 @@ mutation {
 
 ## Reference
 
-The [`deleteRequisitionListItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteRequisitionListItems) reference provides detailed information about the types and fields defined in this mutation.
+The `deleteRequisitionListItems` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deleteRequisitionListItems)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteRequisitionListItems)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/delete.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/delete.md
@@ -34,7 +34,11 @@ mutation {
 
 ## Reference
 
-The [`deleteRequisitionList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteRequisitionList) reference provides detailed information about the types and fields defined in this mutation.
+The `deleteRequisitionList` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deleteRequisitionList)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteRequisitionList)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/move-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/move-items.md
@@ -35,7 +35,11 @@ mutation {
 
 ## Reference
 
-The [`moveItemsBetweenRequisitionLists`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-moveItemsBetweenRequisitionLists) reference provides detailed information about the types and fields defined in this mutation.
+The `moveItemsBetweenRequisitionLists` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-moveItemsBetweenRequisitionLists)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-moveItemsBetweenRequisitionLists)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/update-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/update-items.md
@@ -34,7 +34,11 @@ mutation {
 
 ## Reference
 
-The [`updateRequisitionListItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateRequisitionListItems) reference provides detailed information about the types and fields defined in this mutation.
+The `updateRequisitionListItems` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateRequisitionListItems)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateRequisitionListItems)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/update.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/update.md
@@ -36,7 +36,11 @@ mutation {
 
 ## Reference
 
-The [`updateRequisitionList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateRequisitionList) reference provides detailed information about the types and fields defined in this mutation.
+The `updateRequisitionList` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateRequisitionList)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateRequisitionList)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/add-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-products.md
@@ -49,7 +49,11 @@ mutation {
 
 ## Reference
 
-The [`addProductsToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addProductsToCart) reference provides detailed information about the types and fields defined in this mutation.
+The `addProductsToCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addProductsToCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addProductsToCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/apply-coupon.md
+++ b/src/pages/graphql/schema/cart/mutations/apply-coupon.md
@@ -12,7 +12,11 @@ The `applyCouponToCart` mutation applies a predefined coupon code to the specifi
 
 ## Reference
 
-The [`applyCouponToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-applyCouponToCart) reference provides detailed information about the types and fields defined in this mutation.
+The `applyCouponToCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-applyCouponToCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-applyCouponToCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/apply-coupons.md
+++ b/src/pages/graphql/schema/cart/mutations/apply-coupons.md
@@ -18,7 +18,11 @@ The `type` field of the `ApplyCouponsToCartInput` object must be set to either `
 
 ## Reference
 
-The [`applyCouponsToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-applyCouponsToCart) reference provides detailed information about the types and fields defined in this mutation.
+The `applyCouponsToCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-applyCouponsToCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-applyCouponsToCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/apply-giftcard.md
+++ b/src/pages/graphql/schema/cart/mutations/apply-giftcard.md
@@ -16,7 +16,11 @@ The `applyGiftCardToCart` mutation applies a predefined gift card code to the sp
 
 ## Reference
 
-The [`applyGiftCardToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-applyGiftCardToCart) reference provides detailed information about the types and fields defined in this mutation.
+The `applyGiftCardToCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-applyGiftCardToCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-applyGiftCardToCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/apply-reward-points.md
+++ b/src/pages/graphql/schema/cart/mutations/apply-reward-points.md
@@ -18,7 +18,11 @@ Use the [`removeRewardPointsFromCart` mutation](remove-reward-points.md) to undo
 
 ## Reference
 
-The [`applyRewardPointsToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-applyRewardPointsToCart) reference provides detailed information about the types and fields defined in this mutation.
+The `applyRewardPointsToCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-applyRewardPointsToCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-applyRewardPointsToCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/apply-store-credit.md
+++ b/src/pages/graphql/schema/cart/mutations/apply-store-credit.md
@@ -24,7 +24,11 @@ If the amount of available store credit equals or exceeds the grand total of the
 
 ## Reference
 
-The [`applyStoreCreditToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-applyStoreCreditToCart) reference provides detailed information about the types and fields defined in this mutation.
+The `applyStoreCreditToCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-applyStoreCreditToCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-applyStoreCreditToCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/assign-customer-to-guest-cart.md
+++ b/src/pages/graphql/schema/cart/mutations/assign-customer-to-guest-cart.md
@@ -32,7 +32,11 @@ mutation {
 
 ## Reference
 
-The [`assignCustomerToGuestCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-assignCustomerToGuestCart) reference provides detailed information about the types and fields defined in this mutation.
+The `assignCustomerToGuestCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-assignCustomerToGuestCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-assignCustomerToGuestCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/create-guest-cart.md
+++ b/src/pages/graphql/schema/cart/mutations/create-guest-cart.md
@@ -18,7 +18,11 @@ mutation {
 
 ## Reference
 
-The [`createGuestCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createGuestCart) reference provides detailed information about the types and fields defined in this mutation.
+The `createGuestCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createGuestCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createGuestCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
+++ b/src/pages/graphql/schema/cart/mutations/estimate-shipping-methods.md
@@ -19,7 +19,11 @@ mutation {
 
 ## Reference
 
-The [`estimateShippingMethods`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-estimateShippingMethods) reference provides detailed information about the types and fields defined in this mutation.
+The `estimateShippingMethods` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-estimateShippingMethods)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-estimateShippingMethods)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/estimate-totals.md
+++ b/src/pages/graphql/schema/cart/mutations/estimate-totals.md
@@ -19,7 +19,11 @@ mutation {
 
 ## Reference
 
-The [`estimateTotals`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-estimateTotals) reference provides detailed information about the types and fields defined in this mutation.
+The `estimateTotals` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-estimateTotals)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-estimateTotals)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/merge.md
+++ b/src/pages/graphql/schema/cart/mutations/merge.md
@@ -30,7 +30,11 @@ mutation {
 
 ## Reference
 
-The [`mergeCarts`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-mergeCarts) reference provides detailed information about the types and fields defined in this mutation.
+The `mergeCarts` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-mergeCarts)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-mergeCarts)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/place-order.md
+++ b/src/pages/graphql/schema/cart/mutations/place-order.md
@@ -36,7 +36,11 @@ mutation {
 
 ## Reference
 
-The [`placeOrder`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-placeOrder) reference provides detailed information about the types and fields defined in this mutation.
+The `placeOrder` reference provides detailed information about the types and fields defined in this mutation.
+
+- &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-placeOrder)
+
+- &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-placeOrder)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/redeem-giftcard-balance.md
+++ b/src/pages/graphql/schema/cart/mutations/redeem-giftcard-balance.md
@@ -28,7 +28,11 @@ mutation {
 
 ## Reference
 
-The [`redeemGiftCardBalanceAsStoreCredit`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-redeemGiftCardBalanceAsStoreCredit) reference provides detailed information about the types and fields defined in this mutation.
+The `redeemGiftCardBalanceAsStoreCredit` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-redeemGiftCardBalanceAsStoreCredit)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-redeemGiftCardBalanceAsStoreCredit)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/remove-coupon.md
+++ b/src/pages/graphql/schema/cart/mutations/remove-coupon.md
@@ -12,7 +12,11 @@ The `removeCouponFromCart` mutation removes a previously-applied coupon from the
 
 ## Reference
 
-The [`removeCouponFromCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeCouponFromCart) reference provides detailed information about the types and fields defined in this mutation.
+The `removeCouponFromCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeCouponFromCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeCouponFromCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/remove-coupons.md
+++ b/src/pages/graphql/schema/cart/mutations/remove-coupons.md
@@ -16,7 +16,11 @@ The `removeCouponsFromCart` mutation removes previously-applied coupons from the
 
 ## Reference
 
-The [`removeCouponsFromCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeCouponsFromCart) reference provides detailed information about the types and fields defined in this mutation.
+The `removeCouponsFromCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeCouponsFromCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeCouponsFromCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/remove-giftcard.md
+++ b/src/pages/graphql/schema/cart/mutations/remove-giftcard.md
@@ -16,7 +16,11 @@ The `removeGiftCardFromCart` mutation removes a previously-applied gift card fro
 
 ## Reference
 
-The [`removeGiftCardFromCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftCardFromCart) reference provides detailed information about the types and fields defined in this mutation.
+The `removeGiftCardFromCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeGiftCardFromCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftCardFromCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/remove-item.md
+++ b/src/pages/graphql/schema/cart/mutations/remove-item.md
@@ -12,7 +12,11 @@ The `removeItemFromCart` mutation deletes the entire quantity of a specified ite
 
 ## Reference
 
-The [`removeItemFromCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeItemFromCart) reference provides detailed information about the types and fields defined in this mutation.
+The `removeItemFromCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeItemFromCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeItemFromCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/remove-reward-points.md
+++ b/src/pages/graphql/schema/cart/mutations/remove-reward-points.md
@@ -16,7 +16,11 @@ The `removeRewardPointsFromCart` mutation removes all reward points that were pr
 
 ## Reference
 
-The [`removeRewardPointsFromCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeRewardPointsFromCart) reference provides detailed information about the types and fields defined in this mutation.
+The `removeRewardPointsFromCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeRewardPointsFromCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeRewardPointsFromCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/remove-store-credit.md
+++ b/src/pages/graphql/schema/cart/mutations/remove-store-credit.md
@@ -18,7 +18,11 @@ Store credit must be enabled on the store to run this mutation.
 
 ## Reference
 
-The [`removeStoreCreditFromCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeStoreCreditFromCart) reference provides detailed information about the types and fields defined in this mutation.
+The `removeStoreCreditFromCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeStoreCreditFromCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeStoreCreditFromCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/set-billing-address.md
+++ b/src/pages/graphql/schema/cart/mutations/set-billing-address.md
@@ -12,7 +12,11 @@ The `setBillingAddressOnCart` mutation sets the billing address for a specific c
 
 ## Reference
 
-The [`setBillingAddressOnCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setBillingAddressOnCart) reference provides detailed information about the types and fields defined in this mutation.
+The `setBillingAddressOnCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setBillingAddressOnCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setBillingAddressOnCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/set-gift-options.md
+++ b/src/pages/graphql/schema/cart/mutations/set-gift-options.md
@@ -42,7 +42,11 @@ Gift wrapping is available for simple, configurable, bundle products as well as 
 
 ## Reference
 
-The [`setGiftOptionsOnCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setGiftOptionsOnCart) reference provides detailed information about the types and fields defined in this mutation.
+The `setGiftOptionsOnCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setGiftOptionsOnCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setGiftOptionsOnCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/set-guest-email.md
+++ b/src/pages/graphql/schema/cart/mutations/set-guest-email.md
@@ -14,7 +14,11 @@ A logged-in customer specifies an email address when they create an account. The
 
 ## Reference
 
-The [`setGuestEmailOnCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setGuestEmailOnCart) reference provides detailed information about the types and fields defined in this mutation.
+The `setGuestEmailOnCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setGuestEmailOnCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setGuestEmailOnCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/set-payment-method.md
+++ b/src/pages/graphql/schema/cart/mutations/set-payment-method.md
@@ -41,7 +41,11 @@ braintree: {
 
 ## Reference
 
-The [`setPaymentMethodOnCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setPaymentMethodOnCart) reference provides detailed information about the types and fields defined in this mutation.
+The `setPaymentMethodOnCart` reference provides detailed information about the types and fields defined in this mutation.
+
+- &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setPaymentMethodOnCart)
+
+- &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setPaymentMethodOnCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/set-shipping-address.md
+++ b/src/pages/graphql/schema/cart/mutations/set-shipping-address.md
@@ -15,7 +15,11 @@ The `setShippingAddressesOnCart` mutation sets one or more shipping addresses on
 
 ## Reference
 
-The [`setShippingAddressesOnCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setShippingAddressesOnCart) reference provides detailed information about the types and fields defined in this mutation.
+The `setShippingAddressesOnCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setShippingAddressesOnCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setShippingAddressesOnCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/set-shipping-method.md
+++ b/src/pages/graphql/schema/cart/mutations/set-shipping-method.md
@@ -26,7 +26,11 @@ Do not run the `setShippingMethodsOnCart` mutation on in-store pickup orders. In
 
 ## Reference
 
-The [`setShippingMethodsOnCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setShippingMethodsOnCart) reference provides detailed information about the types and fields defined in this mutation.
+The `setShippingMethodsOnCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-setShippingMethodsOnCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-setShippingMethodsOnCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/update-items.md
+++ b/src/pages/graphql/schema/cart/mutations/update-items.md
@@ -16,7 +16,11 @@ Setting the quantity to `0` removes an item from the cart.
 
 ## Reference
 
-The [`updateCartItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCartItems) reference provides detailed information about the types and fields defined in this mutation.
+The `updateCartItems` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCartItems)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCartItems)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/queries/cart.md
+++ b/src/pages/graphql/schema/cart/queries/cart.md
@@ -18,7 +18,11 @@ Cart functionality is defined in the `Quote` module. A Quote represents the cont
 
 ## Reference
 
-The [`cart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-cart) reference provides detailed information about the types and fields defined in this query.
+The `cart` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-cart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-cart)
 
 ## Sample queries
 

--- a/src/pages/graphql/schema/cart/queries/pickup-locations.md
+++ b/src/pages/graphql/schema/cart/queries/pickup-locations.md
@@ -36,7 +36,11 @@ pickupLocations (area: AreaInput filters: PickupLocationFilterInput sort: Pickup
 
 ## Reference
 
-The [`pickupLocations`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-pickupLocations) reference provides detailed information about the types and fields defined in this query.
+The `pickupLocations` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-pickupLocations)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-pickupLocations)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/checkout/mutations/create-braintree-client-token.md
+++ b/src/pages/graphql/schema/checkout/mutations/create-braintree-client-token.md
@@ -2,6 +2,7 @@
 title: createBraintreeClientToken mutation
 contributor_name: Something Digital (now Rightpoint)
 contributor_link: https://www.rightpoint.com/
+ediition: paas
 ---
 
 # createBraintreeClientToken mutation

--- a/src/pages/graphql/schema/checkout/mutations/delete-payment-token.md
+++ b/src/pages/graphql/schema/checkout/mutations/delete-payment-token.md
@@ -24,7 +24,11 @@ mutation {
 
 ## Reference
 
-The [`deletePaymentToken`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deletePaymentToken) reference provides detailed information about the types and fields defined in this mutation.
+The `deletePaymentToken` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deletePaymentToken)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deletePaymentToken)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/checkout/queries/agreements.md
+++ b/src/pages/graphql/schema/checkout/queries/agreements.md
@@ -16,7 +16,11 @@ The `content` field can contain HTML or plain text. Use the `is_html` field dete
 
 ## Reference
 
-The [`checkoutAgreements`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-checkoutAgreements) reference provides detailed information about the types and fields defined in this query.
+The `checkoutAgreements` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-checkoutAgreements)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-checkoutAgreements)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/checkout/queries/customer-payment-tokens.md
+++ b/src/pages/graphql/schema/checkout/queries/customer-payment-tokens.md
@@ -18,7 +18,11 @@ You must specify the customer's authorization token in the header of the call.
 
 ## Reference
 
-The [`customerPaymentTokens`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customerPaymentTokens) reference provides detailed information about the types and fields defined in this query.
+The `customerPaymentTokens` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-customerPaymentTokens)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customerPaymentTokens)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/assign-compare-list.md
+++ b/src/pages/graphql/schema/customer/mutations/assign-compare-list.md
@@ -24,7 +24,11 @@ mutation {
 
 ## Reference
 
-The [`assignCompareListToCustomer`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-assignCompareListToCustomer) reference provides detailed information about the types and fields defined in this mutation.
+The `assignCompareListToCustomer` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-assignCompareListToCustomer)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-assignCompareListToCustomer)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/change-password.md
+++ b/src/pages/graphql/schema/customer/mutations/change-password.md
@@ -14,7 +14,11 @@ To return or modify information about a customer, we recommend you use customer 
 
 ## Reference
 
-The [`changeCustomerPassword`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-changeCustomerPassword) reference provides detailed information about the types and fields defined in this mutation.
+The `changeCustomerPassword` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-changeCustomerPassword)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-changeCustomerPassword)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/confirm-email.md
+++ b/src/pages/graphql/schema/customer/mutations/confirm-email.md
@@ -12,7 +12,11 @@ The `confirmEmail` mutation completes the customer activation process by confirm
 
 ## Reference
 
-The [`confirmEmail`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-confirmEmail) reference provides detailed information about the types and fields defined in this mutation.
+The `confirmEmail` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-confirmEmail)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-confirmEmail)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/create-address.md
+++ b/src/pages/graphql/schema/customer/mutations/create-address.md
@@ -14,7 +14,11 @@ To return or modify information about a customer, we recommend you use customer 
 
 ## Reference
 
-The [`createCustomerAddress`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCustomerAddress) reference provides detailed information about the types and fields defined in this mutation.
+The `createCustomerAddress` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createCustomerAddress)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCustomerAddress)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/create-v2.md
+++ b/src/pages/graphql/schema/customer/mutations/create-v2.md
@@ -18,7 +18,11 @@ As of version 2.4.7, you can use the `custom_attributes` field to define an arra
 
 ## Reference
 
-The [`createCustomerV2`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCustomerV2) reference provides detailed information about the types and fields defined in this mutation.
+The `createCustomerV2` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createCustomerV2)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCustomerV2)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/delete-address-v2.md
+++ b/src/pages/graphql/schema/customer/mutations/delete-address-v2.md
@@ -1,5 +1,6 @@
 ---
 title: deleteCustomerAddressV2 mutation
+edition: saas
 ---
 
 # deleteCustomerAddressV2 mutation
@@ -24,11 +25,11 @@ mutation {
 }
 ```
 
-<!---
 ## Reference
 
-The [`deleteCustomerAddressV2`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deleteCustomerAddressV2) reference provides detailed information about the types and fields defined in this mutation.
--->
+The `deleteCustomerAddressV2` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deleteCustomerAddressV2)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/delete-address.md
+++ b/src/pages/graphql/schema/customer/mutations/delete-address.md
@@ -26,7 +26,11 @@ mutation {
 
 ## Reference
 
-The [`deleteCustomerAddress`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCustomerAddress) reference provides detailed information about the types and fields defined in this mutation.
+The `deleteCustomerAddress` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deleteCustomerAddress)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCustomerAddress)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/generate-token-as-admin.md
+++ b/src/pages/graphql/schema/customer/mutations/generate-token-as-admin.md
@@ -17,7 +17,11 @@ mutation {generateCustomerTokenAsAdmin(input: GenerateCustomerTokenAsAdminInput!
 
 ## Reference
 
-The [`generateCustomerTokenAsAdmin`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-generateCustomerTokenAsAdmin) reference provides detailed information about the types and fields defined in this mutation.
+The `generateCustomerTokenAsAdmin` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-generateCustomerTokenAsAdmin)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-generateCustomerTokenAsAdmin)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/request-password-reset-email.md
+++ b/src/pages/graphql/schema/customer/mutations/request-password-reset-email.md
@@ -33,7 +33,11 @@ Use the value of the token in the `resetPassword` mutation.
 
 ## Reference
 
-The [`requestPasswordResetEmail`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestPasswordResetEmail) reference provides detailed information about the types and fields defined in this mutation.
+The `requestPasswordResetEmail` reference provides detailed information about the types and fields defined in this mutation.
+
+- &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-requestPasswordResetEmail)
+
+- &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestPasswordResetEmail)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/resend-confirmation-email.md
+++ b/src/pages/graphql/schema/customer/mutations/resend-confirmation-email.md
@@ -14,7 +14,11 @@ The mutation returns `true` if the request was successful. Otherwise, it returns
 
 ## Reference
 
-The [`resendConfirmationEmail`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-resendConfirmationEmail) reference provides detailed information about the types and fields defined in this mutation.
+The `resendConfirmationEmail` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-resendConfirmationEmail)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-resendConfirmationEmail)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/reset-password.md
+++ b/src/pages/graphql/schema/customer/mutations/reset-password.md
@@ -22,7 +22,11 @@ The reset password token value can also be found in the `customer_entity`.`rp_to
 
 ## Reference
 
-The [`resetPassword`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-resetPassword) reference provides detailed information about the types and fields defined in this mutation.
+The `resetPassword` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-resetPassword)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-resetPassword)
 
 ## Example usage
 
@@ -63,4 +67,4 @@ Error | Description
 
 ## Related topics
 
--  [requestPasswordResetEmail mutation](request-password-reset-email.md)
+* [requestPasswordResetEmail mutation](request-password-reset-email.md)

--- a/src/pages/graphql/schema/customer/mutations/revoke-token.md
+++ b/src/pages/graphql/schema/customer/mutations/revoke-token.md
@@ -20,7 +20,11 @@ mutation {
 
 ## Reference
 
-The [`revokeCustomerToken`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-revokeCustomerToken) reference provides detailed information about the types and fields defined in this mutation.
+The `revokeCustomerToken` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-revokeCustomerToken)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-revokeCustomerToken)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/subscribe-email-to-newsletter.md
+++ b/src/pages/graphql/schema/customer/mutations/subscribe-email-to-newsletter.md
@@ -14,7 +14,11 @@ The `subscribeEmailToNewsletter` mutation allows guests and registered customers
 
 ## Reference
 
-The [`subscribeEmailToNewsletter`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-subscribeEmailToNewsletter) reference provides detailed information about the types and fields defined in this mutation.
+The `subscribeEmailToNewsletter` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-subscribeEmailToNewsletter)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-subscribeEmailToNewsletter)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/update-address-v2.md
+++ b/src/pages/graphql/schema/customer/mutations/update-address-v2.md
@@ -1,5 +1,6 @@
 ---
 title: updateCustomerAddressV2 mutation
+edition: saas
 ---
 
 # updateCustomerAddressV2 mutation
@@ -25,11 +26,11 @@ mutation {
 }
 ```
 
-<!---
 ## Reference
 
-The [`updateCustomerAddressV2`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCustomerAddressV2) reference provides detailed information about the types and fields defined in this mutation.
--->
+The `updateCustomerAddressV2` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCustomerAddressV2)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/update-address.md
+++ b/src/pages/graphql/schema/customer/mutations/update-address.md
@@ -18,7 +18,11 @@ To return or modify information about a customer, we recommend you use customer 
 
 ## Reference
 
-The [`updateCustomerAddress`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCustomerAddress) reference provides detailed information about the types and fields defined in this mutation.
+The `updateCustomerAddress` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCustomerAddress)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCustomerAddress)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/update-email.md
+++ b/src/pages/graphql/schema/customer/mutations/update-email.md
@@ -14,7 +14,11 @@ To return or modify information about a customer, we recommend you use customer 
 
 ## Reference
 
-The [`updateCustomerEmail`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCustomerEmail) reference provides detailed information about the types and fields defined in this mutation.
+The `updateCustomerEmail` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCustomerEmail)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCustomerEmail)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/mutations/update-v2.md
+++ b/src/pages/graphql/schema/customer/mutations/update-v2.md
@@ -20,7 +20,11 @@ As of version 2.4.7, you can use the `custom_attributes` field to define an arra
 
 ## Reference
 
-The [`updateCustomerV2`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCustomerV2) reference provides detailed information about the types and fields defined in this mutation.
+The `updateCustomerV2` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateCustomerV2)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateCustomerV2)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/queries/cart.md
+++ b/src/pages/graphql/schema/customer/queries/cart.md
@@ -23,7 +23,11 @@ If you know the value of the logged-in customer's cart ID, you can allow the cus
 
 ## Reference
 
-The [`customerCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customerCart) reference provides detailed information about the types and fields defined in this query.
+The `customerCart` reference provides detailed information about the types and fields defined in this query.
+
+- &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-customerCart)
+
+- &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customerCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/queries/customer.md
+++ b/src/pages/graphql/schema/customer/queries/customer.md
@@ -17,7 +17,11 @@ To retrieve information about a customer, we recommend you use customer tokens i
 
 ## Reference
 
-The [`customer`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customer) reference provides detailed information about the types and fields defined in this query.
+The `customer` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-customer)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-customer)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/queries/giftcard-account.md
+++ b/src/pages/graphql/schema/customer/queries/giftcard-account.md
@@ -16,7 +16,11 @@ The `giftCardAccount` query returns information for a specific gift card.
 
 ## Reference
 
-The [`giftCardAccount`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftCardAccount) reference provides detailed information about the types and fields defined in this query.
+The `giftCardAccount` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-giftCardAccount)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftCardAccount)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/customer/queries/is-email-available.md
+++ b/src/pages/graphql/schema/customer/queries/is-email-available.md
@@ -14,7 +14,11 @@ When guest checkout logins are enabled, or in versions prior to 2.4.7, a value o
 
 ## Reference
 
-The [`isEmailAvailable`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isEmailAvailable) reference provides detailed information about the types and fields defined in this query.
+The `isEmailAvailable` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-isEmailAvailable)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-isEmailAvailable)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/mutations/add-registrants.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/add-registrants.md
@@ -27,7 +27,11 @@ mutation {
 
 ## Reference
 
-The [`addGiftRegistryRegistrants`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addGiftRegistryRegistrants) reference provides detailed information about the types and fields defined in this mutation.
+The `addGiftRegistryRegistrants` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addGiftRegistryRegistrants)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addGiftRegistryRegistrants)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/mutations/create.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/create.md
@@ -40,7 +40,11 @@ mutation {
 
 ## Reference
 
-The [`createGiftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createGiftRegistry) reference provides detailed information about the types and fields defined in this mutation.
+The `createGiftRegistry` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createGiftRegistry)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createGiftRegistry)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/mutations/move-cart-items.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/move-cart-items.md
@@ -29,7 +29,11 @@ mutation {
 
 ## Reference
 
-The [`moveCartItemsToGiftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-moveCartItemsToGiftRegistry) reference provides detailed information about the types and fields defined in this mutation.
+The `moveCartItemsToGiftRegistry` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-moveCartItemsToGiftRegistry)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-moveCartItemsToGiftRegistry)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/mutations/remove-items.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/remove-items.md
@@ -27,7 +27,11 @@ mutation {
 
 ## Reference
 
-The [`removeGiftRegistryItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftRegistryItems) reference provides detailed information about the types and fields defined in this mutation.
+The `removeGiftRegistryItems` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeGiftRegistryItems)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftRegistryItems)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/mutations/remove-registrants.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/remove-registrants.md
@@ -27,7 +27,11 @@ mutation {
 
 ## Reference
 
-The [`removeGiftRegistryRegistrants`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftRegistryRegistrants) reference provides detailed information about the types and fields defined in this mutation.
+The `removeGiftRegistryRegistrants` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeGiftRegistryRegistrants)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftRegistryRegistrants)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/mutations/remove.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/remove.md
@@ -20,7 +20,11 @@ removeGiftRegistry ( giftRegistryUid ID! ) RemoveGiftRegistryOutput
 
 ## Reference
 
-The [`removeGiftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftRegistry) reference provides detailed information about the types and fields defined in this mutation.
+The `removeGiftRegistry` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeGiftRegistry)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeGiftRegistry)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/mutations/share.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/share.md
@@ -29,7 +29,11 @@ mutation {
 
 ## Reference
 
-The [`shareGiftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-shareGiftRegistry) reference provides detailed information about the types and fields defined in this mutation.
+The `shareGiftRegistry` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-shareGiftRegistry)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-shareGiftRegistry)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/mutations/update-items.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/update-items.md
@@ -27,7 +27,11 @@ mutation {
 
 ## Reference
 
-The [`updateGiftRegistryItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateGiftRegistryItems) reference provides detailed information about the types and fields defined in this mutation.
+The `updateGiftRegistryItems` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateGiftRegistryItems)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateGiftRegistryItems)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/mutations/update-registrants.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/update-registrants.md
@@ -27,7 +27,11 @@ mutation {
 
 ## Reference
 
-The [`updateGiftRegistryRegistrants`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateGiftRegistryRegistrants) reference provides detailed information about the types and fields defined in this mutation.
+The `updateGiftRegistryRegistrants` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateGiftRegistryRegistrants)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateGiftRegistryRegistrants)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/mutations/update.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/update.md
@@ -29,7 +29,11 @@ mutation {
 
 ## Reference
 
-The [`updateGiftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateGiftRegistry) reference provides detailed information about the types and fields defined in this mutation.
+The `updateGiftRegistry` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateGiftRegistry)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateGiftRegistry)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/queries/email-search.md
+++ b/src/pages/graphql/schema/gift-registry/queries/email-search.md
@@ -18,7 +18,11 @@ giftRegistryEmailSearch(email: String!): [GiftRegistrySearchResult]
 
 ## Reference
 
-The [`giftRegistryEmailSearch`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryEmailSearch) reference provides detailed information about the types and fields defined in this query.
+The `giftRegistryEmailSearch` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-giftRegistryEmailSearch)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryEmailSearch)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/queries/gift-registry.md
+++ b/src/pages/graphql/schema/gift-registry/queries/gift-registry.md
@@ -21,7 +21,11 @@ giftRegistry(uid: ID!): GiftRegistry
 
 ## Reference
 
-The [`giftRegistry`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistry) reference provides detailed information about the types and fields defined in this query.
+The `giftRegistry` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-giftRegistry)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistry)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/queries/id-search.md
+++ b/src/pages/graphql/schema/gift-registry/queries/id-search.md
@@ -18,7 +18,11 @@ giftRegistryIdSearch(giftRegistryUid: String!): [GiftRegistrySearchResult]
 
 ## Reference
 
-The [`giftRegistryIdSearch`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryIdSearch) reference provides detailed information about the types and fields defined in this query.
+The `giftRegistryIdSearch` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-giftRegistryIdSearch)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryIdSearch)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/queries/type-search.md
+++ b/src/pages/graphql/schema/gift-registry/queries/type-search.md
@@ -22,7 +22,11 @@ giftRegistryTypeSearch(
 
 ## Reference
 
-The [`giftRegistryTypeSearch`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryTypeSearch) reference provides detailed information about the types and fields defined in this query.
+The `giftRegistryTypeSearch` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-giftRegistryTypeSearch)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryTypeSearch)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/gift-registry/queries/types.md
+++ b/src/pages/graphql/schema/gift-registry/queries/types.md
@@ -20,7 +20,11 @@ giftRegistryTypes: [GiftRegistryType]
 
 ## Reference
 
-The [`giftRegistryTypes`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryTypes) reference provides detailed information about the types and fields defined in this query.
+The `giftRegistryTypes` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-giftRegistryTypes)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-giftRegistryTypes)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/interfaces/credit-memo-item.md
+++ b/src/pages/graphql/schema/orders/interfaces/credit-memo-item.md
@@ -13,7 +13,11 @@ title: CreditMemoItemInterface attributes and implementations
 
 ## Reference
 
-The [`CreditMemoItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CreditMemoItemInterface) reference provides detailed information about the types and fields defined in this interface.
+The `CreditMemoItemInterface` reference provides detailed information about the types and fields defined in this interface.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-CreditMemoItemInterface)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-CreditMemoItemInterface)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/interfaces/invoice-item.md
+++ b/src/pages/graphql/schema/orders/interfaces/invoice-item.md
@@ -13,7 +13,11 @@ title: InvoiceItemInterface attributes and implementations
 
 ## Reference
 
-The [`InvoiceItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-InvoiceItemInterface) reference provides detailed information about the types and fields defined in this interface.
+The `InvoiceItemInterface` reference provides detailed information about the types and fields defined in this interface.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-InvoiceItemInterface)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-InvoiceItemInterface)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/interfaces/order-item.md
+++ b/src/pages/graphql/schema/orders/interfaces/order-item.md
@@ -13,7 +13,11 @@ title: OrderItemInterface attributes and implementations
 
 ## Reference
 
-The [`OrderItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-OrderItemInterface) reference provides detailed information about the types and fields defined in this interface.
+The `OrderItemInterface` reference provides detailed information about the types and fields defined in this interface.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-OrderItemInterface)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-OrderItemInterface)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/interfaces/shipment-item.md
+++ b/src/pages/graphql/schema/orders/interfaces/shipment-item.md
@@ -12,7 +12,11 @@ title: ShipmentItemInterface attributes and implementations
 
 ## Reference
 
-The [`ShipmentItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-ShipmentItemInterface) reference provides detailed information about the types and fields defined in this interface.
+The `ShipmentItemInterface` reference provides detailed information about the types and fields defined in this interface.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-ShipmentItemInterface)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-ShipmentItemInterface)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/mutations/add-return-comment.md
+++ b/src/pages/graphql/schema/orders/mutations/add-return-comment.md
@@ -16,7 +16,11 @@ mutation: {
 
 ## Reference
 
-The [`addReturnComment`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addReturnComment) reference provides detailed information about the types and fields defined in this mutation.
+The `addReturnComment` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addReturnComment)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addReturnComment)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/mutations/add-return-tracking.md
+++ b/src/pages/graphql/schema/orders/mutations/add-return-tracking.md
@@ -16,7 +16,11 @@ mutation: {
 
 ## Reference
 
-The [`addReturnTracking`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addReturnTracking) reference provides detailed information about the types and fields defined in this mutation.
+The `addReturnTracking` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addReturnTracking)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addReturnTracking)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/mutations/cancel-order.md
+++ b/src/pages/graphql/schema/orders/mutations/cancel-order.md
@@ -22,7 +22,11 @@ The mutation returns an error if the order cannot be cancelled.
 
 ## Reference
 
-The [`cancelOrder`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-cancelOrder) reference provides detailed information about the types and fields defined in this mutation.
+The `cancelOrder` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-cancelOrder)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-cancelOrder)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/mutations/confirm-cancel-order.md
+++ b/src/pages/graphql/schema/orders/mutations/confirm-cancel-order.md
@@ -22,7 +22,11 @@ The mutation returns an error if the order cannot be cancelled.
 
 ## Reference
 
-The [`confirmCancelOrder`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-confirmCancelOrder) reference provides detailed information about the types and fields defined in this mutation.
+The `confirmCancelOrder` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-confirmCancelOrder)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-confirmCancelOrder)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/mutations/confirm-return.md
+++ b/src/pages/graphql/schema/orders/mutations/confirm-return.md
@@ -20,7 +20,11 @@ mutation {
 
 ## Reference
 
-The [`confirmReturn`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-confirmReturn) reference provides detailed information about the types and fields defined in this mutation.
+The `confirmReturn` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-confirmReturn)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-confirmReturn)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/mutations/remove-return-tracking.md
+++ b/src/pages/graphql/schema/orders/mutations/remove-return-tracking.md
@@ -16,7 +16,11 @@ mutation: {
 
 ## Reference
 
-The [`removeReturnTracking`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeReturnTracking) reference provides detailed information about the types and fields defined in this mutation.
+The `removeReturnTracking` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeReturnTracking)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeReturnTracking)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/mutations/reorder-items.md
+++ b/src/pages/graphql/schema/orders/mutations/reorder-items.md
@@ -24,7 +24,11 @@ The `reorderItems` mutation will not add any products to the cart if it encounte
 
 ## Reference
 
-The [`reorderItems`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-reorderItems) reference provides detailed information about the types and fields defined in this mutation.
+The `reorderItems` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-reorderItems)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-reorderItems)
 
 ## Example usage
 
@@ -39,8 +43,8 @@ Sprite Foam Yoga Brick | 24-WG084 | 1
 
 The customer wants to reorder these items, but the status of some of these items has changed:
 
--  Aeon Capri (WP07-29-Black) is in stock, but fewer than three items are available for sale.
--  The Sprite Foam Yoga Brick (24-WG084) is out of stock.
+*  Aeon Capri (WP07-29-Black) is in stock, but fewer than three items are available for sale.
+*  The Sprite Foam Yoga Brick (24-WG084) is out of stock.
 
 These items will not be added to the cart.
 
@@ -147,4 +151,4 @@ mutation{
 
 ## Related topics
 
--  [customer](../../customer/queries/customer.md) query
+*  [customer](../../customer/queries/customer.md) query

--- a/src/pages/graphql/schema/orders/mutations/request-guest-order-cancel.md
+++ b/src/pages/graphql/schema/orders/mutations/request-guest-order-cancel.md
@@ -20,7 +20,11 @@ The mutation returns an error if the order cannot be cancelled.
 
 ## Reference
 
-The [`requestGuestOrderCancel`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestGuestOrderCancel) reference provides detailed information about the types and fields defined in this mutation.
+The `requestGuestOrderCancel` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-requestGuestOrderCancel)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestGuestOrderCancel)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/mutations/request-guest-return.md
+++ b/src/pages/graphql/schema/orders/mutations/request-guest-return.md
@@ -30,7 +30,11 @@ mutation {
 
 ## Reference
 
-The [`requestGuestReturn`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestGuestReturn) reference provides detailed information about the types and fields defined in this mutation.
+The `requestGuestReturn` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-requestGuestReturn)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestGuestReturn)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/mutations/request-return.md
+++ b/src/pages/graphql/schema/orders/mutations/request-return.md
@@ -29,7 +29,11 @@ mutation {
 
 ## Reference
 
-The [`requestReturn`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestReturn) reference provides detailed information about the types and fields defined in this mutation.
+The `requestReturn` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-requestReturn)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-requestReturn)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/queries/guest-order-by-token.md
+++ b/src/pages/graphql/schema/orders/queries/guest-order-by-token.md
@@ -13,7 +13,11 @@ You can retrieve the token from the `CustomerOrder` object on the [`placeOrder` 
 
 ## Reference
 
-The [`guestOrderByToken`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-guestOrderByToken) reference provides detailed information about the types and fields defined in this query.
+The `guestOrderByToken` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-guestOrderByToken)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-guestOrderByToken)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/orders/queries/guest-order.md
+++ b/src/pages/graphql/schema/orders/queries/guest-order.md
@@ -12,7 +12,11 @@ Use the `guestOrder` query to retrieve details about an order placed by a guest 
 
 ## Reference
 
-The [`guestOrder`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-guestOrder) reference provides detailed information about the types and fields defined in this query.
+The `guestOrder` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-guestOrder)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-guestOrder)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/products/mutations/add-products-to-compare-list.md
+++ b/src/pages/graphql/schema/products/mutations/add-products-to-compare-list.md
@@ -24,7 +24,11 @@ mutation {
 
 ## Reference
 
-The [`addProductsToCompareList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addProductsToCompareList) reference provides detailed information about the types and fields defined in this mutation.
+The `addProductsToCompareList` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addProductsToCompareList)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addProductsToCompareList)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/products/mutations/assign-compare-list.md
+++ b/src/pages/graphql/schema/products/mutations/assign-compare-list.md
@@ -24,7 +24,11 @@ mutation {
 
 ## Reference
 
-The [`assignCompareListToCustomer`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-assignCompareListToCustomer) reference provides detailed information about the types and fields defined in this mutation.
+The `assignCompareListToCustomer` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-assignCompareListToCustomer)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-assignCompareListToCustomer)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/products/mutations/create-compare-list.md
+++ b/src/pages/graphql/schema/products/mutations/create-compare-list.md
@@ -24,7 +24,11 @@ mutation {
 
 ## Reference
 
-The [`createCompareList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompareList) reference provides detailed information about the types and fields defined in this mutation.
+The `createCompareList` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createCompareList)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createCompareList)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/products/mutations/delete-compare-list.md
+++ b/src/pages/graphql/schema/products/mutations/delete-compare-list.md
@@ -25,7 +25,11 @@ mutation {
 
 ## Reference
 
-The [`deleteCompareList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCompareList) reference provides detailed information about the types and fields defined in this mutation.
+The `deleteCompareList` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deleteCompareList)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteCompareList)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/products/mutations/remove-from-compare-list.md
+++ b/src/pages/graphql/schema/products/mutations/remove-from-compare-list.md
@@ -24,7 +24,11 @@ mutation {
 
 ## Reference
 
-The [`removeProductsFromCompareList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeProductsFromCompareList) reference provides detailed information about the types and fields defined in this mutation.
+The `removeProductsFromCompareList` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeProductsFromCompareList)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeProductsFromCompareList)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/products/queries/compare-list.md
+++ b/src/pages/graphql/schema/products/queries/compare-list.md
@@ -18,7 +18,11 @@ compareList(
 
 ## Reference
 
-The [`compareList`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-compareList) reference provides detailed information about the types and fields defined in this query.
+The `compareList` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-compareList)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-compareList)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/mutations/contact-us.md
+++ b/src/pages/graphql/schema/store/mutations/contact-us.md
@@ -12,7 +12,11 @@ The `contactUs` mutation submits the contents of the Contact Us form.
 
 ## Reference
 
-The [`contactUs`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-contactUs) reference provides detailed information about the types and fields defined in this mutation.
+The `contactUs` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-contactUs)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-contactUs)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/available-stores.md
+++ b/src/pages/graphql/schema/store/queries/available-stores.md
@@ -16,7 +16,11 @@ Specify the [Store header](../../../usage/headers.md) to determine the scope of 
 
 ## Reference
 
-The [`availableStores`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-availableStores) reference provides detailed information about the types and fields defined in this query.
+The `availableStores` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-availableStores)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-availableStores)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/countries.md
+++ b/src/pages/graphql/schema/store/queries/countries.md
@@ -14,7 +14,11 @@ Use the [country](country.md) query if you want to retrieve information about a 
 
 ## Reference
 
-The [`countries`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-countries) reference provides detailed information about the types and fields defined in this query.
+The `countries` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-countries)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-countries)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/country.md
+++ b/src/pages/graphql/schema/store/queries/country.md
@@ -14,7 +14,11 @@ Use the [countries](../../store/queries/countries.md) query to retrieve a list o
 
 ## Reference
 
-The [`country`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-country) reference provides detailed information about the types and fields defined in this query.
+The `country` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/s://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-country)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-country)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/currency.md
+++ b/src/pages/graphql/schema/store/queries/currency.md
@@ -12,7 +12,11 @@ Use the `currency` query to return information about the store's currency config
 
 ## Reference
 
-The [`currency`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-currency) reference provides detailed information about the types and fields defined in this query.
+The `currency` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-currency)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-currency)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/recaptcha-v3-config.md
+++ b/src/pages/graphql/schema/store/queries/recaptcha-v3-config.md
@@ -12,7 +12,11 @@ The `recaptchaV3Config` query returns information about the reCaptcha V3 configu
 
 ## Reference
 
-The [`recaptchaV3Config`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-recaptchaV3Config) reference provides detailed information about the types and fields defined in this query.
+The `recaptchaV3Config` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-recaptchaV3Config)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-recaptchaV3Config)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/store/queries/store-config.md
+++ b/src/pages/graphql/schema/store/queries/store-config.md
@@ -12,7 +12,11 @@ The `storeConfig` query defines information about a store's configuration. You c
 
 ## Reference
 
-The [`storeConfig`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-storeConfig) reference provides detailed information about the types and fields defined in this query.
+The `storeConfig` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-storeConfig)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-storeConfig)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/interfaces/wishlist.md
+++ b/src/pages/graphql/schema/wishlist/interfaces/wishlist.md
@@ -16,7 +16,11 @@ title: WishlistItemInterface attributes and implementations
 
 ## Reference
 
-The [`WishlistItemInterface`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-WishlistItemInterface) reference provides detailed information about the types and fields defined in this interface.
+The `WishlistItemInterface` reference provides detailed information about the types and fields defined in this interface.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#definition-WishlistItemInterface)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#definition-WishlistItemInterface)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/mutations/add-items-to-cart.md
+++ b/src/pages/graphql/schema/wishlist/mutations/add-items-to-cart.md
@@ -23,7 +23,11 @@ mutation {
 
 ## Reference
 
-The [`addWishlistItemsToCart`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-wishlist) reference provides detailed information about the types and fields defined in this mutation.
+The `addWishlistItemsToCart` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addWishlistItemsToCart)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addWishlistItemsToCart)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/mutations/add-products.md
+++ b/src/pages/graphql/schema/wishlist/mutations/add-products.md
@@ -33,7 +33,11 @@ To determine whether wish lists are enabled, specify the `magento_wishlist_gener
 
 ## Reference
 
-The [`addProductsToWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addProductsToWishlist) reference provides detailed information about the types and fields defined in this mutation.
+The `addProductsToWishlist` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-addProductsToWishlist)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-addProductsToWishlist)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/mutations/copy-products.md
+++ b/src/pages/graphql/schema/wishlist/mutations/copy-products.md
@@ -30,7 +30,11 @@ mutation {
 
 ## Reference
 
-The [`copyProductsBetweenWishlists`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-copyProductsBetweenWishlists) reference provides detailed information about the types and fields defined in this mutation.
+The `copyProductsBetweenWishlists` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-copyProductsBetweenWishlists)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-copyProductsBetweenWishlists)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/mutations/create.md
+++ b/src/pages/graphql/schema/wishlist/mutations/create.md
@@ -32,7 +32,11 @@ mutation {
 
 ## Reference
 
-The [`createWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createWishlist) reference provides detailed information about the types and fields defined in this mutation.
+The `createWishlist` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-createWishlist)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-createWishlist)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/mutations/delete.md
+++ b/src/pages/graphql/schema/wishlist/mutations/delete.md
@@ -22,7 +22,11 @@ mutation {
 
 ## Reference
 
-The [`deleteWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteWishlist) reference provides detailed information about the types and fields defined in this mutation.
+The `deleteWishlist` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-deleteWishlist)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-deleteWishlist)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/mutations/move-products.md
+++ b/src/pages/graphql/schema/wishlist/mutations/move-products.md
@@ -29,7 +29,11 @@ mutation {
 
 ## Reference
 
-The [`moveProductsBetweenWishlists`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-moveProductsBetweenWishlists) reference provides detailed information about the types and fields defined in this mutation.
+The `moveProductsBetweenWishlists` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-moveProductsBetweenWishlists)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-moveProductsBetweenWishlists)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/mutations/remove-products.md
+++ b/src/pages/graphql/schema/wishlist/mutations/remove-products.md
@@ -23,7 +23,11 @@ mutation {
 
 ## Reference
 
-The [`removeProductsFromWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeProductsFromWishlist) reference provides detailed information about the types and fields defined in this mutation.
+The `removeProductsFromWishlist` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-removeProductsFromWishlist)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-removeProductsFromWishlist)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/mutations/update-products.md
+++ b/src/pages/graphql/schema/wishlist/mutations/update-products.md
@@ -27,7 +27,11 @@ mutation {
 
 ## Reference
 
-The [`updateProductsInWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateProductsInWishlist) reference provides detailed information about the types and fields defined in this mutation.
+The `updateProductsInWishlist` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateProductsInWishlist)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateProductsInWishlist)
 
 ## Example usage
 

--- a/src/pages/graphql/schema/wishlist/mutations/update.md
+++ b/src/pages/graphql/schema/wishlist/mutations/update.md
@@ -32,7 +32,11 @@ mutation {
 
 ## Reference
 
-The [`updateWishlist`](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateWishlist) reference provides detailed information about the types and fields defined in this mutation.
+The `updateWishlist` reference provides detailed information about the types and fields defined in this mutation.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-updateWishlist)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#mutation-updateWishlist)
 
 ## Example usage
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request standardizes **Reference** sections across many GraphQL schema topics so readers get separate links to **Adobe Commerce as a Cloud Service (SaaS)** and **Adobe Commerce on cloud and on-premises (PaaS)** SpectaQL documentation when the corresponding operation (or interface) appears in `spectaql/schema_saas.json` and/or `spectaql/schema.json`. Pages that use `edition: saas` or `edition: paas` in the frontmatter were left unchanged. A few B2B interface and union index pages were updated so shared union/interface definitions also expose SaaS and PaaS anchors. 

This PR specifically excludes:

* Updates to the Storefront Services (Catalog Service, Live Search, Product Recommendations). The phrasing in the Reference section probably needs to be different.
* The Payment Services schema. They are installed separately on PaaS, and the phrasing might need to be different there too.
* Some interface/union docs. These don't follow the usual pattern for queries and mutations, and I might need to format these topics differently.

The branch also fixes a navigation label typo for the cart `applyGiftCardToCart` mutation.

## Affected pages

This change spans a large set of GraphQL schema reference topics under the Commerce Web API site (mutations, queries, and selected interface/union documentation). 

## Links to Magento Open Source code

N/A
