### PR TITLE
Fix searchCriteria filter value syntax in documentation

### DIFF
--- a/src/pages/rest/use-rest/search-endpoint.md
+++ b/src/pages/rest/use-rest/search-endpoint.md
@@ -142,7 +142,7 @@ The following example gets all products in a given category:
 ```http
 GET <host>/rest/<store_code>/V1/search?searchCriteria[requestName]=catalog_view_container&
 searchCriteria[filterGroups][0][filters][0][field]=category_ids&
-searchCriteria[filterGroups][0][filters][0][value][0]=4&
+searchCriteria[filterGroups][0][filters][0][value]=4&
 searchCriteria[filterGroups][0][filters][0][condition_type]=eq
 ```
 


### PR DESCRIPTION
## Purpose of this pull request

Fixes issue #432 

Fix searchCriteria filter value syntax in documentation.

## Affected pages

https://developer.adobe.com/commerce/webapi/rest/use-rest/search-endpoint/#example-1
