### PR TITLE
CCSAAS-4856 - Add customer JSON import - ACCS

### DIFF
--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -54,24 +54,24 @@ In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does n
 
 * Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
 
-    ```json
-        {
-            "customer": {
-            "email": "user@example.com",
-            "firstname": "User",
-            "lastname": "Name",
-            "website_id": 1,
-            "extension_attributes": {"assistance_allowed": 2}
-            },
-            "password": "Password123!"
-        }
-    ```
+  ```json
+      {
+          "customer": {
+          "email": "user@example.com",
+          "firstname": "User",
+          "lastname": "Name",
+          "website_id": 1,
+          "extension_attributes": {"assistance_allowed": 2}
+          },
+          "password": "Password123!"
+      }
+  ```
 
 * Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
 
-    ```json
-    {"customer": {"extension_attributes": {"assistance_allowed": 2}}}
-    ```
+  ```json
+  {"customer": {"extension_attributes": {"assistance_allowed": 2}}}
+  ```
 
 ### Validation Strategy
 

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -50,11 +50,9 @@ The `import/json` endpoint is designed for JSON data:
 
 #### Customer imports in Adobe Commerce as a Cloud Service
 
-In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does not support the `assistance_allowed` field when the `entity` field is set to `customer`.
+In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does not support the `assistance_allowed` field when the `entity` field is set to `customer`. However, you can create or modify customers that have [remote shopping assistance enabled](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-accounts/manage/login-as-customer#customer-account-permission-for-remote-shopping-assistance) by using the following methods:
 
-If you need to create or modify customers that have [remote shopping assistance enabled](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-accounts/manage/login-as-customer#customer-account-permission-for-remote-shopping-assistance), you can:
-
-* Use `POST /V1/async/bulk/customers` to bulk create customers with assistance_allowed pre-enabled.
+* Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
 
     ```json
         {

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -54,7 +54,7 @@ In Adobe Commerce as a Cloud Service, the customer import API (POST /V1/import/j
 
 If you need to create or modify customers that have [remote shopping assistance enabled](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-accounts/manage/login-as-customer#customer-account-permission-for-remote-shopping-assistance), you can:
 
-- Use `POST /V1/async/bulk/customers` to bulk create customers with assistance_allowed pre-enabled.
+* Use `POST /V1/async/bulk/customers` to bulk create customers with assistance_allowed pre-enabled.
 
     ```json
         {
@@ -69,7 +69,7 @@ If you need to create or modify customers that have [remote shopping assistance 
         }
     ```
 
-- Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
+* Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
 
     ```json
     {"customer": {"extension_attributes": {"assistance_allowed": 2}}}

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -52,7 +52,7 @@ The `import/json` endpoint is designed for JSON data:
 
 In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does not support the `assistance_allowed` field when the `entity` field is set to `customer`. However, you can create or modify customers that have [remote shopping assistance enabled](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-accounts/manage/login-as-customer#customer-account-permission-for-remote-shopping-assistance) by using the following methods:
 
-*  Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
+* Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
 
     ```json
         {
@@ -67,7 +67,7 @@ In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does n
         }
     ```
 
-*  Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
+* Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
 
     ```json
     {"customer": {"extension_attributes": {"assistance_allowed": 2}}}

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -50,28 +50,30 @@ The `import/json` endpoint is designed for JSON data:
 
 #### Customer imports in Adobe Commerce as a Cloud Service
 
-In Adobe Commerce as a Cloud Service, the customer import API (POST /V1/import/json with entity: "customer") does not support assistance_allowed. Attempts to pass it as a field will result in a "Header contains invalid attribute(s): assistance_allowed" error.
+In Adobe Commerce as a Cloud Service, the customer import API (POST /V1/import/json with entity: "customer") does not support `assistance_allowed`.
 
-Alternatively, you can use `POST /V1/async/bulk/customers` to bulk create customers with assistance_allowed pre-enabled.
+If you need to create or modify customers that have [remote shopping assistance enabled](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-accounts/manage/login-as-customer#customer-account-permission-for-remote-shopping-assistance), you can:
 
-```json
-    {
-      "customer": {
-        "email": "user@example.com",
-        "firstname": "User",
-        "lastname": "One",
-        "website_id": 1,
-        "extension_attributes": {"assistance_allowed": 2}
-      },
-      "password": "Password123!"
-    }
-```
+- Use `POST /V1/async/bulk/customers` to bulk create customers with assistance_allowed pre-enabled.
 
-Or individual existing customers using the `PUT /V1/customers/{id}` endpoint:
+    ```json
+        {
+          "customer": {
+            "email": "user@example.com",
+            "firstname": "User",
+            "lastname": "One",
+            "website_id": 1,
+            "extension_attributes": {"assistance_allowed": 2}
+          },
+          "password": "Password123!"
+        }
+    ```
 
-```json
-{"customer": {"extension_attributes": {"assistance_allowed": 2}}}
-```
+- Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
+
+    ```json
+    {"customer": {"extension_attributes": {"assistance_allowed": 2}}}
+    ```
 
 ### Validation Strategy
 

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -48,6 +48,31 @@ The `import/json` endpoint is designed for JSON data:
 *  Convert your CSV into JSON using any trustworthy online converter.
 *  When converting CSV to JSON using standard tools or libraries, special characters within the data are typically escaped automatically. Ensure that any manual edits or custom conversion processes handle this escaping appropriately.
 
+#### Customer imports in Adobe Commerce as a Cloud Service
+
+In Adobe Commerce as a Cloud Service, the customer import API (POST /V1/import/json with entity: "customer") does not support assistance_allowed. Attempts to pass it as a field will result in a "Header contains invalid attribute(s): assistance_allowed" error.
+
+Alternatively, you can use `POST /V1/async/bulk/customers` to bulk create customers with assistance_allowed pre-enabled.
+
+```json
+    {
+      "customer": {
+        "email": "user@example.com",
+        "firstname": "User",
+        "lastname": "One",
+        "website_id": 1,
+        "extension_attributes": {"assistance_allowed": 2}
+      },
+      "password": "Password123!"
+    }
+```
+
+Or individual existing customers using the `PUT /V1/customers/{id}` endpoint:
+
+```json
+{"customer": {"extension_attributes": {"assistance_allowed": 2}}}
+```
+
 ### Validation Strategy
 
 A validation strategy is mandatory. Depending on your chosen strategy, the API will either proceed with the import or abort it upon encountering invalid rows.

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -52,26 +52,26 @@ The `import/json` endpoint is designed for JSON data:
 
 In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does not support the `assistance_allowed` field when the `entity` field is set to `customer`. However, you can create or modify customers that have [remote shopping assistance enabled](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-accounts/manage/login-as-customer#customer-account-permission-for-remote-shopping-assistance) by using the following methods:
 
-* Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
+Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
 
-    ```json
-        {
-          "customer": {
-            "email": "user@example.com",
-            "firstname": "User",
-            "lastname": "One",
-            "website_id": 1,
-            "extension_attributes": {"assistance_allowed": 2}
-          },
-          "password": "Password123!"
-        }
-    ```
+```json
+    {
+        "customer": {
+        "email": "user@example.com",
+        "firstname": "User",
+        "lastname": "One",
+        "website_id": 1,
+        "extension_attributes": {"assistance_allowed": 2}
+        },
+        "password": "Password123!"
+    }
+```
 
-* Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
+Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
 
-    ```json
-    {"customer": {"extension_attributes": {"assistance_allowed": 2}}}
-    ```
+```json
+{"customer": {"extension_attributes": {"assistance_allowed": 2}}}
+```
 
 ### Validation Strategy
 

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -54,24 +54,26 @@ In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does n
 
 * Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
 
-  ```json
-      {
-          "customer": {
-          "email": "user@example.com",
-          "firstname": "User",
-          "lastname": "Name",
-          "website_id": 1,
-          "extension_attributes": {"assistance_allowed": 2}
-          },
-          "password": "Password123!"
-      }
-  ```
+   ```json
+    {
+    "customer": {
+        "email": "user@example.com",
+        "firstname": "User",
+        "lastname": "Name",
+        "website_id": 1,
+        "extension_attributes": {
+        "assistance_allowed": 2
+        }
+    },
+    "password": "Password123!"
+    }
+   ```
 
 * Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
 
-  ```json
-  {"customer": {"extension_attributes": {"assistance_allowed": 2}}}
-  ```
+   ```json
+   {"customer": {"extension_attributes": {"assistance_allowed": 2}}}
+   ```
 
 ### Validation Strategy
 

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -55,16 +55,16 @@ In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does n
 *  Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
 
     ```json
-        {
-          "customer": {
-            "email": "user@example.com",
-            "firstname": "User",
-            "lastname": "One",
-            "website_id": 1,
-            "extension_attributes": {"assistance_allowed": 2}
-          },
-          "password": "Password123!"
-        }
+        {
+          "customer": {
+            "email": "user@example.com",
+            "firstname": "User",
+            "lastname": "One",
+            "website_id": 1,
+            "extension_attributes": {"assistance_allowed": 2}
+          },
+          "password": "Password123!"
+        }
     ```
 
 *  Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -52,26 +52,26 @@ The `import/json` endpoint is designed for JSON data:
 
 In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does not support the `assistance_allowed` field when the `entity` field is set to `customer`. However, you can create or modify customers that have [remote shopping assistance enabled](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-accounts/manage/login-as-customer#customer-account-permission-for-remote-shopping-assistance) by using the following methods:
 
-Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
+* Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
 
-```json
-    {
-        "customer": {
-        "email": "user@example.com",
-        "firstname": "User",
-        "lastname": "One",
-        "website_id": 1,
-        "extension_attributes": {"assistance_allowed": 2}
-        },
-        "password": "Password123!"
-    }
-```
+    ```json
+        {
+            "customer": {
+            "email": "user@example.com",
+            "firstname": "User",
+            "lastname": "Name",
+            "website_id": 1,
+            "extension_attributes": {"assistance_allowed": 2}
+            },
+            "password": "Password123!"
+        }
+    ```
 
-Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
+* Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
 
-```json
-{"customer": {"extension_attributes": {"assistance_allowed": 2}}}
-```
+    ```json
+    {"customer": {"extension_attributes": {"assistance_allowed": 2}}}
+    ```
 
 ### Validation Strategy
 

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -50,7 +50,7 @@ The `import/json` endpoint is designed for JSON data:
 
 #### Customer imports in Adobe Commerce as a Cloud Service
 
-In Adobe Commerce as a Cloud Service, the customer import API (POST /V1/import/json with entity: "customer") does not support `assistance_allowed`.
+In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does not support the `assistance_allowed` field when the `entity` field is set to `customer`.
 
 If you need to create or modify customers that have [remote shopping assistance enabled](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-accounts/manage/login-as-customer#customer-account-permission-for-remote-shopping-assistance), you can:
 

--- a/src/pages/rest/modules/import/index.md
+++ b/src/pages/rest/modules/import/index.md
@@ -52,7 +52,7 @@ The `import/json` endpoint is designed for JSON data:
 
 In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does not support the `assistance_allowed` field when the `entity` field is set to `customer`. However, you can create or modify customers that have [remote shopping assistance enabled](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-accounts/manage/login-as-customer#customer-account-permission-for-remote-shopping-assistance) by using the following methods:
 
-* Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
+*  Use `POST /V1/async/bulk/customers` to bulk create customers with `assistance_allowed` pre-enabled.
 
     ```json
         {
@@ -67,7 +67,7 @@ In Adobe Commerce as a Cloud Service, the `POST /V1/import/json` endpoint does n
         }
     ```
 
-* Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
+*  Use the `PUT /V1/customers/{id}` endpoint to modify existing customers individually.
 
     ```json
     {"customer": {"extension_attributes": {"assistance_allowed": 2}}}


### PR DESCRIPTION
This PR adds a workaround to let users import customer info with `assitance_allowed` enabled as it is not available in the import/json.