### PR TITLE
Corrected set-custom-cart-item query samples

### DIFF
--- a/src/pages/graphql/schema/attributes/mutations/set-custom-cart-item.md
+++ b/src/pages/graphql/schema/attributes/mutations/set-custom-cart-item.md
@@ -42,7 +42,7 @@ mutation {
   setCustomAttributesOnCartItem(
     input: {
       cart_id: "8k0Q4MpH2IGahWrTRtqM61YV2MtLPApz"
-      cart_item_id: "2"
+      cart_item_id: "MTQ="
       custom_attributes: [
         { 
           attribute_code: "first_attribute", 
@@ -57,9 +57,12 @@ mutation {
   ) {
     cart {
       id
-      custom_attributes {
-        attribute_code
-        value
+      items {
+        uid
+        custom_attributes {
+          attribute_code
+          value
+        }
       }
     }
   }
@@ -74,14 +77,19 @@ mutation {
     "setCustomAttributesOnCartItem": {
       "cart": {
         "id": "8k0Q4MpH2IGahWrTRtqM61YV2MtLPApz",
-        "custom_attributes": [
+        "items": [
           {
-            "attribute_code": "first_attribute",
-            "value": "value_one"
-          }
-          {
-            "attribute_code": "second_attribute",
-            "value": "value_twp"
+            "uid": "MTU=",
+            "custom_attributes": [
+              {
+                "attribute_code": "first_attribute",
+                "value": "value_one"
+              },
+              {
+                "attribute_code": "second_attribute",
+                "value": "value_twp"
+              }
+            ]
           }
         ]
       }


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) 

* Corrected cart_item_id argument to use the uid rather than the numeric id.

* Added cart_item custom_attributes field to cart response: previous missing.

## Affected pages

<!-- REQUIRED List the affected pages on developer.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to Magento Open Source code

<!--  OPTIONAL - REMOVE THIS SECTION IF NOT USED. If this pull request references a file in a Magento Open Source or Adobe Commerce codebase repository, add it here. -->

- ...

<!--
If you are fixing a GitHub issue, using the GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) closes the issue when this pull request is merged. Example: `Fixes #1234`.
`main` is the default branch. Merged pull requests to `main` go live on the site automatically. Any requested changes to content on the `main` branch must be related to the released codebase. Any content related to future releases goes in the `develop` branch.
See Contribution guidelines (https://github.com/AdobeDocs/commerce-webapi/blob/main/.github/CONTRIBUTING.md) for more information.
-->

whatsnew
Corrected examples in the `setCustomAttributesOnCartItem` mutation.