### PR TITLE
Add reference sections/links to a couple of schema topics

### DIFF
--- a/src/pages/graphql/schema/customer/mutations/exchange-otp-customer-token.md
+++ b/src/pages/graphql/schema/customer/mutations/exchange-otp-customer-token.md
@@ -14,6 +14,10 @@ Upon successful exchange, the module invalidates the OTP so it cannot be reused.
 `mutation: {
     exchangeOtpForCustomerToken(email: String!, otp: String!) {CustomerToken}}`
 
+## Reference
+
+The [`exchangeOtpForCustomerToken`](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#mutation-exchangeOtpForCustomerToken) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 The following example uses the specified email and one-time password (OTP) to return a customer token.

--- a/src/pages/graphql/schema/store/queries/recaptcha-form-config.md
+++ b/src/pages/graphql/schema/store/queries/recaptcha-form-config.md
@@ -20,7 +20,6 @@ The `recaptchaFormConfig` reference provides detailed information about the type
 
 * &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-recaptchaV3Config)
 
-
 ## Example usage
 
 The following query returns information about the reCaptcha configuration for the CONTACT form:

--- a/src/pages/graphql/schema/store/queries/recaptcha-form-config.md
+++ b/src/pages/graphql/schema/store/queries/recaptcha-form-config.md
@@ -12,9 +12,14 @@ You can use the [`recaptchaV3Config` query](recaptcha-v3-config.md) to return a 
 
 `recaptchaFormConfig(formType: ReCaptchaFormEnum!): ReCaptchaConfigOutput`
 
-## References
+## Reference
 
-The `recaptchaFormConfig` reference provides detailed information about the types and fields defined in this mutation.
+The `recaptchaFormConfig` reference provides detailed information about the types and fields defined in this query.
+
+* &#8203;<Edition name="saas" /> [Adobe Commerce as a Cloud Service](https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-recaptchaFormConfig)
+
+* &#8203;<Edition name="paas" /> [On-Premises/Cloud](https://developer.adobe.com/commerce/webapi/graphql-api/index.html#query-recaptchaV3Config)
+
 
 ## Example usage
 


### PR DESCRIPTION
## Purpose of this pull request

Adds **Reference** sections to two GraphQL topic pages, linking out to the autogenerated API reference for the `exchangeOtpForCustomerToken` mutation and the `recaptchaFormConfig` query. Also corrects a copy error in `recaptcha-form-config.md` that described the query as a mutation, and updates the `recaptchaFormConfig` reference section to include edition-specific links (Adobe Commerce as a Cloud Service and On-Premises/Cloud).

## Affected pages

- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/exchange-otp-customer-token
- https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/recaptcha-form-config

## Links to Magento Open Source code

N/A