### PR TITLE
style(docs): switch contributor edition labels from blue to gray

### DIFF
--- a/src/pages/graphql/develop/debugging.md
+++ b/src/pages/graphql/develop/debugging.md
@@ -1,8 +1,6 @@
 ---
 title: Debugging GraphQL queries
 description: Learn how to use PhpStorm and Xdebug to debug GraphQL API queries.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
 ---
@@ -35,6 +33,6 @@ As a result, Xdebug within the PHP execution attempts to make a connection to an
 *  [GraphQL request headers](../usage/headers.md)
 *  [Exception handling](exceptions.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/develop/extend-existing-schema.md
+++ b/src/pages/graphql/develop/extend-existing-schema.md
@@ -1,8 +1,6 @@
 ---
 title: Extend an existing GraphQL schema
 description: Learn how to add attributes and data types, modify resolver behavior, and add features using extension points.
-contributor_name: Adarsh Manickam
-contributor_link: https://github.com/drpayyne
 keywords:
   - GraphQL
 ---
@@ -138,6 +136,6 @@ type StoreConfig {
 -  [Resolvers](resolvers.md)
 -  [Declarative schema](https://developer.adobe.com/commerce/php/development/components/declarative-schema/)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Adarsh Manickam for contributing this topic!](https://github.com/drpayyne)

--- a/src/pages/graphql/develop/functional-testing.md
+++ b/src/pages/graphql/develop/functional-testing.md
@@ -1,8 +1,6 @@
 ---
 title: GraphQL functional testing
 description: Learn how to use the Adobe Commerce and Magento Open Source test framework to create fixtures, define exceptions, and run finctional tests.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
 ---
@@ -361,6 +359,6 @@ To run the `testFunction1` and `testFunction2` tests, which are part of the `my_
 vendor/bin/phpunit -c dev/tests/api-functional/phpunit_graphql.xml --group my_test_group dev/tests/api-functional/testsuite/Magento/GraphQl/MyTest.php
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/payment-methods/braintree-vault.md
+++ b/src/pages/graphql/payment-methods/braintree-vault.md
@@ -1,8 +1,6 @@
 ---
 title: Braintree Vault payment method
 description: Learn how to use the GraphQL API mutation for the Braintree Vault payment solution.
-contributor_name: Something Digital (now Rightpoint)
-contributor_link: https://www.rightpoint.com/
 keywords:
   - GraphQL
   - Payments
@@ -95,6 +93,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Something Digital (now Rightpoint) for contributing this topic!](https://www.rightpoint.com/)

--- a/src/pages/graphql/payment-methods/braintree.md
+++ b/src/pages/graphql/payment-methods/braintree.md
@@ -1,8 +1,6 @@
 ---
 title: Braintree payment method
 description: Learn how to use the GraphQL API mutation for the Braintree payment solution.
-contributor_name: Something Digital (now Rightpoint)
-contributor_link: https://www.rightpoint.com/
 keywords:
   - GraphQL
   - Payments
@@ -104,6 +102,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Something Digital (now Rightpoint) for contributing this topic!](https://www.rightpoint.com/)

--- a/src/pages/graphql/payment-methods/klarna.md
+++ b/src/pages/graphql/payment-methods/klarna.md
@@ -1,8 +1,6 @@
 ---
 title: Klarna payment method
 description: Learn how to use the GraphQL API mutation for the Klarna payment solution.
-contributor_name: Klarna
-contributor_link: https://www.klarna.com/
 keywords:
   - GraphQL
   - Payments
@@ -141,6 +139,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Klarna for contributing this topic!](https://www.klarna.com/)

--- a/src/pages/graphql/schema/b2b/company/mutations/create-role.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create-role.md
@@ -1,8 +1,6 @@
 ---
 title: createCompanyRole mutation
 description: The createCompanyRole mutation defines a new company role. To create a role, you must provide an array of permissions that determine which resources the us...
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -134,6 +132,6 @@ mutation {
 | `User role with this name already exists. Enter a different name to save this role.` | The company cannot have multiple company roles with the same name. |
 | `Unable to set "allow" for the resource because its parent resource(s) is set to "deny".` | To allow permission for the company role, you must allow all the permissions of the parent tree. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/company/mutations/create-team.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create-team.md
@@ -1,8 +1,6 @@
 ---
 title: createCompanyTeam mutation
 description: Use the createCompanyTeam mutation to create a new team for your company.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -115,6 +113,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/company/mutations/create-user.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create-user.md
@@ -1,8 +1,6 @@
 ---
 title: createCompanyUser mutation
 description: The createCompanyUser mutation allows an existing company user who is assigned a role that contains the MagentoCompany::usersedit permission to create a ne...
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -172,6 +170,6 @@ mutation {
 | `Required parameters are missing: xxx` | The `input`.`xxx` argument was omitted or contains an empty value. |
 | `No such entity with roleId = xxx` | The company role with ID `xxx` doesn't exist. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/company/mutations/delete-role.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/delete-role.md
@@ -1,8 +1,6 @@
 ---
 title: deleteCompanyRole mutation
 description: Use the deleteCompanyRole mutation to delete a company role by ID.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -65,6 +63,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/company/mutations/delete-team.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/delete-team.md
@@ -1,8 +1,6 @@
 ---
 title: deleteCompanyTeam mutation
 description: Use the deleteCompanyTeam mutation to delete a company team by ID. You can get the team ID with the company query.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -63,6 +61,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/company/mutations/delete-user.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/delete-user.md
@@ -1,8 +1,6 @@
 ---
 title: deleteCompanyUser mutation
 description: Use the deleteCompanyUser mutation to deactivate the specified company user.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -72,6 +70,6 @@ mutation {
 | `A customer with the same email address already exists in an associated website` | The email provided in the `input`.`email` argument belongs to another user. |
 | `The user XXX is the company admin and cannot be set to inactive. You must set another user as the company admin first.` | The company owner cannot be deactivated. You must set another user as the company admin first. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/company/mutations/update-role.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-role.md
@@ -1,8 +1,6 @@
 ---
 title: updateCompanyRole mutation
 description: Use the updateCompanyRole mutation to update the company role and permissions.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -175,6 +173,6 @@ mutation {
 | `Unable to set "allow" for the resource because its parent resource(s) is set to "deny".` | To allow permission for the company role, you must allow all the permissions of the parent tree. |
 | `No such entity with roleId = xxx` | The company role with ID `xxx` doesn't exist. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/company/mutations/update-structure.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-structure.md
@@ -1,8 +1,6 @@
 ---
 title: updateCompanyStructure mutation
 description: Use the updateCompanyStructure mutation to change the parent node of a company team.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -110,6 +108,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/company/mutations/update-team.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-team.md
@@ -1,8 +1,6 @@
 ---
 title: updateCompanyTeam mutation
 description: Use the updateCompanyTeam mutation to update the company team data.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -75,6 +73,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/company/mutations/update-user.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-user.md
@@ -1,8 +1,6 @@
 ---
 title: updateCompanyUser mutation
 description: Use the updateCompanyUser mutation to update an existing company user.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -154,6 +152,6 @@ mutation {
 | `No such entity with roleId = xxx` | The company role with ID `xxx` doesn't exist. |
 | `A customer with the same email address already exists in an associated website` | The email provided in the `input`.`email` argument belongs to another user. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/company/queries/is-company-role-name-available.md
+++ b/src/pages/graphql/schema/b2b/company/queries/is-company-role-name-available.md
@@ -1,8 +1,6 @@
 ---
 title: isCompanyRoleNameAvailable query
 description: The isCompanyRoleNameAvailable query checks whether a company role name is valid for creating into a company.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - B2B
 ---
@@ -63,6 +61,6 @@ query {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/add-items-to-cart.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/add-items-to-cart.md
@@ -1,7 +1,6 @@
 ---
 title: addRequisitionListItemsToCart mutation
 description: The addRequisitionListItemsToCart mutation adds requisition list items to the cart. The requisition list does not change after adding items to the cart.
-contributor_name: EY
 keywords:
   - B2B
 ---
@@ -108,6 +107,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/add-products.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/add-products.md
@@ -1,7 +1,6 @@
 ---
 title: addProductsToRequisitionList mutation
 description: The addProductsToRequisitionList mutation adds products to a requisition list.
-contributor_name: EY
 keywords:
   - B2B
 ---
@@ -106,6 +105,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/clear-customer-cart.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/clear-customer-cart.md
@@ -1,7 +1,6 @@
 ---
 title: clearCustomerCart mutation
 description: The clearCustomerCart mutation clears the customer's cart. B2B requisition lists must be enabled to execute this mutation.
-contributor_name: EY
 keywords:
   - B2B
 ---
@@ -66,6 +65,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/copy-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/copy-items.md
@@ -1,7 +1,6 @@
 ---
 title: copyItemsBetweenRequisitionLists mutation
 description: The copyItemsBetweenRequisitionLists mutation copies items from one requisition list to another.
-contributor_name: EY
 keywords:
   - B2B
 ---
@@ -87,6 +86,6 @@ mutation {
 *  [moveItemsBetweenRequisitionLists mutation](move-items.md)
 *  [deleteRequisitionListItems mutation](delete.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/create.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/create.md
@@ -1,7 +1,6 @@
 ---
 title: createRequisitionList mutation
 description: The createRequisitionList mutation creates a requisition list for the logged in customer.
-contributor_name: Zilker Technology
 keywords:
   - B2B
 ---
@@ -77,6 +76,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to Zilker Technology for contributing this topic!

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/delete-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/delete-items.md
@@ -1,7 +1,6 @@
 ---
 title: deleteRequisitionListItems mutation
 description: The deleteRequisitionListItems mutation removes items from the specified requisition list for the logged in customer.
-contributor_name: EY
 keywords:
   - B2B
 ---
@@ -79,6 +78,6 @@ mutation {
 *  [updateRequisitionList mutation](update.md)
 *  [deleteRequisitionList mutation](delete.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/delete.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/delete.md
@@ -1,7 +1,6 @@
 ---
 title: deleteRequisitionList mutation
 description: The deleteRequisitionList mutation deletes a requisition list of the logged in customer. The response can include any remaining requisition lists.
-contributor_name: Zilker Technology
 keywords:
   - B2B
 ---
@@ -87,6 +86,6 @@ mutation {
 *  [createRequisitionList mutation](create.md)
 *  [updateRequisitionList mutation](update.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to Zilker Technology for contributing this topic!

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/move-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/move-items.md
@@ -1,7 +1,6 @@
 ---
 title: moveItemsBetweenRequisitionLists mutation
 description: The moveItemsBetweenRequisitionLists mutation moves items from one requisition list to another.
-contributor_name: EY
 keywords:
   - B2B
 ---
@@ -96,6 +95,6 @@ mutation {
 *  [copyItemsBetweenRequisitionLists mutation](copy-items.md)
 *  [deleteRequisitionListItems mutation](delete-items.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/update-items.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/update-items.md
@@ -1,7 +1,6 @@
 ---
 title: updateRequisitionListItems mutation
 description: The updateRequisitionListItems mutation updates products in a requisition list.
-contributor_name: EY
 keywords:
   - B2B
 ---
@@ -105,6 +104,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/update.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/update.md
@@ -1,7 +1,6 @@
 ---
 title: updateRequisitionList mutation
 description: The updateRequisitionList mutation updates the name and, optionally, the description of a requisition list.
-contributor_name: Zilker Technology
 keywords:
   - B2B
 ---
@@ -84,6 +83,6 @@ mutation {
 *  [createRequisitionList mutation](create.md)
 *  [deleteRequisitionList mutation](delete.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to Zilker Technology for contributing this topic!

--- a/src/pages/graphql/schema/cart/mutations/add-bundle-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-bundle-products.md
@@ -1,8 +1,6 @@
 ---
 title: addBundleProductsToCart mutation
 description: We recommend using the addProductsToCart mutation to add any type of product to the cart.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 <Fragment src="../../../../includes/paas-only.md"/>
@@ -227,6 +225,6 @@ mutation {
 
 -  [Bundle product data types](../../products/interfaces/types/bundle.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/cart/mutations/add-downloadable-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-downloadable-products.md
@@ -1,8 +1,6 @@
 ---
 title: addDownloadableProductsToCart mutation
 description: We recommend using the addProductsToCart mutation to add any type of product to the cart.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 <Fragment src="../../../../includes/paas-only.md"/>
@@ -253,6 +251,6 @@ mutation {
 | `Required parameter "cart_items" is missing` | The `cart_items` argument is empty or is not of type `array`. |
 | `Please specify product link(s).` | You tried to add a downloadable product in which the `Links can be purchased separately` option is enabled, but you did not specify individual product links. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/cart/mutations/add-products.md
+++ b/src/pages/graphql/schema/cart/mutations/add-products.md
@@ -1,8 +1,6 @@
 ---
 title: addProductsToCart mutation
 description: The addProductsToCart mutation adds any type of product to the shopping cart. It streamlines the process of adding products by allowing you to specify mult...
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # addProductsToCart mutation
@@ -650,6 +648,6 @@ mutation {
 | `INSUFFICIENT_STOCK` | `This product is out of stock` | The requested product is out of stock |
 | `UNDEFINED` | `UNDEFINED` | The error message does not match any error code |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/cart/mutations/assign-customer-to-guest-cart.md
+++ b/src/pages/graphql/schema/cart/mutations/assign-customer-to-guest-cart.md
@@ -1,8 +1,6 @@
 ---
 title: assignCustomerToGuestCart mutation
 description: The assignCustomerToGuestCart mutation merges a logged-in customer's shopping cart into the specified guest cart. The mutation inactivates the customer's s...
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # assignCustomerToGuestCart mutation
@@ -111,6 +109,6 @@ mutation {
 | `Could not find a cart with ID "XXX"` | The specified `cart_id` value does not exist in the `quote_id_mask` table. |
 | `The current user cannot perform operations on cart "XXX"` | Tried to assign the customer to the customer's cart. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/cart/mutations/set-payment-place-order.md
+++ b/src/pages/graphql/schema/cart/mutations/set-payment-place-order.md
@@ -1,8 +1,6 @@
 ---
 title: setPaymentMethodAndPlaceOrder mutation
 description: The setPaymentMethodAndPlaceOrder mutation has been deprecated. Use the setPaymentMethodOnCart and placeOrder mutations instead. You can run the two method...
-contributor_name: Something Digital (now Rightpoint)
-contributor_link: https://www.rightpoint.com/
 ---
 
 <Fragment src="../../../../includes/paas-only.md"/>
@@ -94,6 +92,6 @@ mutation {
 | `The requested Payment Method is not available.` | The payment method specified in the `payment_method` argument is disabled or does not exist. |
 | `Unable to place order: Some of the products are out of stock.` | Some of the products in a cart are out of stock. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Something Digital (now Rightpoint) for contributing this topic!](https://www.rightpoint.com/)

--- a/src/pages/graphql/schema/cart/queries/pickup-locations.md
+++ b/src/pages/graphql/schema/cart/queries/pickup-locations.md
@@ -1,8 +1,6 @@
 ---
 title: pickupLocations query
 description: Use the pickupLocations query to retrieve a list of available pickup locations.
-contributor_name: Oleksandr Kravchuk
-contributor_link: https://github.com/swnsma
 ---
 
 # pickupLocations query
@@ -137,6 +135,6 @@ For the available Pickup location, the response would look like:
 | `Field AreaInput.radius of required type Int! was not provided` | The value specified in the `AreaInput.radius` argument is empty. |
 | `Field AreaInput.search_term of required type String! was not provided` | The value specified in the `AreaInput.search_term` argument is empty. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Oleksandr Kravchuk for contributing this topic!](https://github.com/swnsma)

--- a/src/pages/graphql/schema/checkout/mutations/create-braintree-client-token.md
+++ b/src/pages/graphql/schema/checkout/mutations/create-braintree-client-token.md
@@ -1,8 +1,6 @@
 ---
 title: createBraintreeClientToken mutation
 description: The createBraintreeClientToken mutation creates the client token for Braintree JavaScript SDK initialization.
-contributor_name: Something Digital (now Rightpoint)
-contributor_link: https://www.rightpoint.com/
 ediition: paas
 ---
 
@@ -50,6 +48,6 @@ mutation {
 | --- | --- |
 | `The Braintree payment method is not active.` | The [Braintree](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/payments/braintree) payment method is disabled in admin. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Something Digital (now Rightpoint) for contributing this topic!](https://www.rightpoint.com/)

--- a/src/pages/graphql/schema/checkout/mutations/create-klarna-payments-session.md
+++ b/src/pages/graphql/schema/checkout/mutations/create-klarna-payments-session.md
@@ -1,8 +1,6 @@
 ---
 title: createKlarnaPaymentsSession mutation
 description: The Klarna Vendor Bundled Extension was removed from the Adobe Commerce codebase in version 2.4.4. This mutation is no longer supported.
-contributor_name: Klarna
-contributor_link: https://www.klarna.com/
 ---
 
 <Fragment src="../../../../includes/paas-only.md"/>
@@ -121,6 +119,6 @@ The `Assets` object can contain the following attributes.
 | --- | --- |
 | `The Klarna payment method is not active.` | The [Klarna](https://experienceleague.adobe.com/en/docs/commerce-admin/config/sales/payment-methods/payment-methods) payment method is disabled in admin. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Klarna for contributing this topic!](https://www.klarna.com/)

--- a/src/pages/graphql/schema/checkout/queries/agreements.md
+++ b/src/pages/graphql/schema/checkout/queries/agreements.md
@@ -1,8 +1,6 @@
 ---
 title: checkoutAgreements query
 description: The checkoutAgreements query retrieves checkout agreements. The query will always return an empty array when the Enable Terms and Conditions option is set...
-contributor_name: Something Digital (now Rightpoint)
-contributor_link: https://www.rightpoint.com/
 ---
 
 # checkoutAgreements query
@@ -63,6 +61,6 @@ The following query returns enabled checkout agreements.
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Something Digital (now Rightpoint) for contributing this topic!](https://www.rightpoint.com/)

--- a/src/pages/graphql/schema/customer/mutations/assign-compare-list.md
+++ b/src/pages/graphql/schema/customer/mutations/assign-compare-list.md
@@ -1,8 +1,6 @@
 ---
 title: assignCompareListToCustomer mutation
 description: The assignCompareListToCustomer mutation assigns the specified comparison list to the logged-in customer. Use this mutation when a customer creates a compa...
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # assignCompareListToCustomer mutation
@@ -129,6 +127,6 @@ mutation {
 *  [deleteCompareList mutation](../../products/mutations/delete-compare-list.md)
 *  [removeProductsFromCompareList mutation](../../products/mutations/remove-from-compare-list.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/customer/mutations/generate-token-as-admin.md
+++ b/src/pages/graphql/schema/customer/mutations/generate-token-as-admin.md
@@ -1,7 +1,6 @@
 ---
 title: generateCustomerTokenAsAdmin mutation
 description: The generateCustomerTokenAsAdmin mutation generates a new customer token as an admin so that an administrator can perform remote shopping assistance on beh...
-contributor_name: EY 
 ---
 
 # generateCustomerTokenAsAdmin mutation
@@ -57,6 +56,6 @@ mutation{
 *  [customer query](../queries/customer.md)
 *  [revokeCustomerToken mutation](revoke-token.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/customer/mutations/request-password-reset-email.md
+++ b/src/pages/graphql/schema/customer/mutations/request-password-reset-email.md
@@ -1,8 +1,6 @@
 ---
 title: requestPasswordResetEmail mutation
 description: The requestPasswordResetEmail mutation triggers the password reset email by the provided email address. Use it to initiate the process to reset the registe...
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # requestPasswordResetEmail mutation
@@ -77,6 +75,6 @@ mutation {
 
 [resetPassword mutation](reset-password.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/customer/mutations/reset-password.md
+++ b/src/pages/graphql/schema/customer/mutations/reset-password.md
@@ -1,8 +1,6 @@
 ---
 title: resetPassword mutation
 description: The resetPassword mutation resets customer password using a reset password token and the customer's email address. Use it to set a new password for the reg...
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # resetPassword mutation
@@ -70,6 +68,6 @@ mutation {
 
 * [requestPasswordResetEmail mutation](request-password-reset-email.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/customer/mutations/subscribe-email-to-newsletter.md
+++ b/src/pages/graphql/schema/customer/mutations/subscribe-email-to-newsletter.md
@@ -1,8 +1,6 @@
 ---
 title: subscribeEmailToNewsletter mutation
 description: The subscribeEmailToNewsletter mutation allows guests and registered customers to sign up to receive newsletters. It can return a value of NOTACTIVE or SUB...
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # subscribeEmailToNewsletter mutation
@@ -60,6 +58,6 @@ mutation {
 | `This email address is already subscribed.` | The email address provided in the `email` argument is already subscribed. |
 | `You must specify an email address to subscribe to a newsletter.`| The `email` argument is empty. |
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/gift-registry/mutations/create.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/create.md
@@ -1,7 +1,6 @@
 ---
 title: createGiftRegistry mutation
 description: The createGiftRegistry mutation creates a gift registry for the logged in customer.
-contributor_name: EY
 ---
 
 <Fragment src="../../../../includes/commerce-only.md"/>
@@ -212,6 +211,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/gift-registry/mutations/move-cart-items.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/move-cart-items.md
@@ -1,8 +1,6 @@
 ---
 title: moveCartItemsToGiftRegistry mutation
 description: The moveCartItemsToGiftRegistry mutation moves all items from the cart to a gift registry.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 <Fragment src="../../../../includes/commerce-only.md"/>
@@ -104,6 +102,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/gift-registry/mutations/share.md
+++ b/src/pages/graphql/schema/gift-registry/mutations/share.md
@@ -1,7 +1,6 @@
 ---
 title: shareGiftRegistry mutation
 description: The shareGiftRegistry mutation sends an invitation to a list email addresses to shop from the customer's gift registry.
-contributor_name: EY
 ---
 
 <Fragment src="../../../../includes/commerce-only.md"/>
@@ -75,6 +74,6 @@ mutation{
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/gift-registry/queries/gift-registry.md
+++ b/src/pages/graphql/schema/gift-registry/queries/gift-registry.md
@@ -1,7 +1,6 @@
 ---
 title: giftRegistry query
 description: The giftRegistry query retrieves details about the specified gift registry. Use the customer query to return a list of valid uid values.
-contributor_name: EY
 ---
 
 <Fragment src="../../../../includes/commerce-only.md"/>
@@ -205,6 +204,6 @@ query{
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to EY for contributing this topic!

--- a/src/pages/graphql/schema/gift-registry/queries/types.md
+++ b/src/pages/graphql/schema/gift-registry/queries/types.md
@@ -1,7 +1,6 @@
 ---
 title: giftRegistryTypes query
 description: The giftRegistryTypes query returns a list of available gift registry types.
-contributor_name: Zilker Technology
 ---
 
 <Fragment src="../../../../includes/commerce-only.md"/>
@@ -134,6 +133,6 @@ query{
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 Thanks to Zilker Technology for contributing this topic!

--- a/src/pages/graphql/schema/products/interfaces/types/simple.md
+++ b/src/pages/graphql/schema/products/interfaces/types/simple.md
@@ -1,8 +1,6 @@
 ---
 title: Simple product data types
 description: The SimpleProduct data type implements the following interfaces:
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # Simple product data types
@@ -108,6 +106,6 @@ The following query returns information about simple product `24-MB01`, which is
 
 -  [addSimpleProductsToCart mutation](../../../cart/mutations/add-simple-products.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/products/interfaces/types/virtual.md
+++ b/src/pages/graphql/schema/products/interfaces/types/virtual.md
@@ -1,8 +1,6 @@
 ---
 title: Virtual product data types
 description: The VirtualProduct data type implements the following interfaces:
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # Virtual product data types
@@ -101,6 +99,6 @@ The following query returns information about virtual product.
 
 -  [addVirtualProductsToCart mutation](../../../cart/mutations/add-virtual-products.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/products/mutations/add-products-to-compare-list.md
+++ b/src/pages/graphql/schema/products/mutations/add-products-to-compare-list.md
@@ -1,8 +1,6 @@
 ---
 title: addProductsToCompareList mutation
 description: The addProductsToCompareList mutation adds products to the comparison list.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # addProductsToCompareList mutation
@@ -146,6 +144,6 @@ mutation {
 *  [deleteCompareList mutation](delete-compare-list.md)
 *  [removeProductsFromCompareList mutation](remove-from-compare-list.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/products/mutations/assign-compare-list.md
+++ b/src/pages/graphql/schema/products/mutations/assign-compare-list.md
@@ -1,8 +1,6 @@
 ---
 title: assignCompareListToCustomer mutation
 description: The assignCompareListToCustomer mutation assigns the specified comparison list to the logged-in customer. Use this mutation when a customer creates a compa...
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # assignCompareListToCustomer mutation
@@ -129,6 +127,6 @@ mutation {
 *  [deleteCompareList mutation](delete-compare-list.md)
 *  [removeProductsFromCompareList mutation](remove-from-compare-list.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/products/mutations/create-compare-list.md
+++ b/src/pages/graphql/schema/products/mutations/create-compare-list.md
@@ -1,8 +1,6 @@
 ---
 title: createCompareList mutation
 description: The createCompareList mutation creates a new comparison list with products specified in the input attribute.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # createCompareList mutation
@@ -125,6 +123,6 @@ mutation {
 *  [deleteCompareList mutation](delete-compare-list.md)
 *  [removeProductsFromCompareList mutation](remove-from-compare-list.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/products/mutations/delete-compare-list.md
+++ b/src/pages/graphql/schema/products/mutations/delete-compare-list.md
@@ -1,8 +1,6 @@
 ---
 title: deleteCompareList mutation
 description: The deleteCompareList mutation deletes the specified comparison list. Run this mutation in the following circumstances:
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # deleteCompareList mutation
@@ -68,6 +66,6 @@ mutation {
 *  [createCompareList mutation](create-compare-list.md)
 *  [removeProductsFromCompareList mutation](remove-from-compare-list.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/products/mutations/remove-from-compare-list.md
+++ b/src/pages/graphql/schema/products/mutations/remove-from-compare-list.md
@@ -1,8 +1,6 @@
 ---
 title: removeProductsFromCompareList mutation
 description: The removeProductsFromCompareList mutation removes products from a comparison list.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # removeProductsFromCompareList mutation
@@ -126,6 +124,6 @@ mutation {
 *  [createCompareList mutation](create-compare-list.md)
 *  [deleteCompareList mutation](delete-compare-list.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/schema/products/queries/compare-list.md
+++ b/src/pages/graphql/schema/products/queries/compare-list.md
@@ -1,8 +1,6 @@
 ---
 title: compareList query
 description: The compareList query retrieves information about a list of products so that the shopper can compare those products.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 ---
 
 # compareList query
@@ -117,6 +115,6 @@ The following query returns the information about products in the comparison lis
 *  [deleteCompareList mutation](../mutations/delete-compare-list.md)
 *  [removeProductsFromCompareList mutation](../mutations/remove-from-compare-list.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
+++ b/src/pages/graphql/tutorials/checkout/add-product-to-cart.md
@@ -1,8 +1,6 @@
 ---
 title: Step 3. Add products to the cart
 description: Learn how to add products to a cart with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -167,6 +165,6 @@ The response lists all items currently in the cart, including the just-added vid
 
 1. Go to the shopping cart. All the items you added are displayed.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/apply-coupon.md
+++ b/src/pages/graphql/tutorials/checkout/apply-coupon.md
@@ -1,8 +1,6 @@
 ---
 title: Step 7. Apply a coupon
 description: Learn how to set a apply a coupon to an order with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -130,6 +128,6 @@ mutation {
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/create-cart.md
+++ b/src/pages/graphql/tutorials/checkout/create-cart.md
@@ -1,8 +1,6 @@
 ---
 title: Step 2. Create an empty cart
 description: Learn how to create a cart with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -84,6 +82,6 @@ Copy the value of the `id` attribute. Use this value in subsequent steps whereve
 
 There are no additional verification steps. The value of `id` is not displayed on the website or in the Admin.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/create-customer.md
+++ b/src/pages/graphql/tutorials/checkout/create-customer.md
@@ -1,8 +1,6 @@
 ---
 title: Step 1. Create a customer
 description: Learn how to create a customer with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -97,6 +95,6 @@ The name of the header is `Authorization` and the value is `Bearer <token>`.
 
 Sign in as a customer to the website using the email `john.doe@example.com` and password `b1b2b3l@w+`. You should be successfully logged in.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/index.md
+++ b/src/pages/graphql/tutorials/checkout/index.md
@@ -1,8 +1,6 @@
 ---
 title: GraphQL checkout tutorial
 description: Learn how to place an order with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -42,6 +40,6 @@ Complete the following prerequisites:
 
 -  [REST Tutorials](/rest/tutorials/index.md) provides additional information about completing any REST tutorial.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/place-order.md
+++ b/src/pages/graphql/tutorials/checkout/place-order.md
@@ -1,8 +1,6 @@
 ---
 title: Step 10. Place the order
 description: Learn how to place an order with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -55,6 +53,6 @@ mutation {
 
 1. Go to **My Account** > **My Orders**. The order you created is displayed.  The order is also displayed on the Orders grid (**Sales** > **Orders**) in the Admin.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/set-billing-address.md
+++ b/src/pages/graphql/tutorials/checkout/set-billing-address.md
@@ -1,8 +1,6 @@
 ---
 title: Step 5. Set billing address
 description: Learn how to set a billing address for an order with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -114,6 +112,6 @@ Verification is possible after [Step 6: Set the delivery method](set-delivery-me
 
 1. Go to the Review & Payments step. The Billing Address form is populated with the address details you entered.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/set-delivery-method.md
+++ b/src/pages/graphql/tutorials/checkout/set-delivery-method.md
@@ -1,8 +1,6 @@
 ---
 title: Step 6. Set the delivery method
 description: Learn how to set a delivery method for an order with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -84,6 +82,6 @@ mutation {
 
 1. The selected delivery method is displayed in the Shipping Methods section on the Shipping step.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/set-email-address.md
+++ b/src/pages/graphql/tutorials/checkout/set-email-address.md
@@ -1,8 +1,6 @@
 ---
 title: Step 8. Set email on the cart
 description: Learn how to set a an email address for an order with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -53,6 +51,6 @@ mutation {
 
 There are no additional verification steps. `quote`.`customer_email` is displayed for administrator on back-end side.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/set-payment-method.md
+++ b/src/pages/graphql/tutorials/checkout/set-payment-method.md
@@ -1,8 +1,6 @@
 ---
 title: Step 9. Set the payment method
 description: Learn how to set a payment method for an order with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -103,6 +101,6 @@ If the operation is successful, the response contains the code of the selected p
 
 1. The selected payment method is displayed in the Payment Method section on the Review & Payments step.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/set-shipping-address.md
+++ b/src/pages/graphql/tutorials/checkout/set-shipping-address.md
@@ -1,8 +1,6 @@
 ---
 title: Step 4. Set the shipping address
 description: Learn how to set a shipping address for an order with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -140,6 +138,6 @@ Note the `available_shipping_methods` in the response. We will use this informat
 
 1. On the Shipping step, the Shipping Address form contains the address details you entered.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/tutorials/checkout/set-shipping-method.md
+++ b/src/pages/graphql/tutorials/checkout/set-shipping-method.md
@@ -1,8 +1,6 @@
 ---
 title: Step 6. Set the delivery method
 description: Learn how to set a shipping method for an order with the GraphQL API.
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Checkout
@@ -84,6 +82,6 @@ mutation {
 
 1. The selected delivery method is displayed in the Shipping Methods section on the Shipping step.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/graphql/usage/authorization-tokens.md
+++ b/src/pages/graphql/usage/authorization-tokens.md
@@ -1,8 +1,6 @@
 ---
 title: GraphQL authorization
 description: Learn how to authorize GraphQL API calls using tokens. 
-contributor_name: Atwix
-contributor_link: https://www.atwix.com/
 keywords:
   - GraphQL
   - Security
@@ -109,6 +107,6 @@ To re-enable these cookies, run:
 
 `bin/magento config:set graphql/session/disable 0`
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Atwix for contributing this topic!](https://www.atwix.com/)

--- a/src/pages/rest/inventory/in-store-pickup.md
+++ b/src/pages/rest/inventory/in-store-pickup.md
@@ -1,8 +1,6 @@
 ---
 title: In-Store Pickup
 description: Retrieve a list or search for pickup locations using the REST API
-contributor_name: Oleksandr Kravchuk
-contributor_link: https://github.com/swnsma
 keywords:
   - Inventory
   - REST
@@ -154,6 +152,6 @@ Commerce returns an array with success status and an array of error messages for
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Oleksandr Kravchuk for contributing this topic!](https://github.com/swnsma)

--- a/src/pages/rest/tutorials/bulk-configurable-product/create-configurable-simple-products.md
+++ b/src/pages/rest/tutorials/bulk-configurable-product/create-configurable-simple-products.md
@@ -1,8 +1,6 @@
 ---
 title: Step 2. Create the configurable and simple products
 description: In this step of the tutorial you will create the configurable and simple products
-contributor_name: comwrap GmbH
-contributor_link: https://comwrap.com/en/
 keywords:
   - REST
 ---
@@ -310,6 +308,6 @@ For information about response fields, see the [Bulk API](/rest/use-rest/bulk-en
 
 *  On the Luma storefront page, search for `Champ`. No results are returned.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to comwrap GmbH for contributing this topic!](https://comwrap.com/en/)

--- a/src/pages/rest/tutorials/bulk-configurable-product/create-personalization-option.md
+++ b/src/pages/rest/tutorials/bulk-configurable-product/create-personalization-option.md
@@ -1,8 +1,6 @@
 ---
 title: Step 4. Create the personalization option
 description: In this step of the tutorial you will create the personalization option
-contributor_name: comwrap GmbH
-contributor_link: https://comwrap.com/en/
 keywords:
   - REST
 ---
@@ -70,6 +68,6 @@ The `product_sku` is the `sku` of the configurable product. The `sku` specified 
 
 [Order Processing with REST APIs Tutorial](/rest/tutorials/orders/index.md)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to comwrap GmbH for contributing this topic!](https://comwrap.com/en/)

--- a/src/pages/rest/tutorials/bulk-configurable-product/define-config-product-options.md
+++ b/src/pages/rest/tutorials/bulk-configurable-product/define-config-product-options.md
@@ -1,8 +1,6 @@
 ---
 title: Step 3. Define configurable product options
 description: In this step of the tutorial you will define the configurable product options
-contributor_name: comwrap GmbH
-contributor_link: https://comwrap.com/en/
 keywords:
   - REST
 ---
@@ -161,6 +159,6 @@ Bulk endpoint routes cannot contain input parameters, such as a `sku` value.  Yo
 ...
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to comwrap GmbH for contributing this topic!](https://comwrap.com/en/)

--- a/src/pages/rest/tutorials/bulk-configurable-product/index.md
+++ b/src/pages/rest/tutorials/bulk-configurable-product/index.md
@@ -1,8 +1,6 @@
 ---
 title: Create a configurable product using bulk APIs
 description: A tutorial that describes how to create a configurable product using bulk API calls
-contributor_name: comwrap GmbH
-contributor_link: https://comwrap.com/en/
 keywords:
   - REST
 ---
@@ -30,6 +28,6 @@ A system integrator can use Adobe Commerce REST bulk APIs to perform actions on 
 *  [Asynchronous web endpoints](/rest/use-rest/asynchronous-web-endpoints.md) provides information about how to use the Commerce Asynchronous API
 *  [Bulk endpoints](/rest/use-rest/bulk-endpoints.md) provides information about how to use the Commerce Bulk API
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to comwrap GmbH for contributing this topic!](https://comwrap.com/en/)

--- a/src/pages/rest/tutorials/bulk-configurable-product/plan-product.md
+++ b/src/pages/rest/tutorials/bulk-configurable-product/plan-product.md
@@ -1,8 +1,6 @@
 ---
 title: Step 1. Plan the product
 description: In this step of the tutorial you will plan and define the product
-contributor_name: comwrap GmbH
-contributor_link: https://comwrap.com/en/
 keywords:
   - REST
 ---
@@ -139,6 +137,6 @@ searchCriteria[filter_groups][0][filters][0][condition_type]=gte
 
  At this point, we're gathering information, so there is nothing to verify.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to comwrap GmbH for contributing this topic!](https://comwrap.com/en/)

--- a/src/pages/rest/tutorials/bundle-product/create-bundle-product.md
+++ b/src/pages/rest/tutorials/bundle-product/create-bundle-product.md
@@ -1,8 +1,6 @@
 ---
 title: Step 3. Create the bundle product 
 description: In this step of the tutorial you will create the bundle product
-contributor_name: Goivvy LLC
-contributor_link: https://www.goivvy.com/magento-optimization-service
 keywords:
   - REST
 ---
@@ -313,6 +311,6 @@ POST http://domain.com/rest/default/V1/products
 
 If you do not see the bundle product on the frontend, you can try reindexing and clearing the cache.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Goivvy LLC for contributing this topic!](https://www.goivvy.com/magento-optimization-service)

--- a/src/pages/rest/tutorials/bundle-product/create-simple-products.md
+++ b/src/pages/rest/tutorials/bundle-product/create-simple-products.md
@@ -1,8 +1,6 @@
 ---
 title: Step 2. Create the simple products
 description: In this step of the tutorial you will create simple products
-contributor_name: Goivvy LLC
-contributor_link: https://www.goivvy.com/magento-optimization-service
 keywords:
   - REST
 ---
@@ -583,6 +581,6 @@ Log in to the Adobe Commerce Admin Panel and select **Catalog** > **Products** a
 
 If you do not see your products in the catalog, you can try reindexing and clearing the cache.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Goivvy LLC for contributing this topic!](https://www.goivvy.com/magento-optimization-service)

--- a/src/pages/rest/tutorials/bundle-product/index.md
+++ b/src/pages/rest/tutorials/bundle-product/index.md
@@ -1,8 +1,6 @@
 ---
 title: Create a bundle product tutorial
 description: In this tutorial you will learn how to create a bundled product
-contributor_name: Goivvy LLC
-contributor_link: https://www.goivvy.com/magento-optimization-service
 keywords:
   - REST
 ---
@@ -23,6 +21,6 @@ This **3-step tutorial** generally takes **40 minutes**.
 
 *  Generate an admin authorization token. All calls in this tutorial require administrator privileges.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Goivvy LLC for contributing this topic!](https://www.goivvy.com/magento-optimization-service)

--- a/src/pages/rest/tutorials/bundle-product/plan-product.md
+++ b/src/pages/rest/tutorials/bundle-product/plan-product.md
@@ -1,8 +1,6 @@
 ---
 title: Step 1. Plan the product
 description: In this step of the tutorial you will plan the product
-contributor_name: Goivvy LLC
-contributor_link: https://www.goivvy.com/magento-optimization-service
 keywords:
   - REST
 ---
@@ -198,6 +196,6 @@ We can see from the above response that the `id` for `What's New` is equal to `3
 
 Since we are only gathering information, there is nothing to verify.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Goivvy LLC for contributing this topic!](https://www.goivvy.com/magento-optimization-service)

--- a/src/pages/rest/tutorials/image/delete.md
+++ b/src/pages/rest/tutorials/image/delete.md
@@ -1,8 +1,6 @@
 ---
 title: Step 4. Delete an image 
 description: We will learn how to delete an existing image.
-contributor_name: Goivvy LLC
-contributor_link: https://www.goivvy.com/
 keywords:
   - REST
 ---
@@ -37,6 +35,6 @@ Refresh the `MJ03` product page and see if your image was deleted.
 
 You can re-run this call to verify that the image can no longer be found. You should receive the following message: `No image with the provided ID was found. Verify the ID and try again`.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Goivvy LLC for contributing this topic!](https://www.goivvy.com/)

--- a/src/pages/rest/tutorials/image/index.md
+++ b/src/pages/rest/tutorials/image/index.md
@@ -1,8 +1,6 @@
 ---
 title: Manage product images tutorial
 description: We will learn how to add, list, update and delete product images.
-contributor_name: Goivvy LLC
-contributor_link: https://www.goivvy.com/
 keywords:
   - REST
 ---
@@ -33,6 +31,6 @@ This **4-step tutorial** generally takes **30 minutes**.
 
 *  Generate an [admin access token](../../../get-started/authentication/gs-authentication-token.md), which will we will use to make image managing API calls.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Goivvy LLC for contributing this topic!](https://www.goivvy.com/)

--- a/src/pages/rest/tutorials/image/list.md
+++ b/src/pages/rest/tutorials/image/list.md
@@ -1,8 +1,6 @@
 ---
 title: Step 1. Getting a list of product images 
 description: We will learn how to get a list of all product images.
-contributor_name: Goivvy LLC
-contributor_link: https://www.goivvy.com/
 keywords:
   - REST
 ---
@@ -67,6 +65,6 @@ We will use the image `id` for later steps in this tutorial.
 
 1. Confirm that the number of images in the storefront matches the number of images in your API response.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Goivvy LLC for contributing this topic!](https://www.goivvy.com/)

--- a/src/pages/rest/tutorials/image/new.md
+++ b/src/pages/rest/tutorials/image/new.md
@@ -1,8 +1,6 @@
 ---
 title: Step 2. Add a new image 
 description: We will learn how to add a new image to a product.
-contributor_name: Goivvy LLC
-contributor_link: https://www.goivvy.com/
 keywords:
   - REST
 ---
@@ -74,6 +72,6 @@ Refresh the `MJ03` product page and see if your new image was added.
 
 ![New Product Image](../../../images/api-frontend-new-image.png)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Goivvy LLC for contributing this topic!](https://www.goivvy.com/)

--- a/src/pages/rest/tutorials/image/update.md
+++ b/src/pages/rest/tutorials/image/update.md
@@ -1,8 +1,6 @@
 ---
 title: Step 3. Update an image 
 description: We will learn how to update an existing image 
-contributor_name: Goivvy LLC
-contributor_link: https://www.goivvy.com/
 keywords:
   - REST
 ---
@@ -79,6 +77,6 @@ Refresh the `MJ03` product page and see if the existing image was updated.
 
 ![Updated Image](../../../images/update-image-frontend.png)
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to Goivvy LLC for contributing this topic!](https://www.goivvy.com/)

--- a/src/pages/rest/use-rest/asynchronous-web-endpoints.md
+++ b/src/pages/rest/use-rest/asynchronous-web-endpoints.md
@@ -1,8 +1,6 @@
 ---
 title: Asynchronous web endpoints
 description: Learn about asynchronous web points, how they are used and how to define store scopes
-contributor_name: comwrap GmbH
-contributor_link: https://comwrap.com/en/
 keywords:
   - REST
 ---
@@ -133,6 +131,6 @@ The following rules apply when you create or update an object, such as a product
 *  If you include the `all` parameter, then Commerce updates values for all store scopes (in case a particular store doesn't yet have its own value set).
 *  If `<store_code>` parameter is set, then values for only defined store will be updated.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to comwrap GmbH for contributing this topic!](https://comwrap.com/en/)

--- a/src/pages/rest/use-rest/bulk-endpoints.md
+++ b/src/pages/rest/use-rest/bulk-endpoints.md
@@ -1,8 +1,6 @@
 ---
 title: Bulk endpoints
 description: Learn how to combine multiple API calls of the same type into a single request
-contributor_name: comwrap GmbH
-contributor_link: https://comwrap.com/en/
 keywords:
   - REST
 ---
@@ -198,6 +196,6 @@ The following rules apply when you create or update an object, such as a product
 *  If you include the `all` parameter, then Commerce updates values for all store scopes (in case a particular store doesn't yet have its own value set).
 *  If `<store_code>` parameter is set, then values for only defined store will be updated.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to comwrap GmbH for contributing this topic!](https://comwrap.com/en/)

--- a/src/pages/rest/use-rest/operation-status-endpoints.md
+++ b/src/pages/rest/use-rest/operation-status-endpoints.md
@@ -1,8 +1,6 @@
 ---
 title: Bulk operation status endpoints
 description: Track the status of bulk endpoints
-contributor_name: comwrap GmbH
-contributor_link: https://www.comwrap.com/en/
 keywords:
   - REST
 ---
@@ -179,6 +177,6 @@ The `GET /V1/bulk/:bulkUuid/detailed-status` endpoint returns detailed informati
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to comwrap GmbH for contributing this topic!](https://www.comwrap.com/en/)

--- a/src/pages/rest/use-rest/operation-status-search.md
+++ b/src/pages/rest/use-rest/operation-status-search.md
@@ -1,8 +1,6 @@
 ---
 title: Search for the status of a bulk operation
 description: Search for bulk operation statuses
-contributor_name: comwrap GmbH
-contributor_link: https://www.comwrap.com/en/
 keywords:
   - REST
 ---
@@ -133,6 +131,6 @@ The operation with bulk UUID `c43ed402-3dd3-4100-92e2-dc5852d3009b` contains a `
 }
 ```
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to comwrap GmbH for contributing this topic!](https://www.comwrap.com/en/)

--- a/src/pages/rest/use-rest/search-endpoint.md
+++ b/src/pages/rest/use-rest/search-endpoint.md
@@ -1,8 +1,6 @@
 ---
 title: Search for products with the /search endpoint
 description: Search for products using the /search endpoints
-contributor_name: comwrap GmbH
-contributor_link: https://www.comwrap.com/en/
 keywords:
   - REST
 ---
@@ -151,6 +149,6 @@ searchCriteria[filterGroups][0][filters][0][condition_type]=eq
 
 [Search using REST](/rest/use-rest/performing-searches.md) provides examples that can be used to search for products.
 
-<Edition slots="text" backgroundcolor="blue"/>
+<Edition slots="text" backgroundcolor="gray"/>
 
 [Thanks to comwrap GmbH for contributing this topic!](https://www.comwrap.com/en/)


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates contributor-attributed topics across the Commerce Web APIs documentation to use a gray edition label instead of blue, and removes redundant `contributor_name` / `contributor_link` frontmatter where contributor credit already appears in the page footer.

Changes apply to **87** topics in these areas:

- **GraphQL develop** (3 topics) — debugging, schema extension, functional testing
- **GraphQL payment methods** (3 topics) — Braintree, Braintree Vault, Klarna
- **GraphQL schema reference** (48 topics) — B2B company and requisition list, cart, checkout, customer, gift registry, and products
- **GraphQL checkout tutorial** (12 topics)
- **GraphQL usage** (1 topic) — authorization tokens
- **REST** (20 topics) — in-store pickup, bulk configurable and bundle product tutorials, image tutorials, and use-REST guides

On each page, `<Edition slots="text" backgroundcolor="blue"/>` is changed to `backgroundcolor="gray"`. Footer contributor acknowledgments (for example, “Thanks to Atwix for contributing this topic!”) are unchanged.

## Affected pages

87 contributor-attributed topics under `src/pages/`. Representative URLs:

**GraphQL**

- https://developer.adobe.com/commerce/webapi/graphql/develop/debugging
- https://developer.adobe.com/commerce/webapi/graphql/payment-methods/braintree
- https://developer.adobe.com/commerce/webapi/graphql/schema/b2b/company/mutations/create-role
- https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/assign-customer-to-guest-cart
- https://developer.adobe.com/commerce/webapi/graphql/tutorials/checkout/
- https://developer.adobe.com/commerce/webapi/graphql/usage/authorization-tokens

**REST**

- https://developer.adobe.com/commerce/webapi/rest/inventory/in-store-pickup
- https://developer.adobe.com/commerce/webapi/rest/tutorials/bulk-configurable-product/
- https://developer.adobe.com/commerce/webapi/rest/tutorials/bundle-product/
- https://developer.adobe.com/commerce/webapi/rest/tutorials/image/
- https://developer.adobe.com/commerce/webapi/rest/use-rest/bulk-endpoints