### PR TITLE
Remove outdated GraphQL availability statements

### DIFF
--- a/src/pages/graphql/schema/customer/mutations/create-v2.md
+++ b/src/pages/graphql/schema/customer/mutations/create-v2.md
@@ -1,6 +1,6 @@
 ---
 title: createCustomerV2 mutation
-description: The createCustomerV2 mutation creates a customer account. Use the createCustomerAddress mutation to complete the customer profile and define billing and sh...
+description: Creates a customer account.
 ---
 
 # createCustomerV2 mutation

--- a/src/pages/graphql/schema/customer/mutations/delete-address-v2.md
+++ b/src/pages/graphql/schema/customer/mutations/delete-address-v2.md
@@ -1,7 +1,6 @@
 ---
 title: deleteCustomerAddressV2 mutation
-description: Use the deleteCustomerAddressV2 mutation to delete the specified customer address. It returns a Boolean value that indicates whether the operation was succ...
-
+description: Deletes the specified customer address.
 ---
 
 <Fragment src="../../../../includes/saas-only.md"/>
@@ -14,7 +13,7 @@ We recommend you use a customer token in the header of your call to delete a cus
 
 <InlineAlert variant="info" slots="text1" />
 
-This mutation is part of the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/). It will be added to Adobe Commerce 2.4.9.
+This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
 ## Syntax
 

--- a/src/pages/graphql/schema/customer/mutations/exchange-external-customer-token.md
+++ b/src/pages/graphql/schema/customer/mutations/exchange-external-customer-token.md
@@ -1,13 +1,14 @@
 ---
 title: exchangeExternalCustomerToken mutation
-description: This mutation is part of the Storefront Compatibility Package. It will be added to Adobe Commerce 2.4.9.
+description: This mutation provides the capability for social login authentication.
+ee_only: true
 ---
 
 # exchangeExternalCustomerToken mutation
 
 <InlineAlert variant="info" slots="text" />
 
-This mutation is part of the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/). It will be added to Adobe Commerce 2.4.9.
+This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
 The `exchangeExternalCustomerToken` mutation provides the capability for social login authentication using App Builder. With integration token credentials, it allows a shopper to log in. If the shopper does not have an account, the mutation creates one.. It returns a customer authentication token.
 

--- a/src/pages/graphql/schema/customer/mutations/update-address-v2.md
+++ b/src/pages/graphql/schema/customer/mutations/update-address-v2.md
@@ -14,7 +14,7 @@ To return or modify information about a customer, we recommend you use customer 
 
 <InlineAlert variant="info" slots="text1" />
 
-This mutation is part of the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/). It will be added to Adobe Commerce 2.4.9.
+This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
 ## Syntax
 

--- a/src/pages/graphql/schema/customer/queries/customer-group.md
+++ b/src/pages/graphql/schema/customer/queries/customer-group.md
@@ -1,15 +1,15 @@
 ---
 title: customerGroup query
-description: This query is part of the Storefront Compatibility Package. It will be added to Adobe Commerce 2.4.9.
+description: Provides the encoded ID of a customer group assigned to the logged-in customer or guest shopper.
 ---
 
 # customerGroup query
 
 <InlineAlert variant="info" slots="text" />
 
-This query is part of the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/). It will be added to Adobe Commerce 2.4.9.
+This query was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
-The `customerGroup` query provides encoded ID of Customer Group assigned to the Logged-in Customer or Guest shopper.
+The `customerGroup` query provides encoded ID of a customer group assigned to the logged-in customer or guest shopper.
 
 To retrieve customer group for a customer, we recommend you use customer tokens in the header of your GraphQL calls. However, in case of guest information, token should not be passed.
 

--- a/src/pages/graphql/schema/customer/queries/customer-segments.md
+++ b/src/pages/graphql/schema/customer/queries/customer-segments.md
@@ -1,15 +1,15 @@
 ---
 title: customerSegments query
-description: This query is part of the Storefront Compatibility Package. It will be added to Adobe Commerce 2.4.9.
+description: Provides the encoded ID of customer segments assigned to the logged-in customer or guest shopper.
 ---
 
 # customerSegments query
 
 <InlineAlert variant="info" slots="text" />
 
-This query is part of the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/). It will be added to Adobe Commerce 2.4.9.
+This query was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
-The `customerSegments` query provides encoded ID of Customer Segments assigned to the Logged-in Customer or Guest shopper.
+The `customerSegments` query provides the eencoded ID of customer segments assigned to the logged-in customer or guest shopper.
 
 To retrieve customer segments for a customer, we recommend you use customer tokens in the header of your GraphQL calls. However, in case of guest information, token should not be passed.
 

--- a/src/pages/graphql/schema/customer/queries/customer-segments.md
+++ b/src/pages/graphql/schema/customer/queries/customer-segments.md
@@ -9,7 +9,7 @@ description: Provides the encoded ID of customer segments assigned to the logged
 
 This query was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
-The `customerSegments` query provides the eencoded ID of customer segments assigned to the logged-in customer or guest shopper.
+The `customerSegments` query provides the encoded ID of customer segments assigned to the logged-in customer or guest shopper.
 
 To retrieve customer segments for a customer, we recommend you use customer tokens in the header of your GraphQL calls. However, in case of guest information, token should not be passed.
 

--- a/src/pages/graphql/schema/customer/queries/customer-segments.md
+++ b/src/pages/graphql/schema/customer/queries/customer-segments.md
@@ -1,6 +1,7 @@
 ---
 title: customerSegments query
 description: Provides the encoded ID of customer segments assigned to the logged-in customer or guest shopper.
+ee_only: true
 ---
 
 # customerSegments query

--- a/src/pages/graphql/schema/wishlist/mutations/clear.md
+++ b/src/pages/graphql/schema/wishlist/mutations/clear.md
@@ -11,7 +11,7 @@ This mutation requires a valid [customer authentication token](../../customer/mu
 
 <InlineAlert variant="info" slots="text1" />
 
-This mutation is part of the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/). It will be added to Adobe Commerce 2.4.9.
+This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
 ## Syntax
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates GraphQL schema reference topics that still stated Storefront Compatibility Package APIs “will be added to Adobe Commerce 2.4.9.” Those notices are outdated now that 2.4.9 is available.

The changes:
- Replace future-tense availability alerts with wording that these operations were created for the Storefront Compatibility Package and are now available on Adobe Commerce 2.4.9.
- Refresh frontmatter `description` values on several customer and wishlist topics so they describe the operation instead of repeating the old availability notice.
- Add `ee_only: true` to the `exchangeExternalCustomerToken` mutation  and `customerSegments` query topics.

## Affected pages

- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/create-v2
- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/delete-address-v2
- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/exchange-external-customer-token
- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/update-address-v2
- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer-group
- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer-segments
- https://developer.adobe.com/commerce/webapi/graphql/schema/wishlist/mutations/clear

## Links to Magento Open Source code
- N/A

whatsnew
Updated statements about the availability of queries and mutations originally made available in the Storefront Compatibility Package 2.4.8.