### PR TITLE
Response code of 200 when an error occurs

### DIFF
--- a/src/pages/graphql/usage/api-response.md
+++ b/src/pages/graphql/usage/api-response.md
@@ -15,7 +15,7 @@ Each GraphQL API call returns an HTTP status code that reflects the result of a 
 
 HTTP code | Meaning | Description
 --- | --- | ---
-200 | Success | The framework returns HTTP 200 to the caller upon success.
+200 | Success | The framework returns HTTP 200 to the caller upon success. This code can also be returned whenever the server successfully parses and begins executing the request but encounters a business logic error before completion.
 401 | Unauthorized | The caller was not authorized to perform the request. For example, the request included an invalid token, or a user with customer permissions attempted to access an object that requires administrator permissions.
 403 | Forbidden | Access is not allowed for reasons that are not covered by error code 401.
 500 | System Errors | If service implementation throws any other exception, such as a network error or database communication failure, the framework returns HTTP 500.


### PR DESCRIPTION
This pull request clarifies the **HTTP 200** row in the GraphQL API response documentation: a 200 response can indicate not only full success but also cases where the server successfully parses and starts executing the request but then hits a **business logic error** before completion.

Fixes #405 

## Affected pages
- [GraphQL API response](https://developer.adobe.com/commerce/webapi/graphql/usage/api-response)
## Links to Magento Open Source code
N/A
<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->
