### PR TITLE
Fix typo in custom-filters documentation

### DIFF
--- a/src/pages/graphql/usage/custom-filters.md
+++ b/src/pages/graphql/usage/custom-filters.md
@@ -145,4 +145,4 @@ When a product requires a filter attribute that is not a field on its output sch
 </type>
 ```
 
-This example adds `field_to_sort` and `other_field_to_sort` attributes to the `additionalAttributes` array defined in the `ProductEntityAttributesForAst` class. The array already contains the `min_price`, `max_price`, and `category_id` attributes.
+This example adds `field_to_sort` and `other_field_to_sort` attributes to the `additionalAttributes` array defined in the `ProductEntityAttributesForAst` class. The array already contains the `min_price`, `max_price`, and `category_uid` attributes.

--- a/src/pages/graphql/usage/custom-filters.md
+++ b/src/pages/graphql/usage/custom-filters.md
@@ -145,4 +145,4 @@ When a product requires a filter attribute that is not a field on its output sch
 </type>
 ```
 
-This example adds `field_to_sort` and `other_field_to_sort` attributes to the `additionalAttributes` array defined in the `ProductEntityAttributesForAst` class. The array already contains the `min_price`, `max_price`, and `category_ids` attributes.
+This example adds `field_to_sort` and `other_field_to_sort` attributes to the `additionalAttributes` array defined in the `ProductEntityAttributesForAst` class. The array already contains the `min_price`, `max_price`, and `category_id` attributes.


### PR DESCRIPTION
## Purpose of this pull request

Fixes issue #406 

Fixes typo in custom-filters documentation:  `catalog_ids` ==> `catalog_uid`  (catalog_id) is deprecated.

## Affected pages

https://developer.adobe.com/commerce/webapi/graphql/usage/custom-filters/#output-attributes