### PR TITLE
Update schemas July - ACCS

### DIFF
--- a/spectaql/schema_saas.json
+++ b/spectaql/schema_saas.json
@@ -4649,6 +4649,29 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AuthenticationResult",
+        "description": "",
+        "fields": [
+          {
+            "name": "liability_shift",
+            "description": "Liability Shift",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "LiabilityShift",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AvailableCurrency",
         "description": "Defines the code and symbol of a currency that can be used for purchase orders.",
         "fields": [
@@ -8121,6 +8144,18 @@
         "description": "",
         "fields": [
           {
+            "name": "authentication_result",
+            "description": "Authentication result",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AuthenticationResult",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "bin_details",
             "description": "Card bin details",
             "args": [],
@@ -10113,6 +10148,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "CartTaxItem",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custom_fees",
+            "description": "Custom fees applied to the cart via out-of-process webhooks.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "OopeCustomFee",
                 "ofType": null
               }
             },
@@ -15967,33 +16018,6 @@
           }
         ],
         "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "CompletePayByLinkPaymentOutput",
-        "description": "Result of completing a Pay By Link payment.",
-        "fields": [
-          {
-            "name": "order_number",
-            "description": "The increment id of the order whose payment was completed.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -37251,6 +37275,18 @@
             "deprecationReason": null
           },
           {
+            "name": "google_pay_mode",
+            "description": "Google Pay mode",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "GooglePayMode",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "is_visible",
             "description": "Indicates whether the payment method is displayed",
             "args": [],
@@ -37389,6 +37425,29 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "GooglePayMode",
+        "description": "Google Pay mode.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "TEST",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PRODUCTION",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -40114,6 +40173,35 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "LiabilityShift",
+        "description": "Defines the possible values of liability shift",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "NO",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POSSIBLE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNKNOWN",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "LineItemNoteInput",
         "description": "Sets quote item note.",
@@ -41766,47 +41854,6 @@
             "type": {
               "kind": "OBJECT",
               "name": "PlaceOrderOutput",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "completePayByLinkPayment",
-            "description": "Complete a Pay By Link payment for an in-process gateway (Payment Services).",
-            "args": [
-              {
-                "name": "token",
-                "description": "The token issued for the Pay By Link payment.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "payment_method",
-                "description": "The payment method the customer has selected to complete the order.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "PaymentMethodInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "CompletePayByLinkPaymentOutput",
               "ofType": null
             },
             "isDeprecated": false,
@@ -50028,6 +50075,78 @@
       },
       {
         "kind": "OBJECT",
+        "name": "NominatedSourceError",
+        "description": "Error wrapper describing the nomination state of a cart item.",
+        "fields": [
+          {
+            "name": "code",
+            "description": "Machine-readable error code.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NominatedSourceErrorCode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": "Human-readable description of the error.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "NominatedSourceErrorCode",
+        "description": "Reasons a nominated-source operation can fail for a given cart item.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "UNKNOWN_SOURCE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SOURCE_DISABLED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_ENOUGH_QTY",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "NoSuchEntityUidError",
         "description": "Contains an error message when an invalid UID was specified.",
         "fields": [
@@ -50123,6 +50242,65 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "OopeCustomFee",
+        "description": "A custom fee applied to the cart by an out-of-process webhook.",
+        "fields": [
+          {
+            "name": "amount",
+            "description": "The fee amount in the cart currency.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "code",
+            "description": "The unique identifier for this fee.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": "The display label for this fee.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -52088,423 +52266,6 @@
       },
       {
         "kind": "INPUT_OBJECT",
-        "name": "PayByLinkInput",
-        "description": "Defines optional inputs for the Pay By Link payment method.",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "recipient_email",
-            "description": "Email address of the person who should receive the payment link. When omitted, the link is sent to the order customer's email.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "PayByLinkOrder",
-        "description": "Read-only projection of the pending order behind a Pay By Link token. Returned by `payByLinkOrder` so the EDS payment page can render the order summary before collecting payment.",
-        "fields": [
-          {
-            "name": "billing_address",
-            "description": "The order's billing address. Read-only on the payment page.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "PayByLinkOrderAddress",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "customer_email",
-            "description": "Email address the payment link was sent to.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "expires_at",
-            "description": "UTC `Y-m-d H:i:s` timestamp after which the token is no longer redeemable.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "items",
-            "description": "Top-level line items on the order. Resolve product detail (image, description, variant) from the Catalog Service using `sku`.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PayByLinkOrderItem",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "shipping_address",
-            "description": "The order's shipping address. Read-only on the payment page.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "PayByLinkOrderAddress",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "totals",
-            "description": "Money totals for the order.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PayByLinkOrderTotals",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "PayByLinkOrderAddress",
-        "description": "Read-only address attached to a Pay By Link order.",
-        "fields": [
-          {
-            "name": "city",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "country_code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "firstname",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "lastname",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "postcode",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "region",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "region_code",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "street",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "telephone",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "PayByLinkOrderItem",
-        "description": "A single line item on a Pay By Link order.",
-        "fields": [
-          {
-            "name": "name",
-            "description": "Product name captured on the order at placement time.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "price",
-            "description": "Unit price for the item, including currency.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Money",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "quantity",
-            "description": "Quantity ordered.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "sku",
-            "description": "SKU captured on the order line. Use this to resolve product detail from the Catalog Service.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "PayByLinkOrderTotals",
-        "description": "Order-level money totals.",
-        "fields": [
-          {
-            "name": "grand_total",
-            "description": "Amount the customer will be charged.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Money",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "shipping",
-            "description": "Shipping amount.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Money",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "subtotal",
-            "description": "Sum of line item prices before shipping/tax/discount.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Money",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tax",
-            "description": "Tax amount.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Money",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
         "name": "PaymentAttributeInput",
         "description": "Defines the payment attribute.",
         "fields": null,
@@ -52857,6 +52618,12 @@
             "deprecationReason": null
           },
           {
+            "name": "START_OF_CHECKOUT",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ADMIN",
             "description": "",
             "isDeprecated": false,
@@ -52896,16 +52663,6 @@
                 "name": "String",
                 "ofType": null
               }
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "paybylink",
-            "description": "Pay By Link payment method options.",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "PayByLinkInput",
-              "ofType": null
             },
             "defaultValue": null
           },
@@ -58231,6 +57988,18 @@
             "deprecationReason": null
           },
           {
+            "name": "canEditQuantity",
+            "description": "Indicates if the quantity of the option value can be edited.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "title",
             "description": "The display name of the option value. For example, `Red`, `Blue` or `Green`",
             "args": [],
@@ -58744,16 +58513,12 @@
             "name": "items",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
+              "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             "defaultValue": null
@@ -61732,33 +61497,6 @@
             "deprecationReason": null
           },
           {
-            "name": "payByLinkOrder",
-            "description": "Resolves a Pay By Link token to the pending order's summary so the EDS payment page can render it before collecting payment.",
-            "args": [
-              {
-                "name": "token",
-                "description": "The token issued for the Pay By Link payment.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "PayByLinkOrder",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "pickupLocations",
             "description": "The pickup locations query searches for locations that match the search request requirements.",
             "args": [
@@ -63336,6 +63074,89 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RejectedNomination",
+        "description": "A single cart item whose source nomination was rejected.",
+        "fields": [
+          {
+            "name": "available_qty",
+            "description": "The quantity available at the nominated source, when applicable.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cart_item_uid",
+            "description": "The unique ID of the cart item the nomination was requested for.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "code",
+            "description": "Machine-readable reason the nomination was rejected.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NominatedSourceErrorCode",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": "Human-readable description of the rejection.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requested_qty",
+            "description": "The quantity requested at the nominated source, when applicable.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
               "ofType": null
             },
             "isDeprecated": false,
@@ -71960,6 +71781,216 @@
       },
       {
         "kind": "OBJECT",
+        "name": "SourceAddress",
+        "description": "Physical address of an inventory source, for store-finder use cases.",
+        "fields": [
+          {
+            "name": "city",
+            "description": "City of the source.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country_id",
+            "description": "Two-letter country code of the source.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "latitude",
+            "description": "Latitude of the source.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "longitude",
+            "description": "Longitude of the source.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Display name of the source.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "phone",
+            "description": "Contact phone number of the source.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postcode",
+            "description": "Postal code of the source.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "region",
+            "description": "Region or state of the source.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "source_code",
+            "description": "The inventory source code.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "street",
+            "description": "Street address of the source.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SourceAvailability",
+        "description": "Per-source availability for a SKU.",
+        "fields": [
+          {
+            "name": "available_qty",
+            "description": "Quantity available at the source, net of open source-level reservations.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "is_salable",
+            "description": "Whether the SKU is salable at the source.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sku",
+            "description": "The product SKU the availability applies to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "source_code",
+            "description": "The inventory source code.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "StatsBucket",
         "description": "For retrieving statistics across multiple buckets",
         "fields": [
@@ -76369,13 +76400,9 @@
             "name": "sku",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null
           }

--- a/src/openapi/accs-schema.yaml
+++ b/src/openapi/accs-schema.yaml
@@ -59,6 +59,19 @@ definitions:
     - apply_fee_on_last_invoice
     - apply_fee_on_last_creditmemo
     type: object
+  adobe-assets-integration-data-alt-text-item-interface:
+    description: Alt text item interface. DTO for per-store-view alt text label.
+    properties:
+      store_code:
+        description: Store view code
+        type: string
+      value:
+        description: Alt text value
+        type: string
+    required:
+    - store_code
+    - value
+    type: object
   adobe-assets-integration-data-asset-image-interface:
     description: Asset image data interface
     properties:
@@ -96,6 +109,11 @@ definitions:
   adobe-assets-integration-data-image-item-interface:
     description: Image item Interface. Dto to receive an import image asset.
     properties:
+      alt_texts:
+        description: Alt texts per store view
+        items:
+          "$ref": "#/definitions/adobe-assets-integration-data-alt-text-item-interface"
+        type: array
       asset_id:
         description: Asset ID
         type: string
@@ -118,6 +136,31 @@ definitions:
     - asset_id
     - roles
     - url
+    - alt_texts
+    type: object
+  adobe-assets-integration-data-sync-asset-sku-mapping-interface:
+    description: Per-SKU mapping data within a syncAsset request.
+    properties:
+      alt_texts:
+        description: Alt texts
+        items:
+          "$ref": "#/definitions/adobe-assets-integration-data-alt-text-item-interface"
+        type: array
+      position:
+        description: Position
+        type: integer
+      roles:
+        description: Roles
+        items:
+          type: string
+        type: array
+      sku:
+        description: SKU
+        type: string
+    required:
+    - sku
+    - roles
+    - alt_texts
     type: object
   adobe-assets-integration-data-video-item-interface:
     description: Video item Interface. Dto to receive an import video asset.
@@ -2255,6 +2298,11 @@ definitions:
       id:
         description: Id field
         type: string
+      installed:
+        description: If the extension is installed
+        type: boolean
+    required:
+    - installed
     type: object
   company-credit-data-credit-balance-options-interface:
     description: Credit balance data transfer object interface.
@@ -2842,6 +2890,9 @@ definitions:
       reference_id:
         description: Reference ID for this send request.
         type: string
+      reply_to_email:
+        description: Reply to email address used for this email (if any).
+        type: string
       template_code:
         description: Code (name) from the template record.
         type: string
@@ -2854,6 +2905,93 @@ definitions:
     - recipient_email
     - template_id
     - template_code
+    type: object
+  custom-email-template-data-email-template-detail-interface:
+    description: Full custom email template DTO returned by the single-resource (detail)
+      read. Extends the lean list DTO with the heavy content fields (template_text,
+      template_styles) that the list endpoint deliberately omits. The WebAPI serializer
+      renders fields from the declared return type, so exposing these here — and only
+      here — keeps GET /V1/custom-email/templates a summary while GET /V1/custom-email/templates/{id}
+      returns the complete template.
+    properties:
+      added_at:
+        description: Timestamp.
+        type: string
+      modified_at:
+        description: Modification timestamp.
+        type: string
+      template_code:
+        description: Code (name).
+        type: string
+      template_id:
+        description: ID (usable with custom-email/send).
+        type: integer
+      template_styles:
+        description: Styles (CSS). Empty for plain-text templates.
+        type: string
+      template_subject:
+        description: Subject.
+        type: string
+      template_text:
+        description: Content (raw stored body, markup intact; not rendered).
+        type: string
+      template_type:
+        description: Content type ("html" or "text").
+        type: string
+    required:
+    - template_text
+    - template_styles
+    - template_id
+    - template_code
+    - template_subject
+    - template_type
+    type: object
+  custom-email-template-data-email-template-interface:
+    description: Custom email template DTO. Represents a row from the email_template
+      table (a user-created custom template). The template_id is usable as-is with
+      POST /V1/custom-email/send.
+    properties:
+      added_at:
+        description: Timestamp.
+        type: string
+      modified_at:
+        description: Modification timestamp.
+        type: string
+      template_code:
+        description: Code (name).
+        type: string
+      template_id:
+        description: ID (usable with custom-email/send).
+        type: integer
+      template_subject:
+        description: Subject.
+        type: string
+      template_type:
+        description: Content type ("html" or "text").
+        type: string
+    required:
+    - template_id
+    - template_code
+    - template_subject
+    - template_type
+    type: object
+  custom-email-template-data-email-template-search-results-interface:
+    description: Search results for custom email templates.
+    properties:
+      items:
+        description: Templates list.
+        items:
+          "$ref": "#/definitions/custom-email-template-data-email-template-interface"
+        type: array
+      search_criteria:
+        "$ref": "#/definitions/framework-search-criteria-interface"
+      total_count:
+        description: Total count.
+        type: integer
+    required:
+    - items
+    - search_criteria
+    - total_count
     type: object
   customer-data-address-extension-interface:
     description: ExtensionInterface class for @see \Magento\Customer\Api\Data\AddressInterface
@@ -4820,6 +4958,15 @@ definitions:
     - source_selection_items
     - shippable
     type: object
+  login-as-customer-storefront-compatibility-data-one-time-login-code-response-interface:
+    description: Response containing the one-time password for customer login.
+    properties:
+      otp:
+        description: The one-time password.
+        type: string
+    required:
+    - otp
+    type: object
   negotiable-quote-data-attachment-content-extension-interface:
     description: ExtensionInterface class for @see \Magento\NegotiableQuote\Api\Data\AttachmentContentInterface
     type: object
@@ -5383,15 +5530,6 @@ definitions:
     - default
     - visible_on_front
     type: object
-  otp-rest-data-otp-response-interface:
-    description: Response containing the one-time password for customer login.
-    properties:
-      otp:
-        description: The one-time password.
-        type: string
-    required:
-    - otp
-    type: object
   out-of-process-observability-data-subscription-header-interface:
     description: Observability Subscription Header data interface
     properties:
@@ -5810,6 +5948,8 @@ definitions:
         type: array
       negotiable_quote_item:
         "$ref": "#/definitions/negotiable-quote-data-negotiable-quote-item-interface"
+      nominated_source_code:
+        type: string
     type: object
   quote-data-cart-item-interface:
     description: Interface CartItemInterface
@@ -7617,6 +7757,8 @@ definitions:
         items:
           "$ref": "#/definitions/tax-data-order-tax-item-interface"
         type: array
+      admin_assisted_order:
+        type: integer
       applied_taxes:
         items:
           "$ref": "#/definitions/tax-data-order-tax-details-applied-tax-interface"
@@ -8258,6 +8400,8 @@ definitions:
         items:
           "$ref": "#/definitions/tax-data-order-tax-item-interface"
         type: array
+      nominated_source_code:
+        type: string
     type: object
   sales-data-order-item-interface:
     description: Order item interface. An order is a document that a web store issues
@@ -10384,9 +10528,9 @@ definitions:
 host: https://<server>.api.commerce.adobe.com/<tenant-id>
 info:
   title: Adobe Commerce as a Cloud Service
-  version: May 2026
+  version: July 2026
   description:
-    "$ref": "intro/accs-intro.md"
+    "$ref": intro/accs-intro.md
 paths:
   "/V1/addresses/{addressId}":
     delete:
@@ -10471,7 +10615,9 @@ paths:
       consumes:
       - application/json
       - application/xml
-      description: Saving the selected extensions to database.
+      description: Saving the selected extensions to database. If an extension already
+        exists for the given extension_name and extension_workspace, it is updated
+        instead of failing.
       operationId: PostV1AdminuisdkExtension
       parameters:
       - in: body
@@ -15932,6 +16078,10 @@ paths:
             recipientEmail:
               description: Recipient email address
               type: string
+            replyToEmail:
+              description: Optional Reply-To email address; omit or pass null to use
+                the template sender
+              type: string
             templateId:
               description: Email template ID
               type: integer
@@ -15966,15 +16116,149 @@ paths:
       tags:
       - custom-email/send
       summary: custom-email/send
+  "/V1/custom-email/templates":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Retrieve custom email templates matching the given search criteria.
+      operationId: GetV1CustomemailTemplates
+      parameters:
+      - description: Field
+        in: query
+        name: searchCriteria[filterGroups][0][filters][0][field]
+        type: string
+      - description: Value
+        in: query
+        name: searchCriteria[filterGroups][0][filters][0][value]
+        type: string
+      - description: Condition type
+        in: query
+        name: searchCriteria[filterGroups][0][filters][0][conditionType]
+        type: string
+      - description: Sorting field.
+        in: query
+        name: searchCriteria[sortOrders][0][field]
+        type: string
+      - description: Sorting direction.
+        in: query
+        name: searchCriteria[sortOrders][0][direction]
+        type: string
+      - description: Page size.
+        in: query
+        name: searchCriteria[pageSize]
+        type: integer
+      - description: Current page.
+        in: query
+        name: searchCriteria[currentPage]
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/custom-email-template-data-email-template-search-results-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - custom-email/templates
+      summary: custom-email/templates
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: Create a custom email template. Server-assigned fields (template_id,
+        added_at, modified_at) and the strict-mode flag (is_legacy = 0) are set by
+        the service; any value supplied for them is ignored. The template_code must
+        be unique. Returns the persisted template, including its server-assigned template_id
+        (usable as-is with POST /V1/custom-email/send).
+      operationId: PostV1CustomemailTemplates
+      parameters:
+      - in: body
+        name: PostV1CustomemailTemplatesBody
+        schema:
+          properties:
+            template:
+              "$ref": "#/definitions/custom-email-template-data-email-template-detail-interface"
+          required:
+          - template
+          type: object
+          xml:
+            name: request
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/custom-email-template-data-email-template-detail-interface"
+        '400':
+          description: 400 Bad Request
+          schema:
+            "$ref": "#/definitions/error-response"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - custom-email/templates
+      summary: custom-email/templates
+  "/V1/custom-email/templates/{templateId}":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Retrieve a single custom email template by id, including its content
+        and styles.
+      operationId: GetV1CustomemailTemplatesTemplateId
+      parameters:
+      - in: path
+        name: templateId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/custom-email-template-data-email-template-detail-interface"
+        '400':
+          description: 400 Bad Request
+          schema:
+            "$ref": "#/definitions/error-response"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - custom-email/templates/{templateId}
+      summary: custom-email/templates/{templateId}
   "/V1/customer/{customerId}/otp":
     post:
       consumes:
       - application/json
       - application/xml
-      description: Generate a one-time password for the customer identified by ID.
-        The OTP can be used with the exchangeOtpForCustomerToken GraphQL mutation.
-        Returns a successful response even when the customer does not exist (prevents
-        user enumeration).
+      description: Generate a one-time code for the customer. The code is used as
+        the password with generateCustomerToken / one-time exchange flow.
       operationId: PostV1CustomerCustomerIdOtp
       parameters:
       - in: path
@@ -15986,6 +16270,8 @@ paths:
         schema:
           properties:
             reason:
+              description: Human-readable audit reason; omitted or blank (after trim)
+                uses {@see self::DEFAULT_GENERATE_OTP_AUDIT_REASON}.
               type: string
           type: object
           xml:
@@ -15997,7 +16283,7 @@ paths:
         '200':
           description: 200 Success.
           schema:
-            "$ref": "#/definitions/otp-rest-data-otp-response-interface"
+            "$ref": "#/definitions/login-as-customer-storefront-compatibility-data-one-time-login-code-response-interface"
         '401':
           description: 401 Unauthorized
           schema:
@@ -22657,6 +22943,293 @@ paths:
       tags:
       - order/{orderId}/ship
       summary: order/{orderId}/ship
+  "/V1/orderChain/{id}/cancel":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: Cancels a specified order.
+      operationId: PostV1OrderChainIdCancel
+      parameters:
+      - description: The order ID.
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            type: boolean
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - orderChain/{id}/cancel
+      summary: orderChain/{id}/cancel
+  "/V1/orderChain/{id}/comments":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Lists comments for a specified order.
+      operationId: GetV1OrderChainIdComments
+      parameters:
+      - description: The order ID.
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/sales-data-order-status-history-search-result-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - orderChain/{id}/comments
+      summary: orderChain/{id}/comments
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: Adds a comment to a specified order.
+      operationId: PostV1OrderChainIdComments
+      parameters:
+      - description: The order ID.
+        in: path
+        name: id
+        required: true
+        type: integer
+      - in: body
+        name: PostV1OrderChainIdCommentsBody
+        schema:
+          properties:
+            statusHistory:
+              "$ref": "#/definitions/sales-data-order-status-history-interface"
+          required:
+          - statusHistory
+          type: object
+          xml:
+            name: request
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            type: boolean
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - orderChain/{id}/comments
+      summary: orderChain/{id}/comments
+  "/V1/orderChain/{id}/emails":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: Emails a user a specified order.
+      operationId: PostV1OrderChainIdEmails
+      parameters:
+      - description: The order ID.
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            type: boolean
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - orderChain/{id}/emails
+      summary: orderChain/{id}/emails
+  "/V1/orderChain/{id}/hold":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: Holds a specified order.
+      operationId: PostV1OrderChainIdHold
+      parameters:
+      - description: The order ID.
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            type: boolean
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - orderChain/{id}/hold
+      summary: orderChain/{id}/hold
+  "/V1/orderChain/{id}/statuses":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Gets the status for a specified order.
+      operationId: GetV1OrderChainIdStatuses
+      parameters:
+      - description: The order ID.
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            description: Order status.
+            type: string
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - orderChain/{id}/statuses
+      summary: orderChain/{id}/statuses
+  "/V1/orderChain/{id}/unhold":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: Releases a specified order from hold status.
+      operationId: PostV1OrderChainIdUnhold
+      parameters:
+      - description: The order ID.
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            type: boolean
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - orderChain/{id}/unhold
+      summary: orderChain/{id}/unhold
+  "/V1/orderChain/{orderId}/invoice":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: ''
+      operationId: PostV1OrderChainOrderIdInvoice
+      parameters:
+      - in: path
+        name: orderId
+        required: true
+        type: integer
+      - in: body
+        name: PostV1OrderChainOrderIdInvoiceBody
+        schema:
+          properties:
+            appendComment:
+              type: boolean
+            arguments:
+              "$ref": "#/definitions/sales-data-invoice-creation-arguments-interface"
+            capture:
+              type: boolean
+            comment:
+              "$ref": "#/definitions/sales-data-invoice-comment-creation-interface"
+            items:
+              items:
+                "$ref": "#/definitions/sales-data-invoice-item-creation-interface"
+              type: array
+            notify:
+              type: boolean
+          type: object
+          xml:
+            name: request
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            type: integer
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - orderChain/{orderId}/invoice
+      summary: orderChain/{orderId}/invoice
   "/V1/orders":
     get:
       consumes:
@@ -22720,6 +23293,7 @@ paths:
       consumes:
       - application/json
       - application/xml
+      deprecated: true
       description: Performs persist operations for a specified order.
       operationId: PostV1Orders
       parameters:
@@ -22758,6 +23332,7 @@ paths:
       consumes:
       - application/json
       - application/xml
+      deprecated: true
       description: Performs persist operations for a specified order.
       operationId: PutV1OrdersCreate
       parameters:
@@ -23149,6 +23724,107 @@ paths:
       tags:
       - orders/{id}/unhold
       summary: orders/{id}/unhold
+  "/V1/orders/{orderId}/edit/start":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: Copy an existing order into a new admin quote and return the quote
+        ID. Items, addresses, shipping method, and coupon code are copied from the
+        original order. The resulting quote is an inactive admin quote (isSuperMode)
+        that can be modified via the standard cart REST APIs before submission.
+      operationId: PostV1OrdersOrderIdEditStart
+      parameters:
+      - in: path
+        name: orderId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            description: The quote ID to use for further modifications and for submitEdit
+            type: integer
+        '400':
+          description: 400 Bad Request
+          schema:
+            "$ref": "#/definitions/error-response"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - orders/{orderId}/edit/start
+      summary: orders/{orderId}/edit/start
+  "/V1/orders/{orderId}/edit/submit":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: 'Submit an edited quote as a new order, replacing the original
+        order. The quote must have a payment method set before calling this (use PUT
+        /V1/carts/:quoteId/selected-payment-method). On success:   - A new order is
+        created from the quote   - The original order is cancelled   - The two orders
+        are linked via relation_parent_id / relation_child_id   - The new order gets
+        an increment ID of the form {originalIncrement}-{n}'
+      operationId: PostV1OrdersOrderIdEditSubmit
+      parameters:
+      - description: The original order being edited
+        in: path
+        name: orderId
+        required: true
+        type: integer
+      - in: body
+        name: PostV1OrdersOrderIdEditSubmitBody
+        schema:
+          properties:
+            quoteId:
+              description: The quote ID returned by startEdit
+              type: integer
+          required:
+          - quoteId
+          type: object
+          xml:
+            name: request
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            description: The new order ID
+            type: integer
+        '400':
+          description: 400 Bad Request
+          schema:
+            "$ref": "#/definitions/error-response"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - orders/{orderId}/edit/submit
+      summary: orders/{orderId}/edit/submit
   "/V1/orders/{parent_id}":
     put:
       consumes:
@@ -24614,12 +25290,12 @@ paths:
       - application/json
       - application/xml
       responses:
-        '401':
-          description: 401 Unauthorized
+        '400':
+          description: 400 Bad Request
           schema:
             "$ref": "#/definitions/error-response"
-        '500':
-          description: Internal Server error
+        '401':
+          description: 401 Unauthorized
           schema:
             "$ref": "#/definitions/error-response"
         default:
@@ -24674,6 +25350,10 @@ paths:
         name: PostV1ProductsExternalmediaImageBody
         schema:
           properties:
+            altTexts:
+              items:
+                "$ref": "#/definitions/adobe-assets-integration-data-alt-text-item-interface"
+              type: array
             assetId:
               type: string
             position:
@@ -24838,6 +25518,58 @@ paths:
       tags:
       - products/external-media/remove-by-sku
       summary: products/external-media/remove-by-sku
+  "/V1/products/external-media/sync-asset":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: 'POST to sync an asset: removes stale SKU mappings and imports
+        current ones in a single atomic call. Replaces the three-call sequence: getSku
+        + removeByAssetIdAndSku + importImage/importVideo.'
+      operationId: PostV1ProductsExternalmediaSyncasset
+      parameters:
+      - in: body
+        name: PostV1ProductsExternalmediaSyncassetBody
+        schema:
+          properties:
+            assetId:
+              type: string
+            deliveryUrl:
+              description: CDN delivery URL; used as image URL or as video thumbnail
+                URL
+              type: string
+            skus:
+              items:
+                "$ref": "#/definitions/adobe-assets-integration-data-sync-asset-sku-mapping-interface"
+              type: array
+            videoPlayerUrl:
+              description: Set for video assets; null for images
+              type: string
+          required:
+          - assetId
+          - deliveryUrl
+          type: object
+          xml:
+            name: request
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '400':
+          description: 400 Bad Request
+          schema:
+            "$ref": "#/definitions/error-response"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - products/external-media/sync-asset
+      summary: products/external-media/sync-asset
   "/V1/products/external-media/version":
     get:
       consumes:
@@ -30141,6 +30873,8 @@ tags:
 - name: creditmemo/refund
 - name: creditmemos
 - name: custom-email/send
+- name: custom-email/templates
+- name: custom-email/templates/{templateId}
 - name: customer/{customerId}/otp
 - name: customerGroups
 - name: customerGroups/{id}
@@ -30268,6 +31002,13 @@ tags:
 - name: order/{orderId}/refund
 - name: order/{orderId}/ship
 - name: order/notify-orders-are-ready-for-pickup
+- name: orderChain/{id}/cancel
+- name: orderChain/{id}/comments
+- name: orderChain/{id}/emails
+- name: orderChain/{id}/hold
+- name: orderChain/{id}/statuses
+- name: orderChain/{id}/unhold
+- name: orderChain/{orderId}/invoice
 - name: orders
 - name: orders/{id}
 - name: orders/{id}/cancel
@@ -30276,6 +31017,8 @@ tags:
 - name: orders/{id}/hold
 - name: orders/{id}/statuses
 - name: orders/{id}/unhold
+- name: orders/{orderId}/edit/start
+- name: orders/{orderId}/edit/submit
 - name: orders/{parent_id}
 - name: orders/create
 - name: orders/items
@@ -30330,6 +31073,7 @@ tags:
 - name: products/external-media/remove-by-asset-id
 - name: products/external-media/remove-by-asset-id-and-sku
 - name: products/external-media/remove-by-sku
+- name: products/external-media/sync-asset
 - name: products/external-media/version
 - name: products/external-media/video
 - name: products/links/{type}/attributes
@@ -30548,6 +31292,8 @@ x-tagGroups:
 - name: custom email
   tags:
   - custom-email/send
+  - custom-email/templates
+  - custom-email/templates/{templateId}
 - name: customer
   tags:
   - customer/{customerId}/otp
@@ -30725,6 +31471,15 @@ x-tagGroups:
   - order/{orderId}/invoice
   - order/{orderId}/refund
   - order/{orderId}/ship
+- name: orderChain
+  tags:
+  - orderChain/{id}/cancel
+  - orderChain/{id}/comments
+  - orderChain/{id}/emails
+  - orderChain/{id}/hold
+  - orderChain/{id}/statuses
+  - orderChain/{id}/unhold
+  - orderChain/{orderId}/invoice
 - name: orders
   tags:
   - orders
@@ -30738,6 +31493,8 @@ x-tagGroups:
   - orders/{id}/hold
   - orders/{id}/statuses
   - orders/{id}/unhold
+  - orders/{orderId}/edit/start
+  - orders/{orderId}/edit/submit
   - orders/{parent_id}
 - name: products
   tags:
@@ -30773,6 +31530,7 @@ x-tagGroups:
   - products/external-media/remove-by-asset-id
   - products/external-media/remove-by-asset-id-and-sku
   - products/external-media/remove-by-sku
+  - products/external-media/sync-asset
   - products/external-media/version
   - products/external-media/video
   - products/links/types

--- a/src/pages/includes/autogenerated/graphql-api-saas-mutations.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-mutations.md
@@ -115,11 +115,11 @@ mutation acceptNegotiableQuoteTemplate($input: AcceptNegotiableQuoteTemplateInpu
     "acceptNegotiableQuoteTemplate": {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
-      "created_at": "xyz789",
+      "created_at": "abc123",
       "expiration_date": "abc123",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
-      "is_min_max_qty_used": true,
+      "is_min_max_qty_used": false,
       "is_virtual": false,
       "items": [CartItemInterface],
       "max_order_commitment": 123,
@@ -135,10 +135,10 @@ mutation acceptNegotiableQuoteTemplate($input: AcceptNegotiableQuoteTemplateInpu
         NegotiableQuoteShippingAddress
       ],
       "status": "abc123",
-      "template_id": "4",
-      "total_quantity": 987.65,
-      "uid": "4",
-      "updated_at": "xyz789"
+      "template_id": 4,
+      "total_quantity": 123.45,
+      "uid": 4,
+      "updated_at": "abc123"
     }
   }
 }
@@ -227,7 +227,7 @@ mutation addGiftRegistryRegistrants(
 
 ```json
 {
-  "giftRegistryUid": "4",
+  "giftRegistryUid": 4,
   "registrants": [AddGiftRegistryRegistrantInput]
 }
 ```
@@ -350,9 +350,9 @@ mutation addProductsToCompareList($input: AddProductsToCompareListInput) {
   "data": {
     "addProductsToCompareList": {
       "attributes": [ComparableAttribute],
-      "item_count": 123,
+      "item_count": 987,
       "items": [ComparableItem],
-      "uid": 4
+      "uid": "4"
     }
   }
 }
@@ -675,7 +675,7 @@ mutation addRequisitionListItemsToCart(
         AddRequisitionListItemToCartUserError
       ],
       "cart": Cart,
-      "status": true
+      "status": false
     }
   }
 }
@@ -813,7 +813,10 @@ mutation addWishlistItemsToCart(
 ##### Variables
 
 ```json
-{"wishlistId": 4, "wishlistItemIds": [4]}
+{
+  "wishlistId": "4",
+  "wishlistItemIds": ["4"]
+}
 ```
 
 ##### Response
@@ -1255,7 +1258,7 @@ mutation assignCustomerToGuestCart($cart_id: String!) {
 ##### Variables
 
 ```json
-{"cart_id": "xyz789"}
+{"cart_id": "abc123"}
 ```
 
 ##### Response
@@ -1274,15 +1277,15 @@ mutation assignCustomerToGuestCart($cart_id: String!) {
       ],
       "billing_address": BillingCartAddress,
       "custom_attributes": [CustomAttribute],
-      "email": "abc123",
+      "email": "xyz789",
       "gift_message": GiftMessage,
       "gift_receipt_included": true,
       "gift_wrapping": GiftWrapping,
-      "id": 4,
-      "is_virtual": false,
+      "id": "4",
+      "is_virtual": true,
       "itemsV2": CartItems,
       "prices": CartPrices,
-      "printed_card_included": true,
+      "printed_card_included": false,
       "rules": [CartRuleStorefront],
       "selected_payment_method": SelectedPaymentMethod,
       "shipping_addresses": [ShippingCartAddress],
@@ -1371,28 +1374,28 @@ mutation cancelNegotiableQuoteTemplate($input: CancelNegotiableQuoteTemplateInpu
     "cancelNegotiableQuoteTemplate": {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
-      "created_at": "abc123",
+      "created_at": "xyz789",
       "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
-      "is_min_max_qty_used": true,
+      "is_min_max_qty_used": false,
       "is_virtual": false,
       "items": [CartItemInterface],
       "max_order_commitment": 987,
-      "min_order_commitment": 987,
-      "name": "xyz789",
+      "min_order_commitment": 123,
+      "name": "abc123",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
         NegotiableQuoteReferenceDocumentLink
       ],
-      "sales_rep_name": "abc123",
+      "sales_rep_name": "xyz789",
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
-      "status": "xyz789",
+      "status": "abc123",
       "template_id": 4,
-      "total_quantity": 987.65,
+      "total_quantity": 123.45,
       "uid": 4,
       "updated_at": "abc123"
     }
@@ -1660,19 +1663,19 @@ mutation changeCustomerPassword(
       "created_at": "xyz789",
       "custom_attributes": [AttributeValueInterface],
       "date_of_birth": "xyz789",
-      "default_billing": "abc123",
-      "default_shipping": "xyz789",
-      "email": "abc123",
-      "firstname": "abc123",
-      "gender": 123,
+      "default_billing": "xyz789",
+      "default_shipping": "abc123",
+      "email": "xyz789",
+      "firstname": "xyz789",
+      "gender": 987,
       "gift_registries": [GiftRegistry],
       "gift_registry": GiftRegistry,
       "group": CustomerGroupStorefront,
-      "id": "4",
-      "is_subscribed": true,
+      "id": 4,
+      "is_subscribed": false,
       "job_title": "abc123",
-      "lastname": "xyz789",
-      "middlename": "xyz789",
+      "lastname": "abc123",
+      "middlename": "abc123",
       "orders": CustomerOrders,
       "prefix": "abc123",
       "purchase_order": PurchaseOrder,
@@ -1681,7 +1684,7 @@ mutation changeCustomerPassword(
       "purchase_order_approval_rules": PurchaseOrderApprovalRules,
       "purchase_orders": PurchaseOrders,
       "purchase_orders_enabled": false,
-      "quote_enabled": false,
+      "quote_enabled": true,
       "requisition_lists": RequisitionLists,
       "return": Return,
       "returns": Returns,
@@ -1691,8 +1694,8 @@ mutation changeCustomerPassword(
       "status": "ACTIVE",
       "store_credit": CustomerStoreCredit,
       "structure_id": "4",
-      "suffix": "xyz789",
-      "taxvat": "xyz789",
+      "suffix": "abc123",
+      "taxvat": "abc123",
       "team": CompanyTeam,
       "telephone": "abc123",
       "wishlist_v2": Wishlist,
@@ -1734,7 +1737,7 @@ mutation clearCustomerCart($cartUid: String!) {
 ##### Variables
 
 ```json
-{"cartUid": "abc123"}
+{"cartUid": "xyz789"}
 ```
 
 ##### Response
@@ -1742,7 +1745,7 @@ mutation clearCustomerCart($cartUid: String!) {
 ```json
 {
   "data": {
-    "clearCustomerCart": {"cart": Cart, "status": false}
+    "clearCustomerCart": {"cart": Cart, "status": true}
   }
 }
 ```
@@ -1781,7 +1784,7 @@ mutation clearWishlist($wishlistId: ID!) {
 ##### Variables
 
 ```json
-{"wishlistId": "4"}
+{"wishlistId": 4}
 ```
 
 ##### Response
@@ -1950,7 +1953,7 @@ mutation confirmCancelOrder($input: ConfirmCancelOrderInput!) {
 {
   "data": {
     "confirmCancelOrder": {
-      "error": "abc123",
+      "error": "xyz789",
       "errorV2": CancelOrderError,
       "order": CustomerOrder
     }
@@ -2420,9 +2423,9 @@ mutation createCompareList($input: CreateCompareListInput) {
   "data": {
     "createCompareList": {
       "attributes": [ComparableAttribute],
-      "item_count": 123,
+      "item_count": 987,
       "items": [ComparableItem],
-      "uid": 4
+      "uid": "4"
     }
   }
 }
@@ -2499,20 +2502,20 @@ mutation createCustomerAddress($input: CustomerAddressInput!) {
       "default_billing": true,
       "default_shipping": true,
       "extension_attributes": [CustomerAddressAttribute],
-      "fax": "xyz789",
+      "fax": "abc123",
       "firstname": "xyz789",
-      "id": 987,
+      "id": 123,
       "lastname": "xyz789",
-      "middlename": "abc123",
-      "postcode": "abc123",
-      "prefix": "abc123",
+      "middlename": "xyz789",
+      "postcode": "xyz789",
+      "prefix": "xyz789",
       "region": CustomerAddressRegion,
-      "region_id": 987,
+      "region_id": 123,
       "street": ["abc123"],
       "suffix": "xyz789",
       "telephone": "abc123",
       "uid": "4",
-      "vat_id": "xyz789"
+      "vat_id": "abc123"
     }
   }
 }
@@ -2684,10 +2687,10 @@ mutation createPaymentOrder($input: CreatePaymentOrderInput!) {
 {
   "data": {
     "createPaymentOrder": {
-      "amount": 987.65,
+      "amount": 123.45,
       "currency_code": "abc123",
-      "id": "abc123",
-      "mp_order_id": "xyz789",
+      "id": "xyz789",
+      "mp_order_id": "abc123",
       "status": "xyz789"
     }
   }
@@ -2750,10 +2753,10 @@ mutation createPurchaseOrderApprovalRule($input: PurchaseOrderApprovalRuleInput!
       "applies_to_roles": [CompanyRole],
       "approver_roles": [CompanyRole],
       "condition": PurchaseOrderApprovalRuleConditionInterface,
-      "created_at": "xyz789",
-      "created_by": "abc123",
+      "created_at": "abc123",
+      "created_by": "xyz789",
       "description": "abc123",
-      "name": "abc123",
+      "name": "xyz789",
       "status": "ENABLED",
       "uid": 4,
       "updated_at": "xyz789"
@@ -2894,7 +2897,7 @@ mutation createVaultCardSetupToken($input: CreateVaultCardSetupTokenInput!) {
 {
   "data": {
     "createVaultCardSetupToken": {
-      "setup_token": "xyz789"
+      "setup_token": "abc123"
     }
   }
 }
@@ -2969,13 +2972,13 @@ mutation deleteCompanyRole($id: ID!) {
 ##### Variables
 
 ```json
-{"id": 4}
+{"id": "4"}
 ```
 
 ##### Response
 
 ```json
-{"data": {"deleteCompanyRole": {"success": false}}}
+{"data": {"deleteCompanyRole": {"success": true}}}
 ```
 
 <HorizontalLine />
@@ -3051,7 +3054,7 @@ mutation deleteCompanyUserV2($id: ID!) {
 ##### Response
 
 ```json
-{"data": {"deleteCompanyUserV2": {"success": true}}}
+{"data": {"deleteCompanyUserV2": {"success": false}}}
 ```
 
 <HorizontalLine />
@@ -3083,7 +3086,7 @@ mutation deleteCompareList($uid: ID!) {
 ##### Variables
 
 ```json
-{"uid": "4"}
+{"uid": 4}
 ```
 
 ##### Response
@@ -3113,7 +3116,7 @@ mutation deleteCustomer {
 ##### Response
 
 ```json
-{"data": {"deleteCustomer": false}}
+{"data": {"deleteCustomer": true}}
 ```
 
 <HorizontalLine />
@@ -3147,13 +3150,13 @@ mutation deleteCustomerAddress($id: Int!) {
 ##### Variables
 
 ```json
-{"id": 123}
+{"id": 987}
 ```
 
 ##### Response
 
 ```json
-{"data": {"deleteCustomerAddress": true}}
+{"data": {"deleteCustomerAddress": false}}
 ```
 
 <HorizontalLine />
@@ -3189,7 +3192,7 @@ mutation deleteCustomerAddressV2($uid: ID!) {
 ##### Response
 
 ```json
-{"data": {"deleteCustomerAddressV2": true}}
+{"data": {"deleteCustomerAddressV2": false}}
 ```
 
 <HorizontalLine />
@@ -3413,7 +3416,7 @@ mutation deleteRequisitionList($requisitionListUid: ID!) {
 ##### Variables
 
 ```json
-{"requisitionListUid": "4"}
+{"requisitionListUid": 4}
 ```
 
 ##### Response
@@ -3467,10 +3470,7 @@ mutation deleteRequisitionListItems(
 ##### Variables
 
 ```json
-{
-  "requisitionListUid": 4,
-  "requisitionListItemUids": ["4"]
-}
+{"requisitionListUid": 4, "requisitionListItemUids": [4]}
 ```
 
 ##### Response
@@ -3635,11 +3635,11 @@ mutation estimateShippingMethods($input: EstimateTotalsInput!) {
       {
         "additional_data": [ShippingAdditionalData],
         "amount": Money,
-        "available": true,
-        "carrier_code": "abc123",
-        "carrier_title": "abc123",
+        "available": false,
+        "carrier_code": "xyz789",
+        "carrier_title": "xyz789",
         "error_message": "abc123",
-        "method_code": "xyz789",
+        "method_code": "abc123",
         "method_title": "xyz789",
         "price_excl_tax": Money,
         "price_incl_tax": Money
@@ -3774,7 +3774,7 @@ mutation exchangeOtpForCustomerToken(
 
 ```json
 {
-  "email": "abc123",
+  "email": "xyz789",
   "otp": "xyz789"
 }
 ```
@@ -3831,7 +3831,7 @@ mutation finishUpload($input: finishUploadInput!) {
     "finishUpload": {
       "key": "xyz789",
       "message": "abc123",
-      "success": true
+      "success": false
     }
   }
 }
@@ -3874,8 +3874,8 @@ mutation generateCustomerToken(
 
 ```json
 {
-  "email": "abc123",
-  "password": "abc123"
+  "email": "xyz789",
+  "password": "xyz789"
 }
 ```
 
@@ -3885,7 +3885,7 @@ mutation generateCustomerToken(
 {
   "data": {
     "generateCustomerToken": {
-      "token": "abc123"
+      "token": "xyz789"
     }
   }
 }
@@ -4067,9 +4067,9 @@ mutation initiateUpload($input: initiateUploadInput!) {
 {
   "data": {
     "initiateUpload": {
-      "expires_at": "abc123",
+      "expires_at": "xyz789",
       "key": "xyz789",
-      "upload_url": "abc123"
+      "upload_url": "xyz789"
     }
   }
 }
@@ -4185,13 +4185,13 @@ mutation mergeCarts(
       "custom_attributes": [CustomAttribute],
       "email": "xyz789",
       "gift_message": GiftMessage,
-      "gift_receipt_included": false,
+      "gift_receipt_included": true,
       "gift_wrapping": GiftWrapping,
       "id": 4,
       "is_virtual": true,
       "itemsV2": CartItems,
       "prices": CartPrices,
-      "printed_card_included": false,
+      "printed_card_included": true,
       "rules": [CartRuleStorefront],
       "selected_payment_method": SelectedPaymentMethod,
       "shipping_addresses": [ShippingCartAddress],
@@ -4243,7 +4243,10 @@ mutation moveCartItemsToGiftRegistry(
 ##### Variables
 
 ```json
-{"cartUid": 4, "giftRegistryUid": 4}
+{
+  "cartUid": "4",
+  "giftRegistryUid": "4"
+}
 ```
 
 ##### Response
@@ -4418,7 +4421,7 @@ mutation moveProductsBetweenWishlists(
 
 ```json
 {
-  "sourceWishlistUid": 4,
+  "sourceWishlistUid": "4",
   "destinationWishlistUid": 4,
   "wishlistItems": [WishlistItemMoveInput]
 }
@@ -4518,11 +4521,11 @@ mutation openNegotiableQuoteTemplate($input: OpenNegotiableQuoteTemplateInput!) 
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
       "created_at": "abc123",
-      "expiration_date": "abc123",
+      "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
       "is_min_max_qty_used": true,
-      "is_virtual": false,
+      "is_virtual": true,
       "items": [CartItemInterface],
       "max_order_commitment": 123,
       "min_order_commitment": 123,
@@ -4532,15 +4535,15 @@ mutation openNegotiableQuoteTemplate($input: OpenNegotiableQuoteTemplateInput!) 
       "reference_document_links": [
         NegotiableQuoteReferenceDocumentLink
       ],
-      "sales_rep_name": "abc123",
+      "sales_rep_name": "xyz789",
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
-      "status": "xyz789",
-      "template_id": 4,
-      "total_quantity": 123.45,
-      "uid": 4,
-      "updated_at": "abc123"
+      "status": "abc123",
+      "template_id": "4",
+      "total_quantity": 987.65,
+      "uid": "4",
+      "updated_at": "xyz789"
     }
   }
 }
@@ -4823,7 +4826,7 @@ mutation redeemGiftCardBalanceAsStoreCredit($input: GiftCardAccountInput!) {
   "data": {
     "redeemGiftCardBalanceAsStoreCredit": {
       "balance": Money,
-      "code": "xyz789",
+      "code": "abc123",
       "expiration_date": "xyz789"
     }
   }
@@ -5029,7 +5032,7 @@ mutation removeGiftRegistry($giftRegistryUid: ID!) {
 ##### Variables
 
 ```json
-{"giftRegistryUid": 4}
+{"giftRegistryUid": "4"}
 ```
 
 ##### Response
@@ -5076,7 +5079,10 @@ mutation removeGiftRegistryItems(
 ##### Variables
 
 ```json
-{"giftRegistryUid": 4, "itemsUid": ["4"]}
+{
+  "giftRegistryUid": "4",
+  "itemsUid": ["4"]
+}
 ```
 
 ##### Response
@@ -5129,7 +5135,10 @@ mutation removeGiftRegistryRegistrants(
 ##### Variables
 
 ```json
-{"giftRegistryUid": 4, "registrantsUid": [4]}
+{
+  "giftRegistryUid": 4,
+  "registrantsUid": ["4"]
+}
 ```
 
 ##### Response
@@ -5316,7 +5325,7 @@ mutation removeNegotiableQuoteTemplateItems($input: RemoveNegotiableQuoteTemplat
       "is_min_max_qty_used": true,
       "is_virtual": true,
       "items": [CartItemInterface],
-      "max_order_commitment": 123,
+      "max_order_commitment": 987,
       "min_order_commitment": 123,
       "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
@@ -5329,10 +5338,10 @@ mutation removeNegotiableQuoteTemplateItems($input: RemoveNegotiableQuoteTemplat
         NegotiableQuoteShippingAddress
       ],
       "status": "abc123",
-      "template_id": 4,
+      "template_id": "4",
       "total_quantity": 123.45,
       "uid": "4",
-      "updated_at": "xyz789"
+      "updated_at": "abc123"
     }
   }
 }
@@ -5384,9 +5393,9 @@ mutation removeProductsFromCompareList($input: RemoveProductsFromCompareListInpu
   "data": {
     "removeProductsFromCompareList": {
       "attributes": [ComparableAttribute],
-      "item_count": 987,
+      "item_count": 123,
       "items": [ComparableItem],
-      "uid": 4
+      "uid": "4"
     }
   }
 }
@@ -5433,7 +5442,7 @@ mutation removeProductsFromWishlist(
 ##### Variables
 
 ```json
-{"wishlistId": 4, "wishlistItemsIds": ["4"]}
+{"wishlistId": "4", "wishlistItemsIds": [4]}
 ```
 
 ##### Response
@@ -5886,30 +5895,30 @@ mutation requestNegotiableQuoteTemplateFromQuote($input: RequestNegotiableQuoteT
     "requestNegotiableQuoteTemplateFromQuote": {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
-      "created_at": "xyz789",
-      "expiration_date": "abc123",
+      "created_at": "abc123",
+      "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
-      "is_min_max_qty_used": false,
+      "is_min_max_qty_used": true,
       "is_virtual": false,
       "items": [CartItemInterface],
       "max_order_commitment": 987,
-      "min_order_commitment": 123,
+      "min_order_commitment": 987,
       "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
         NegotiableQuoteReferenceDocumentLink
       ],
-      "sales_rep_name": "abc123",
+      "sales_rep_name": "xyz789",
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
       "status": "abc123",
-      "template_id": "4",
+      "template_id": 4,
       "total_quantity": 987.65,
       "uid": 4,
-      "updated_at": "abc123"
+      "updated_at": "xyz789"
     }
   }
 }
@@ -6028,13 +6037,13 @@ mutation resendConfirmationEmail($email: String!) {
 ##### Variables
 
 ```json
-{"email": "xyz789"}
+{"email": "abc123"}
 ```
 
 ##### Response
 
 ```json
-{"data": {"resendConfirmationEmail": true}}
+{"data": {"resendConfirmationEmail": false}}
 ```
 
 <HorizontalLine />
@@ -6075,7 +6084,7 @@ mutation resetPassword(
 
 ```json
 {
-  "email": "abc123",
+  "email": "xyz789",
   "resetPasswordToken": "xyz789",
   "newPassword": "abc123"
 }
@@ -6084,7 +6093,7 @@ mutation resetPassword(
 ##### Response
 
 ```json
-{"data": {"resetPassword": true}}
+{"data": {"resetPassword": false}}
 ```
 
 <HorizontalLine />
@@ -6110,7 +6119,7 @@ mutation revokeCustomerToken {
 ##### Response
 
 ```json
-{"data": {"revokeCustomerToken": {"result": true}}}
+{"data": {"revokeCustomerToken": {"result": false}}}
 ```
 
 <HorizontalLine />
@@ -6229,7 +6238,7 @@ mutation setCartAsInactive($cartId: String!) {
 ##### Variables
 
 ```json
-{"cartId": "abc123"}
+{"cartId": "xyz789"}
 ```
 
 ##### Response
@@ -6238,7 +6247,7 @@ mutation setCartAsInactive($cartId: String!) {
 {
   "data": {
     "setCartAsInactive": {
-      "error": "xyz789",
+      "error": "abc123",
       "success": true
     }
   }
@@ -6989,11 +6998,11 @@ mutation setNegotiableQuoteTemplateShippingAddress($input: SetNegotiableQuoteTem
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
       "is_min_max_qty_used": false,
-      "is_virtual": true,
+      "is_virtual": false,
       "items": [CartItemInterface],
-      "max_order_commitment": 123,
+      "max_order_commitment": 987,
       "min_order_commitment": 987,
-      "name": "abc123",
+      "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
@@ -7004,10 +7013,10 @@ mutation setNegotiableQuoteTemplateShippingAddress($input: SetNegotiableQuoteTem
         NegotiableQuoteShippingAddress
       ],
       "status": "xyz789",
-      "template_id": "4",
+      "template_id": 4,
       "total_quantity": 987.65,
       "uid": 4,
-      "updated_at": "xyz789"
+      "updated_at": "abc123"
     }
   }
 }
@@ -7132,16 +7141,16 @@ mutation setQuoteTemplateExpirationDate($input: QuoteTemplateExpirationDateInput
     "setQuoteTemplateExpirationDate": {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
-      "created_at": "abc123",
-      "expiration_date": "xyz789",
+      "created_at": "xyz789",
+      "expiration_date": "abc123",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
-      "is_min_max_qty_used": true,
+      "is_min_max_qty_used": false,
       "is_virtual": false,
       "items": [CartItemInterface],
-      "max_order_commitment": 123,
+      "max_order_commitment": 987,
       "min_order_commitment": 123,
-      "name": "abc123",
+      "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
@@ -7151,9 +7160,9 @@ mutation setQuoteTemplateExpirationDate($input: QuoteTemplateExpirationDateInput
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
-      "status": "abc123",
-      "template_id": 4,
-      "total_quantity": 987.65,
+      "status": "xyz789",
+      "template_id": "4",
+      "total_quantity": 123.45,
       "uid": 4,
       "updated_at": "abc123"
     }
@@ -7245,11 +7254,11 @@ mutation setQuoteTemplateLineItemNote($input: QuoteTemplateLineItemNoteInput!) {
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
       "is_min_max_qty_used": true,
-      "is_virtual": true,
+      "is_virtual": false,
       "items": [CartItemInterface],
-      "max_order_commitment": 987,
-      "min_order_commitment": 123,
-      "name": "abc123",
+      "max_order_commitment": 123,
+      "min_order_commitment": 987,
+      "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
@@ -7259,11 +7268,11 @@ mutation setQuoteTemplateLineItemNote($input: QuoteTemplateLineItemNoteInput!) {
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
-      "status": "abc123",
-      "template_id": "4",
+      "status": "xyz789",
+      "template_id": 4,
       "total_quantity": 123.45,
       "uid": 4,
-      "updated_at": "abc123"
+      "updated_at": "xyz789"
     }
   }
 }
@@ -7487,7 +7496,7 @@ mutation shareRequisitionListByToken($requisitionListUid: ID!) {
 {
   "data": {
     "shareRequisitionListByToken": {
-      "token": "abc123"
+      "token": "xyz789"
     }
   }
 }
@@ -7572,30 +7581,30 @@ mutation submitNegotiableQuoteTemplateForReview($input: SubmitNegotiableQuoteTem
     "submitNegotiableQuoteTemplateForReview": {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
-      "created_at": "xyz789",
+      "created_at": "abc123",
       "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
-      "is_min_max_qty_used": true,
+      "is_min_max_qty_used": false,
       "is_virtual": true,
       "items": [CartItemInterface],
-      "max_order_commitment": 123,
+      "max_order_commitment": 987,
       "min_order_commitment": 987,
-      "name": "abc123",
+      "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
         NegotiableQuoteReferenceDocumentLink
       ],
-      "sales_rep_name": "xyz789",
+      "sales_rep_name": "abc123",
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
       "status": "abc123",
-      "template_id": "4",
-      "total_quantity": 987.65,
+      "template_id": 4,
+      "total_quantity": 123.45,
       "uid": "4",
-      "updated_at": "xyz789"
+      "updated_at": "abc123"
     }
   }
 }
@@ -7678,8 +7687,8 @@ mutation subscribeProductAlertPrice($input: ProductAlertPriceInput!) {
 {
   "data": {
     "subscribeProductAlertPrice": {
-      "message": "xyz789",
-      "success": true
+      "message": "abc123",
+      "success": false
     }
   }
 }
@@ -7724,8 +7733,8 @@ mutation subscribeProductAlertStock($input: ProductAlertStockInput!) {
 {
   "data": {
     "subscribeProductAlertStock": {
-      "message": "abc123",
-      "success": true
+      "message": "xyz789",
+      "success": false
     }
   }
 }
@@ -7764,7 +7773,7 @@ mutation syncPaymentOrder($input: SyncPaymentOrderInput) {
 ##### Response
 
 ```json
-{"data": {"syncPaymentOrder": true}}
+{"data": {"syncPaymentOrder": false}}
 ```
 
 <HorizontalLine />
@@ -7852,7 +7861,7 @@ mutation unsubscribeProductAlertPrice($input: ProductAlertPriceInput!) {
 {
   "data": {
     "unsubscribeProductAlertPrice": {
-      "message": "abc123",
+      "message": "xyz789",
       "success": false
     }
   }
@@ -7886,7 +7895,7 @@ mutation unsubscribeProductAlertPriceAll {
 {
   "data": {
     "unsubscribeProductAlertPriceAll": {
-      "message": "xyz789",
+      "message": "abc123",
       "success": false
     }
   }
@@ -7932,8 +7941,8 @@ mutation unsubscribeProductAlertStock($input: ProductAlertStockInput!) {
 {
   "data": {
     "unsubscribeProductAlertStock": {
-      "message": "abc123",
-      "success": false
+      "message": "xyz789",
+      "success": true
     }
   }
 }
@@ -7966,7 +7975,7 @@ mutation unsubscribeProductAlertStockAll {
 {
   "data": {
     "unsubscribeProductAlertStockAll": {
-      "message": "abc123",
+      "message": "xyz789",
       "success": false
     }
   }
@@ -8289,7 +8298,7 @@ mutation updateCustomerAddress(
 ##### Variables
 
 ```json
-{"id": 123, "input": CustomerAddressInput}
+{"id": 987, "input": CustomerAddressInput}
 ```
 
 ##### Response
@@ -8298,26 +8307,26 @@ mutation updateCustomerAddress(
 {
   "data": {
     "updateCustomerAddress": {
-      "city": "abc123",
+      "city": "xyz789",
       "company": "abc123",
       "country_code": "AF",
       "custom_attributesV2": [AttributeValueInterface],
       "default_billing": false,
-      "default_shipping": false,
+      "default_shipping": true,
       "extension_attributes": [CustomerAddressAttribute],
       "fax": "xyz789",
-      "firstname": "abc123",
-      "id": 123,
+      "firstname": "xyz789",
+      "id": 987,
       "lastname": "abc123",
-      "middlename": "xyz789",
+      "middlename": "abc123",
       "postcode": "xyz789",
       "prefix": "abc123",
       "region": CustomerAddressRegion,
       "region_id": 123,
-      "street": ["abc123"],
-      "suffix": "xyz789",
-      "telephone": "abc123",
-      "uid": 4,
+      "street": ["xyz789"],
+      "suffix": "abc123",
+      "telephone": "xyz789",
+      "uid": "4",
       "vat_id": "abc123"
     }
   }
@@ -8386,7 +8395,10 @@ mutation updateCustomerAddressV2(
 ##### Variables
 
 ```json
-{"uid": 4, "input": CustomerAddressInput}
+{
+  "uid": "4",
+  "input": CustomerAddressInput
+}
 ```
 
 ##### Response
@@ -8395,27 +8407,27 @@ mutation updateCustomerAddressV2(
 {
   "data": {
     "updateCustomerAddressV2": {
-      "city": "xyz789",
+      "city": "abc123",
       "company": "abc123",
       "country_code": "AF",
       "custom_attributesV2": [AttributeValueInterface],
       "default_billing": false,
-      "default_shipping": true,
+      "default_shipping": false,
       "extension_attributes": [CustomerAddressAttribute],
       "fax": "xyz789",
-      "firstname": "abc123",
+      "firstname": "xyz789",
       "id": 987,
       "lastname": "abc123",
-      "middlename": "abc123",
+      "middlename": "xyz789",
       "postcode": "abc123",
       "prefix": "abc123",
       "region": CustomerAddressRegion,
-      "region_id": 123,
-      "street": ["abc123"],
-      "suffix": "abc123",
+      "region_id": 987,
+      "street": ["xyz789"],
+      "suffix": "xyz789",
       "telephone": "abc123",
       "uid": 4,
-      "vat_id": "abc123"
+      "vat_id": "xyz789"
     }
   }
 }
@@ -8460,7 +8472,7 @@ mutation updateCustomerEmail(
 
 ```json
 {
-  "email": "xyz789",
+  "email": "abc123",
   "password": "abc123"
 }
 ```
@@ -8550,7 +8562,7 @@ mutation updateGiftRegistry(
 
 ```json
 {
-  "giftRegistryUid": 4,
+  "giftRegistryUid": "4",
   "giftRegistry": UpdateGiftRegistryInput
 }
 ```
@@ -8604,7 +8616,7 @@ mutation updateGiftRegistryItems(
 
 ```json
 {
-  "giftRegistryUid": "4",
+  "giftRegistryUid": 4,
   "items": [UpdateGiftRegistryItemInput]
 }
 ```
@@ -8885,13 +8897,13 @@ mutation updatePurchaseOrderApprovalRule($input: UpdatePurchaseOrderApprovalRule
       "applies_to_roles": [CompanyRole],
       "approver_roles": [CompanyRole],
       "condition": PurchaseOrderApprovalRuleConditionInterface,
-      "created_at": "xyz789",
+      "created_at": "abc123",
       "created_by": "abc123",
-      "description": "abc123",
-      "name": "xyz789",
+      "description": "xyz789",
+      "name": "abc123",
       "status": "ENABLED",
       "uid": 4,
-      "updated_at": "xyz789"
+      "updated_at": "abc123"
     }
   }
 }
@@ -9054,7 +9066,7 @@ mutation updateWishlist(
 ```json
 {
   "wishlistId": 4,
-  "name": "abc123",
+  "name": "xyz789",
   "visibility": "PUBLIC"
 }
 ```

--- a/src/pages/includes/autogenerated/graphql-api-saas-queries.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-queries.md
@@ -340,7 +340,7 @@ query availableStores($useCurrentGroup: Boolean) {
 ##### Variables
 
 ```json
-{"useCurrentGroup": false}
+{"useCurrentGroup": true}
 ```
 
 ##### Response
@@ -360,85 +360,85 @@ query availableStores($useCurrentGroup: Boolean) {
         "autocomplete_on_storefront": true,
         "base_currency_code": "abc123",
         "base_link_url": "xyz789",
-        "base_media_url": "abc123",
-        "base_static_url": "xyz789",
+        "base_media_url": "xyz789",
+        "base_static_url": "abc123",
         "base_url": "xyz789",
-        "cart_expires_in_days": 987,
+        "cart_expires_in_days": 123,
         "cart_gift_wrapping": "abc123",
         "cart_merge_preference": "xyz789",
-        "cart_printed_card": "xyz789",
+        "cart_printed_card": "abc123",
         "cart_summary_display_quantity": 987,
-        "catalog_default_sort_by": "xyz789",
+        "catalog_default_sort_by": "abc123",
         "category_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
         "category_url_suffix": "xyz789",
         "check_money_order_enable_for_specific_countries": false,
-        "check_money_order_enabled": true,
+        "check_money_order_enabled": false,
         "check_money_order_make_check_payable_to": "abc123",
         "check_money_order_max_order_total": "xyz789",
         "check_money_order_min_order_total": "xyz789",
-        "check_money_order_new_order_status": "xyz789",
-        "check_money_order_payment_from_specific_countries": "abc123",
-        "check_money_order_send_check_to": "abc123",
-        "check_money_order_sort_order": 987,
+        "check_money_order_new_order_status": "abc123",
+        "check_money_order_payment_from_specific_countries": "xyz789",
+        "check_money_order_send_check_to": "xyz789",
+        "check_money_order_sort_order": 123,
         "check_money_order_title": "abc123",
-        "company_credit_enabled": false,
-        "company_enabled": false,
+        "company_credit_enabled": true,
+        "company_enabled": true,
         "configurable_product_image": "ITSELF",
-        "configurable_thumbnail_source": "xyz789",
-        "contact_enabled": false,
+        "configurable_thumbnail_source": "abc123",
+        "contact_enabled": true,
         "countries_with_required_region": "abc123",
         "create_account_confirmation": false,
         "customer_access_token_lifetime": 987.65,
-        "default_country": "abc123",
-        "default_display_currency_code": "abc123",
-        "display_product_prices_in_catalog": 123,
-        "display_shipping_prices": 987,
+        "default_country": "xyz789",
+        "default_display_currency_code": "xyz789",
+        "display_product_prices_in_catalog": 987,
+        "display_shipping_prices": 123,
         "display_state_if_optional": false,
         "enable_multiple_wishlists": "xyz789",
-        "fixed_product_taxes_apply_tax_to_fpt": false,
-        "fixed_product_taxes_display_prices_in_emails": 123,
+        "fixed_product_taxes_apply_tax_to_fpt": true,
+        "fixed_product_taxes_display_prices_in_emails": 987,
         "fixed_product_taxes_display_prices_in_product_lists": 987,
         "fixed_product_taxes_display_prices_in_sales_modules": 987,
-        "fixed_product_taxes_display_prices_on_product_view_page": 987,
-        "fixed_product_taxes_enable": false,
+        "fixed_product_taxes_display_prices_on_product_view_page": 123,
+        "fixed_product_taxes_enable": true,
         "fixed_product_taxes_include_fpt_in_subtotal": true,
-        "graphql_share_customer_group": true,
-        "grid_per_page": 987,
+        "graphql_share_customer_group": false,
+        "grid_per_page": 123,
         "grid_per_page_values": "xyz789",
         "grouped_product_image": "ITSELF",
         "is_checkout_agreements_enabled": true,
-        "is_default_store": false,
-        "is_default_store_group": true,
-        "is_guest_checkout_enabled": true,
-        "is_negotiable_quote_active": false,
-        "is_one_page_checkout_enabled": false,
-        "is_requisition_list_active": "xyz789",
+        "is_default_store": true,
+        "is_default_store_group": false,
+        "is_guest_checkout_enabled": false,
+        "is_negotiable_quote_active": true,
+        "is_one_page_checkout_enabled": true,
+        "is_requisition_list_active": "abc123",
         "list_mode": "xyz789",
         "list_per_page": 987,
         "list_per_page_values": "xyz789",
         "locale": "xyz789",
         "magento_reward_general_is_enabled": "xyz789",
-        "magento_reward_general_is_enabled_on_front": "xyz789",
-        "magento_reward_general_min_points_balance": "xyz789",
-        "magento_reward_general_publish_history": "xyz789",
-        "magento_reward_points_invitation_customer": "xyz789",
+        "magento_reward_general_is_enabled_on_front": "abc123",
+        "magento_reward_general_min_points_balance": "abc123",
+        "magento_reward_general_publish_history": "abc123",
+        "magento_reward_points_invitation_customer": "abc123",
         "magento_reward_points_invitation_customer_limit": "xyz789",
         "magento_reward_points_invitation_order": "abc123",
         "magento_reward_points_invitation_order_limit": "abc123",
         "magento_reward_points_newsletter": "abc123",
-        "magento_reward_points_order": "xyz789",
-        "magento_reward_points_register": "abc123",
-        "magento_reward_points_review": "xyz789",
-        "magento_reward_points_review_limit": "abc123",
-        "magento_wishlist_general_is_enabled": "abc123",
+        "magento_reward_points_order": "abc123",
+        "magento_reward_points_register": "xyz789",
+        "magento_reward_points_review": "abc123",
+        "magento_reward_points_review_limit": "xyz789",
+        "magento_wishlist_general_is_enabled": "xyz789",
         "max_items_in_order_summary": 123,
-        "maximum_number_of_wishlists": "abc123",
-        "minicart_display": false,
-        "minicart_max_items": 123,
+        "maximum_number_of_wishlists": "xyz789",
+        "minicart_display": true,
+        "minicart_max_items": 987,
         "minimum_password_length": "xyz789",
-        "newsletter_enabled": false,
+        "newsletter_enabled": true,
         "optional_zip_countries": "abc123",
-        "order_cancellation_enabled": false,
+        "order_cancellation_enabled": true,
         "order_cancellation_reasons": [
           CancellationReason
         ],
@@ -450,54 +450,54 @@ query availableStores($useCurrentGroup: Boolean) {
         "orders_invoices_credit_memos_display_zero_tax": false,
         "printed_card_priceV2": Money,
         "product_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
-        "product_url_suffix": "abc123",
+        "product_url_suffix": "xyz789",
         "quickorder_active": true,
-        "quote_minimum_amount": 987.65,
+        "quote_minimum_amount": 123.45,
         "quote_minimum_amount_message": "xyz789",
         "required_character_classes_number": "xyz789",
-        "requisition_list_share_link_validity_days": 123,
+        "requisition_list_share_link_validity_days": 987,
         "requisition_list_share_max_recipients": 987,
         "requisition_list_share_storefront_path": "xyz789",
-        "requisition_list_sharing_enabled": true,
-        "returns_enabled": "abc123",
+        "requisition_list_sharing_enabled": false,
+        "returns_enabled": "xyz789",
         "root_category_uid": "4",
         "sales_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
-        "sales_gift_wrapping": "abc123",
-        "sales_printed_card": "xyz789",
+        "sales_gift_wrapping": "xyz789",
+        "sales_printed_card": "abc123",
         "secure_base_link_url": "xyz789",
-        "secure_base_media_url": "abc123",
-        "secure_base_static_url": "abc123",
-        "secure_base_url": "xyz789",
-        "share_active_segments": false,
-        "share_applied_cart_rule": true,
+        "secure_base_media_url": "xyz789",
+        "secure_base_static_url": "xyz789",
+        "secure_base_url": "abc123",
+        "share_active_segments": true,
+        "share_applied_cart_rule": false,
         "shopping_assistance_checkbox_title": "abc123",
-        "shopping_assistance_checkbox_tooltip": "abc123",
-        "shopping_assistance_enabled": false,
+        "shopping_assistance_checkbox_tooltip": "xyz789",
+        "shopping_assistance_enabled": true,
         "shopping_cart_display_full_summary": false,
         "shopping_cart_display_grand_total": true,
-        "shopping_cart_display_price": 987,
-        "shopping_cart_display_shipping": 987,
+        "shopping_cart_display_price": 123,
+        "shopping_cart_display_shipping": 123,
         "shopping_cart_display_subtotal": 987,
         "shopping_cart_display_tax_gift_wrapping": "DISPLAY_EXCLUDING_TAX",
-        "shopping_cart_display_zero_tax": false,
+        "shopping_cart_display_zero_tax": true,
         "store_code": 4,
         "store_group_code": 4,
-        "store_group_name": "xyz789",
-        "store_name": "xyz789",
-        "store_sort_order": 123,
+        "store_group_name": "abc123",
+        "store_name": "abc123",
+        "store_sort_order": 987,
         "timezone": "abc123",
         "title_separator": "xyz789",
-        "use_store_in_url": false,
-        "website_code": 4,
-        "website_name": "abc123",
-        "weight_unit": "xyz789",
-        "zero_subtotal_enable_for_specific_countries": false,
-        "zero_subtotal_enabled": false,
-        "zero_subtotal_new_order_status": "abc123",
-        "zero_subtotal_payment_action": "abc123",
-        "zero_subtotal_payment_from_specific_countries": "abc123",
-        "zero_subtotal_sort_order": 123,
-        "zero_subtotal_title": "abc123"
+        "use_store_in_url": true,
+        "website_code": "4",
+        "website_name": "xyz789",
+        "weight_unit": "abc123",
+        "zero_subtotal_enable_for_specific_countries": true,
+        "zero_subtotal_enabled": true,
+        "zero_subtotal_new_order_status": "xyz789",
+        "zero_subtotal_payment_action": "xyz789",
+        "zero_subtotal_payment_from_specific_countries": "xyz789",
+        "zero_subtotal_sort_order": 987,
+        "zero_subtotal_title": "xyz789"
       }
     ]
   }
@@ -583,7 +583,7 @@ query cart($cart_id: String!) {
 ##### Variables
 
 ```json
-{"cart_id": "abc123"}
+{"cart_id": "xyz789"}
 ```
 
 ##### Response
@@ -604,13 +604,13 @@ query cart($cart_id: String!) {
       "custom_attributes": [CustomAttribute],
       "email": "abc123",
       "gift_message": GiftMessage,
-      "gift_receipt_included": false,
+      "gift_receipt_included": true,
       "gift_wrapping": GiftWrapping,
-      "id": "4",
-      "is_virtual": false,
+      "id": 4,
+      "is_virtual": true,
       "itemsV2": CartItems,
       "prices": CartPrices,
-      "printed_card_included": true,
+      "printed_card_included": false,
       "rules": [CartRuleStorefront],
       "selected_payment_method": SelectedPaymentMethod,
       "shipping_addresses": [ShippingCartAddress],
@@ -690,18 +690,18 @@ query categories(
   "data": {
     "categories": [
       {
-        "availableSortBy": ["xyz789"],
-        "children": ["xyz789"],
+        "availableSortBy": ["abc123"],
+        "children": ["abc123"],
         "defaultSortBy": "xyz789",
-        "id": 4,
+        "id": "4",
         "level": 987,
-        "name": "abc123",
-        "parentId": "xyz789",
+        "name": "xyz789",
+        "parentId": "abc123",
         "position": 123,
         "path": "abc123",
-        "roles": ["abc123"],
+        "roles": ["xyz789"],
         "urlKey": "abc123",
-        "urlPath": "abc123",
+        "urlPath": "xyz789",
         "count": 987,
         "title": "abc123"
       }
@@ -743,13 +743,13 @@ query checkoutAgreements {
   "data": {
     "checkoutAgreements": [
       {
-        "agreement_id": 987,
-        "checkbox_text": "abc123",
+        "agreement_id": 123,
+        "checkbox_text": "xyz789",
         "content": "xyz789",
         "content_height": "abc123",
-        "is_html": false,
+        "is_html": true,
         "mode": "AUTO",
-        "name": "abc123"
+        "name": "xyz789"
       }
     ]
   }
@@ -779,7 +779,13 @@ query commerceOptimizer {
 ##### Response
 
 ```json
-{"data": {"commerceOptimizer": {"priceBookId": 4}}}
+{
+  "data": {
+    "commerceOptimizer": {
+      "priceBookId": "4"
+    }
+  }
+}
 ```
 
 <HorizontalLine />
@@ -871,12 +877,12 @@ query company {
       "credit": CompanyCredit,
       "credit_history": CompanyCreditHistory,
       "custom_attributes": [CustomAttribute],
-      "email": "abc123",
+      "email": "xyz789",
       "id": 4,
       "legal_address": CompanyLegalAddress,
       "legal_name": "xyz789",
-      "name": "abc123",
-      "payment_methods": ["abc123"],
+      "name": "xyz789",
+      "payment_methods": ["xyz789"],
       "reseller_id": "abc123",
       "role": CompanyRole,
       "roles": CompanyRoles,
@@ -938,7 +944,7 @@ query compareList($uid: ID!) {
   "data": {
     "compareList": {
       "attributes": [ComparableAttribute],
-      "item_count": 987,
+      "item_count": 123,
       "items": [ComparableItem],
       "uid": 4
     }
@@ -981,10 +987,10 @@ query countries {
     "countries": [
       {
         "available_regions": [Region],
-        "full_name_english": "xyz789",
+        "full_name_english": "abc123",
         "full_name_locale": "abc123",
-        "id": "xyz789",
-        "three_letter_abbreviation": "xyz789",
+        "id": "abc123",
+        "three_letter_abbreviation": "abc123",
         "two_letter_abbreviation": "xyz789"
       }
     ]
@@ -1040,9 +1046,9 @@ query country($id: String) {
       "available_regions": [Region],
       "full_name_english": "xyz789",
       "full_name_locale": "xyz789",
-      "id": "xyz789",
+      "id": "abc123",
       "three_letter_abbreviation": "abc123",
-      "two_letter_abbreviation": "abc123"
+      "two_letter_abbreviation": "xyz789"
     }
   }
 }
@@ -1082,11 +1088,11 @@ query currency {
   "data": {
     "currency": {
       "available_currency_codes": [
-        "abc123"
+        "xyz789"
       ],
-      "base_currency_code": "xyz789",
-      "base_currency_symbol": "abc123",
-      "default_display_currency_code": "abc123",
+      "base_currency_code": "abc123",
+      "base_currency_symbol": "xyz789",
+      "default_display_currency_code": "xyz789",
       "default_display_currency_symbol": "xyz789",
       "exchange_rates": [ExchangeRate]
     }
@@ -1272,25 +1278,25 @@ query customer {
       "addresses": [CustomerAddress],
       "addressesV2": CustomerAddresses,
       "admin_assistance_actions": AdminAssistanceActions,
-      "allow_remote_shopping_assistance": true,
+      "allow_remote_shopping_assistance": false,
       "companies": UserCompaniesOutput,
       "company_hierarchy": [CompanyHierarchy],
       "compare_list": CompareList,
       "confirmation_status": "ACCOUNT_CONFIRMED",
-      "created_at": "abc123",
+      "created_at": "xyz789",
       "custom_attributes": [AttributeValueInterface],
-      "date_of_birth": "abc123",
+      "date_of_birth": "xyz789",
       "default_billing": "abc123",
       "default_shipping": "abc123",
-      "email": "abc123",
+      "email": "xyz789",
       "firstname": "xyz789",
-      "gender": 987,
+      "gender": 123,
       "gift_registries": [GiftRegistry],
       "gift_registry": GiftRegistry,
       "group": CustomerGroupStorefront,
-      "id": "4",
+      "id": 4,
       "is_subscribed": true,
-      "job_title": "xyz789",
+      "job_title": "abc123",
       "lastname": "abc123",
       "middlename": "xyz789",
       "orders": CustomerOrders,
@@ -1300,7 +1306,7 @@ query customer {
       "purchase_order_approval_rule_metadata": PurchaseOrderApprovalRuleMetadata,
       "purchase_order_approval_rules": PurchaseOrderApprovalRules,
       "purchase_orders": PurchaseOrders,
-      "purchase_orders_enabled": true,
+      "purchase_orders_enabled": false,
       "quote_enabled": false,
       "requisition_lists": RequisitionLists,
       "return": Return,
@@ -1312,7 +1318,7 @@ query customer {
       "store_credit": CustomerStoreCredit,
       "structure_id": 4,
       "suffix": "xyz789",
-      "taxvat": "xyz789",
+      "taxvat": "abc123",
       "team": CompanyTeam,
       "telephone": "xyz789",
       "wishlist_v2": Wishlist,
@@ -1416,7 +1422,7 @@ query customerCart {
       "is_virtual": true,
       "itemsV2": CartItems,
       "prices": CartPrices,
-      "printed_card_included": true,
+      "printed_card_included": false,
       "rules": [CartRuleStorefront],
       "selected_payment_method": SelectedPaymentMethod,
       "shipping_addresses": [ShippingCartAddress],
@@ -1483,7 +1489,7 @@ query customerGroup {
 ##### Response
 
 ```json
-{"data": {"customerGroup": {"uid": 4}}}
+{"data": {"customerGroup": {"uid": "4"}}}
 ```
 
 <HorizontalLine />
@@ -1553,7 +1559,11 @@ query customerSegments($cartId: String!) {
 ##### Response
 
 ```json
-{"data": {"customerSegments": [{"uid": 4}]}}
+{
+  "data": {
+    "customerSegments": [{"uid": "4"}]
+  }
+}
 ```
 
 <HorizontalLine />
@@ -1660,8 +1670,8 @@ query getPaymentOrder(
 
 ```json
 {
-  "cartId": "abc123",
-  "id": "xyz789"
+  "cartId": "xyz789",
+  "id": "abc123"
 }
 ```
 
@@ -1671,7 +1681,7 @@ query getPaymentOrder(
 {
   "data": {
     "getPaymentOrder": {
-      "id": "xyz789",
+      "id": "abc123",
       "mp_order_id": "xyz789",
       "payment_source_details": PaymentSourceDetails,
       "status": "abc123"
@@ -1802,7 +1812,7 @@ query giftCardAccount($input: GiftCardAccountInput!) {
     "giftCardAccount": {
       "balance": Money,
       "code": "xyz789",
-      "expiration_date": "xyz789"
+      "expiration_date": "abc123"
     }
   }
 }
@@ -1858,7 +1868,7 @@ query giftRegistry($giftRegistryUid: ID!) {
 ##### Variables
 
 ```json
-{"giftRegistryUid": 4}
+{"giftRegistryUid": "4"}
 ```
 
 ##### Response
@@ -1873,14 +1883,14 @@ query giftRegistry($giftRegistryUid: ID!) {
       ],
       "event_name": "abc123",
       "items": [GiftRegistryItemInterface],
-      "message": "xyz789",
+      "message": "abc123",
       "owner_name": "xyz789",
       "privacy_settings": "PRIVATE",
       "registrants": [GiftRegistryRegistrant],
       "shipping_address": CustomerAddress,
       "status": "ACTIVE",
       "type": GiftRegistryType,
-      "uid": "4"
+      "uid": 4
     }
   }
 }
@@ -1920,7 +1930,7 @@ query giftRegistryEmailSearch($email: String!) {
 ##### Variables
 
 ```json
-{"email": "abc123"}
+{"email": "xyz789"}
 ```
 
 ##### Response
@@ -1931,10 +1941,10 @@ query giftRegistryEmailSearch($email: String!) {
     "giftRegistryEmailSearch": [
       {
         "event_date": "xyz789",
-        "event_title": "xyz789",
-        "gift_registry_uid": "4",
+        "event_title": "abc123",
+        "gift_registry_uid": 4,
         "location": "xyz789",
-        "name": "xyz789",
+        "name": "abc123",
         "type": "xyz789"
       }
     ]
@@ -1986,12 +1996,12 @@ query giftRegistryIdSearch($giftRegistryUid: ID!) {
   "data": {
     "giftRegistryIdSearch": [
       {
-        "event_date": "xyz789",
+        "event_date": "abc123",
         "event_title": "xyz789",
-        "gift_registry_uid": "4",
-        "location": "xyz789",
+        "gift_registry_uid": 4,
+        "location": "abc123",
         "name": "abc123",
-        "type": "abc123"
+        "type": "xyz789"
       }
     ]
   }
@@ -2044,8 +2054,8 @@ query giftRegistryTypeSearch(
 ```json
 {
   "firstName": "xyz789",
-  "lastName": "xyz789",
-  "giftRegistryTypeUid": "4"
+  "lastName": "abc123",
+  "giftRegistryTypeUid": 4
 }
 ```
 
@@ -2056,12 +2066,12 @@ query giftRegistryTypeSearch(
   "data": {
     "giftRegistryTypeSearch": [
       {
-        "event_date": "xyz789",
+        "event_date": "abc123",
         "event_title": "xyz789",
-        "gift_registry_uid": 4,
+        "gift_registry_uid": "4",
         "location": "abc123",
         "name": "xyz789",
-        "type": "abc123"
+        "type": "xyz789"
       }
     ]
   }
@@ -2220,14 +2230,14 @@ query guestOrder($input: GuestOrderInformationInput!) {
       "applied_gift_cards": [ApplyGiftCardToOrder],
       "available_actions": ["REORDER"],
       "billing_address": OrderAddress,
-      "carrier": "xyz789",
+      "carrier": "abc123",
       "comments": [SalesCommentItem],
       "credit_memos": [CreditMemo],
       "custom_attributes": [CustomAttribute],
       "customer_info": OrderCustomerInfo,
       "email": "xyz789",
       "gift_message": GiftMessage,
-      "gift_receipt_included": false,
+      "gift_receipt_included": true,
       "gift_wrapping": GiftWrapping,
       "id": 4,
       "invoices": [Invoice],
@@ -2236,7 +2246,7 @@ query guestOrder($input: GuestOrderInformationInput!) {
       "items_eligible_for_return": [OrderItemInterface],
       "negotiable_quote": NegotiableQuote,
       "number": "abc123",
-      "order_date": "xyz789",
+      "order_date": "abc123",
       "order_status_change_date": "xyz789",
       "payment_methods": [OrderPaymentMethod],
       "printed_card_included": false,
@@ -2244,7 +2254,7 @@ query guestOrder($input: GuestOrderInformationInput!) {
       "shipments": [OrderShipment],
       "shipping_address": OrderAddress,
       "shipping_method": "abc123",
-      "status": "xyz789",
+      "status": "abc123",
       "token": "xyz789",
       "total": OrderTotal
     }
@@ -2362,18 +2372,18 @@ query guestOrderByToken($input: OrderTokenInput!) {
       "applied_gift_cards": [ApplyGiftCardToOrder],
       "available_actions": ["REORDER"],
       "billing_address": OrderAddress,
-      "carrier": "abc123",
+      "carrier": "xyz789",
       "comments": [SalesCommentItem],
       "credit_memos": [CreditMemo],
       "custom_attributes": [CustomAttribute],
       "customer_info": OrderCustomerInfo,
-      "email": "abc123",
+      "email": "xyz789",
       "gift_message": GiftMessage,
       "gift_receipt_included": false,
       "gift_wrapping": GiftWrapping,
       "id": "4",
       "invoices": [Invoice],
-      "is_virtual": true,
+      "is_virtual": false,
       "items": [OrderItemInterface],
       "items_eligible_for_return": [OrderItemInterface],
       "negotiable_quote": NegotiableQuote,
@@ -2381,13 +2391,13 @@ query guestOrderByToken($input: OrderTokenInput!) {
       "order_date": "abc123",
       "order_status_change_date": "xyz789",
       "payment_methods": [OrderPaymentMethod],
-      "printed_card_included": false,
+      "printed_card_included": true,
       "returns": Returns,
       "shipments": [OrderShipment],
       "shipping_address": OrderAddress,
-      "shipping_method": "abc123",
+      "shipping_method": "xyz789",
       "status": "abc123",
-      "token": "abc123",
+      "token": "xyz789",
       "total": OrderTotal
     }
   }
@@ -2461,13 +2471,13 @@ query isCompanyEmailAvailable($email: String!) {
 ##### Variables
 
 ```json
-{"email": "abc123"}
+{"email": "xyz789"}
 ```
 
 ##### Response
 
 ```json
-{"data": {"isCompanyEmailAvailable": {"is_email_available": false}}}
+{"data": {"isCompanyEmailAvailable": {"is_email_available": true}}}
 ```
 
 <HorizontalLine />
@@ -2499,7 +2509,7 @@ query isCompanyRoleNameAvailable($name: String!) {
 ##### Variables
 
 ```json
-{"name": "xyz789"}
+{"name": "abc123"}
 ```
 
 ##### Response
@@ -2575,7 +2585,7 @@ query isEmailAvailable($email: String!) {
 ##### Variables
 
 ```json
-{"email": "xyz789"}
+{"email": "abc123"}
 ```
 
 ##### Response
@@ -2624,7 +2634,7 @@ query isSubscribedProductAlertPrice($input: ProductAlertPriceInput!) {
   "data": {
     "isSubscribedProductAlertPrice": {
       "isSubscribed": false,
-      "message": "abc123"
+      "message": "xyz789"
     }
   }
 }
@@ -2670,7 +2680,7 @@ query isSubscribedProductAlertStock($input: ProductAlertStockInput!) {
   "data": {
     "isSubscribedProductAlertStock": {
       "isSubscribed": false,
-      "message": "abc123"
+      "message": "xyz789"
     }
   }
 }
@@ -2766,12 +2776,12 @@ query negotiableQuote($uid: ID!) {
       "comments": [NegotiableQuoteComment],
       "created_at": "xyz789",
       "custom_attributes": [CustomAttribute],
-      "email": "xyz789",
+      "email": "abc123",
       "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "is_virtual": false,
       "items": [CartItemInterface],
-      "name": "xyz789",
+      "name": "abc123",
       "order": CustomerOrder,
       "prices": CartPrices,
       "sales_rep_name": "xyz789",
@@ -2780,11 +2790,11 @@ query negotiableQuote($uid: ID!) {
         NegotiableQuoteShippingAddress
       ],
       "status": "SUBMITTED",
-      "template_id": 4,
-      "template_name": "xyz789",
+      "template_id": "4",
+      "template_name": "abc123",
       "total_quantity": 987.65,
       "uid": 4,
-      "updated_at": "abc123"
+      "updated_at": "xyz789"
     }
   }
 }
@@ -2858,7 +2868,7 @@ query negotiableQuoteTemplate($templateId: ID!) {
 ##### Variables
 
 ```json
-{"templateId": 4}
+{"templateId": "4"}
 ```
 
 ##### Response
@@ -2870,13 +2880,13 @@ query negotiableQuoteTemplate($templateId: ID!) {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
       "created_at": "abc123",
-      "expiration_date": "abc123",
+      "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
       "is_min_max_qty_used": false,
       "is_virtual": true,
       "items": [CartItemInterface],
-      "max_order_commitment": 123,
+      "max_order_commitment": 987,
       "min_order_commitment": 987,
       "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
@@ -3205,9 +3215,9 @@ query productSearch(
       "facets": [Aggregation],
       "items": [ProductSearchItem],
       "page_info": SearchResultPageInfo,
-      "related_terms": ["xyz789"],
+      "related_terms": ["abc123"],
       "suggestions": ["xyz789"],
-      "total_count": 123,
+      "total_count": 987,
       "warnings": [ProductSearchWarning]
     }
   }
@@ -3274,7 +3284,7 @@ query products($skus: [String]) {
 ##### Variables
 
 ```json
-{"skus": ["xyz789"]}
+{"skus": ["abc123"]}
 ```
 
 ##### Response
@@ -3285,10 +3295,10 @@ query products($skus: [String]) {
     "products": [
       {
         "addToCartAllowed": true,
-        "inStock": false,
-        "lowStock": false,
+        "inStock": true,
+        "lowStock": true,
         "attributes": [ProductViewAttribute],
-        "description": "abc123",
+        "description": "xyz789",
         "id": 4,
         "images": [ProductViewImage],
         "videos": [ProductViewVideo],
@@ -3296,15 +3306,15 @@ query products($skus: [String]) {
         "metaDescription": "xyz789",
         "metaKeyword": "abc123",
         "metaTitle": "xyz789",
-        "name": "abc123",
+        "name": "xyz789",
         "shortDescription": "abc123",
         "inputOptions": [ProductViewInputOption],
         "sku": "xyz789",
         "externalId": "xyz789",
-        "url": "xyz789",
-        "urlKey": "abc123",
+        "url": "abc123",
+        "urlKey": "xyz789",
         "links": [ProductViewLink],
-        "queryType": "xyz789",
+        "queryType": "abc123",
         "visibility": "abc123"
       }
     ]
@@ -3352,7 +3362,7 @@ query recaptchaFormConfig($formType: ReCaptchaFormEnum!) {
   "data": {
     "recaptchaFormConfig": {
       "configurations": ReCaptchaConfiguration,
-      "is_enabled": false
+      "is_enabled": true
     }
   }
 }
@@ -3443,14 +3453,14 @@ query recaptchaV3Config {
 {
   "data": {
     "recaptchaV3Config": {
-      "badge_position": "abc123",
-      "failure_message": "xyz789",
+      "badge_position": "xyz789",
+      "failure_message": "abc123",
       "forms": ["PLACE_ORDER"],
-      "is_enabled": true,
-      "language_code": "xyz789",
-      "minimum_score": 123.45,
-      "theme": "xyz789",
-      "website_key": "abc123"
+      "is_enabled": false,
+      "language_code": "abc123",
+      "minimum_score": 987.65,
+      "theme": "abc123",
+      "website_key": "xyz789"
     }
   }
 }
@@ -3606,8 +3616,8 @@ query refineProduct(
 
 ```json
 {
-  "optionIds": ["abc123"],
-  "sku": "xyz789"
+  "optionIds": ["xyz789"],
+  "sku": "abc123"
 }
 ```
 
@@ -3618,8 +3628,8 @@ query refineProduct(
   "data": {
     "refineProduct": {
       "addToCartAllowed": false,
-      "inStock": true,
-      "lowStock": false,
+      "inStock": false,
+      "lowStock": true,
       "attributes": [ProductViewAttribute],
       "description": "abc123",
       "id": 4,
@@ -3628,14 +3638,14 @@ query refineProduct(
       "lastModifiedAt": "2007-12-03T10:15:30Z",
       "metaDescription": "xyz789",
       "metaKeyword": "xyz789",
-      "metaTitle": "xyz789",
+      "metaTitle": "abc123",
       "name": "abc123",
-      "shortDescription": "xyz789",
+      "shortDescription": "abc123",
       "inputOptions": [ProductViewInputOption],
       "sku": "xyz789",
-      "externalId": "xyz789",
+      "externalId": "abc123",
       "url": "xyz789",
-      "urlKey": "abc123",
+      "urlKey": "xyz789",
       "links": [ProductViewLink],
       "queryType": "abc123",
       "visibility": "abc123"
@@ -3867,60 +3877,60 @@ query storeConfig {
 {
   "data": {
     "storeConfig": {
-      "allow_company_registration": false,
+      "allow_company_registration": true,
       "allow_gift_receipt": "xyz789",
       "allow_gift_wrapping_on_order": "xyz789",
       "allow_gift_wrapping_on_order_items": "xyz789",
       "allow_items": "xyz789",
       "allow_order": "xyz789",
       "allow_printed_card": "xyz789",
-      "autocomplete_on_storefront": true,
-      "base_currency_code": "abc123",
-      "base_link_url": "xyz789",
+      "autocomplete_on_storefront": false,
+      "base_currency_code": "xyz789",
+      "base_link_url": "abc123",
       "base_media_url": "abc123",
-      "base_static_url": "xyz789",
+      "base_static_url": "abc123",
       "base_url": "xyz789",
       "cart_expires_in_days": 987,
       "cart_gift_wrapping": "xyz789",
-      "cart_merge_preference": "abc123",
-      "cart_printed_card": "xyz789",
+      "cart_merge_preference": "xyz789",
+      "cart_printed_card": "abc123",
       "cart_summary_display_quantity": 987,
-      "catalog_default_sort_by": "xyz789",
+      "catalog_default_sort_by": "abc123",
       "category_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
       "category_url_suffix": "xyz789",
-      "check_money_order_enable_for_specific_countries": false,
+      "check_money_order_enable_for_specific_countries": true,
       "check_money_order_enabled": true,
-      "check_money_order_make_check_payable_to": "xyz789",
-      "check_money_order_max_order_total": "xyz789",
-      "check_money_order_min_order_total": "xyz789",
-      "check_money_order_new_order_status": "abc123",
+      "check_money_order_make_check_payable_to": "abc123",
+      "check_money_order_max_order_total": "abc123",
+      "check_money_order_min_order_total": "abc123",
+      "check_money_order_new_order_status": "xyz789",
       "check_money_order_payment_from_specific_countries": "xyz789",
       "check_money_order_send_check_to": "abc123",
-      "check_money_order_sort_order": 123,
-      "check_money_order_title": "abc123",
-      "company_credit_enabled": false,
-      "company_enabled": true,
+      "check_money_order_sort_order": 987,
+      "check_money_order_title": "xyz789",
+      "company_credit_enabled": true,
+      "company_enabled": false,
       "configurable_product_image": "ITSELF",
-      "configurable_thumbnail_source": "abc123",
+      "configurable_thumbnail_source": "xyz789",
       "contact_enabled": true,
       "countries_with_required_region": "abc123",
-      "create_account_confirmation": true,
+      "create_account_confirmation": false,
       "customer_access_token_lifetime": 123.45,
       "default_country": "xyz789",
-      "default_display_currency_code": "xyz789",
-      "display_product_prices_in_catalog": 987,
-      "display_shipping_prices": 987,
-      "display_state_if_optional": false,
-      "enable_multiple_wishlists": "xyz789",
-      "fixed_product_taxes_apply_tax_to_fpt": true,
+      "default_display_currency_code": "abc123",
+      "display_product_prices_in_catalog": 123,
+      "display_shipping_prices": 123,
+      "display_state_if_optional": true,
+      "enable_multiple_wishlists": "abc123",
+      "fixed_product_taxes_apply_tax_to_fpt": false,
       "fixed_product_taxes_display_prices_in_emails": 123,
       "fixed_product_taxes_display_prices_in_product_lists": 987,
       "fixed_product_taxes_display_prices_in_sales_modules": 987,
       "fixed_product_taxes_display_prices_on_product_view_page": 123,
       "fixed_product_taxes_enable": false,
       "fixed_product_taxes_include_fpt_in_subtotal": false,
-      "graphql_share_customer_group": false,
-      "grid_per_page": 123,
+      "graphql_share_customer_group": true,
+      "grid_per_page": 987,
       "grid_per_page_values": "xyz789",
       "grouped_product_image": "ITSELF",
       "is_checkout_agreements_enabled": true,
@@ -3933,84 +3943,84 @@ query storeConfig {
       "list_mode": "abc123",
       "list_per_page": 987,
       "list_per_page_values": "xyz789",
-      "locale": "abc123",
-      "magento_reward_general_is_enabled": "xyz789",
+      "locale": "xyz789",
+      "magento_reward_general_is_enabled": "abc123",
       "magento_reward_general_is_enabled_on_front": "xyz789",
-      "magento_reward_general_min_points_balance": "xyz789",
-      "magento_reward_general_publish_history": "xyz789",
-      "magento_reward_points_invitation_customer": "abc123",
-      "magento_reward_points_invitation_customer_limit": "xyz789",
-      "magento_reward_points_invitation_order": "xyz789",
+      "magento_reward_general_min_points_balance": "abc123",
+      "magento_reward_general_publish_history": "abc123",
+      "magento_reward_points_invitation_customer": "xyz789",
+      "magento_reward_points_invitation_customer_limit": "abc123",
+      "magento_reward_points_invitation_order": "abc123",
       "magento_reward_points_invitation_order_limit": "abc123",
       "magento_reward_points_newsletter": "xyz789",
       "magento_reward_points_order": "xyz789",
-      "magento_reward_points_register": "abc123",
+      "magento_reward_points_register": "xyz789",
       "magento_reward_points_review": "abc123",
       "magento_reward_points_review_limit": "abc123",
-      "magento_wishlist_general_is_enabled": "abc123",
-      "max_items_in_order_summary": 987,
-      "maximum_number_of_wishlists": "abc123",
+      "magento_wishlist_general_is_enabled": "xyz789",
+      "max_items_in_order_summary": 123,
+      "maximum_number_of_wishlists": "xyz789",
       "minicart_display": true,
-      "minicart_max_items": 123,
-      "minimum_password_length": "xyz789",
-      "newsletter_enabled": false,
-      "optional_zip_countries": "abc123",
+      "minicart_max_items": 987,
+      "minimum_password_length": "abc123",
+      "newsletter_enabled": true,
+      "optional_zip_countries": "xyz789",
       "order_cancellation_enabled": true,
       "order_cancellation_reasons": [CancellationReason],
-      "orders_invoices_credit_memos_display_full_summary": true,
-      "orders_invoices_credit_memos_display_grandtotal": false,
-      "orders_invoices_credit_memos_display_price": 987,
+      "orders_invoices_credit_memos_display_full_summary": false,
+      "orders_invoices_credit_memos_display_grandtotal": true,
+      "orders_invoices_credit_memos_display_price": 123,
       "orders_invoices_credit_memos_display_shipping_amount": 123,
-      "orders_invoices_credit_memos_display_subtotal": 987,
-      "orders_invoices_credit_memos_display_zero_tax": false,
+      "orders_invoices_credit_memos_display_subtotal": 123,
+      "orders_invoices_credit_memos_display_zero_tax": true,
       "printed_card_priceV2": Money,
       "product_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
       "product_url_suffix": "xyz789",
-      "quickorder_active": false,
+      "quickorder_active": true,
       "quote_minimum_amount": 123.45,
-      "quote_minimum_amount_message": "abc123",
-      "required_character_classes_number": "xyz789",
-      "requisition_list_share_link_validity_days": 123,
-      "requisition_list_share_max_recipients": 123,
+      "quote_minimum_amount_message": "xyz789",
+      "required_character_classes_number": "abc123",
+      "requisition_list_share_link_validity_days": 987,
+      "requisition_list_share_max_recipients": 987,
       "requisition_list_share_storefront_path": "xyz789",
-      "requisition_list_sharing_enabled": false,
+      "requisition_list_sharing_enabled": true,
       "returns_enabled": "abc123",
-      "root_category_uid": "4",
+      "root_category_uid": 4,
       "sales_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
       "sales_gift_wrapping": "xyz789",
-      "sales_printed_card": "xyz789",
-      "secure_base_link_url": "xyz789",
+      "sales_printed_card": "abc123",
+      "secure_base_link_url": "abc123",
       "secure_base_media_url": "xyz789",
       "secure_base_static_url": "abc123",
       "secure_base_url": "abc123",
-      "share_active_segments": true,
+      "share_active_segments": false,
       "share_applied_cart_rule": false,
       "shopping_assistance_checkbox_title": "xyz789",
-      "shopping_assistance_checkbox_tooltip": "xyz789",
+      "shopping_assistance_checkbox_tooltip": "abc123",
       "shopping_assistance_enabled": false,
       "shopping_cart_display_full_summary": false,
       "shopping_cart_display_grand_total": false,
-      "shopping_cart_display_price": 123,
+      "shopping_cart_display_price": 987,
       "shopping_cart_display_shipping": 987,
-      "shopping_cart_display_subtotal": 123,
+      "shopping_cart_display_subtotal": 987,
       "shopping_cart_display_tax_gift_wrapping": "DISPLAY_EXCLUDING_TAX",
-      "shopping_cart_display_zero_tax": false,
+      "shopping_cart_display_zero_tax": true,
       "store_code": 4,
-      "store_group_code": "4",
-      "store_group_name": "abc123",
-      "store_name": "abc123",
-      "store_sort_order": 987,
+      "store_group_code": 4,
+      "store_group_name": "xyz789",
+      "store_name": "xyz789",
+      "store_sort_order": 123,
       "timezone": "xyz789",
       "title_separator": "xyz789",
       "use_store_in_url": true,
       "website_code": "4",
       "website_name": "xyz789",
-      "weight_unit": "xyz789",
+      "weight_unit": "abc123",
       "zero_subtotal_enable_for_specific_countries": true,
       "zero_subtotal_enabled": false,
-      "zero_subtotal_new_order_status": "abc123",
+      "zero_subtotal_new_order_status": "xyz789",
       "zero_subtotal_payment_action": "xyz789",
-      "zero_subtotal_payment_from_specific_countries": "xyz789",
+      "zero_subtotal_payment_from_specific_countries": "abc123",
       "zero_subtotal_sort_order": 123,
       "zero_subtotal_title": "xyz789"
     }
@@ -4064,7 +4074,7 @@ query variants(
 {
   "sku": "xyz789",
   "optionIds": ["xyz789"],
-  "pageSize": 987,
+  "pageSize": 123,
   "cursor": "abc123"
 }
 ```
@@ -4076,7 +4086,7 @@ query variants(
   "data": {
     "variants": {
       "variants": [ProductViewVariant],
-      "cursor": "abc123"
+      "cursor": "xyz789"
     }
   }
 }

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-a-b.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-a-b.md
@@ -13,7 +13,7 @@ Specifies the quote template id to accept quote template.
 #### Example
 
 ```json
-{"template_id": 4}
+{"template_id": "4"}
 ```
 
 <HorizontalLine />
@@ -96,7 +96,7 @@ Defines a new registrant.
   ],
   "email": "xyz789",
   "firstname": "xyz789",
-  "lastname": "xyz789"
+  "lastname": "abc123"
 }
 ```
 
@@ -156,10 +156,7 @@ Contains products to add to an existing compare list.
 #### Example
 
 ```json
-{
-  "products": ["4"],
-  "uid": "4"
-}
+{"products": ["4"], "uid": 4}
 ```
 
 <HorizontalLine />
@@ -282,9 +279,9 @@ Defines the purchase order and cart to act on.
 
 ```json
 {
-  "cart_id": "abc123",
+  "cart_id": "xyz789",
   "purchase_order_uid": "4",
-  "replace_existing_cart_items": false
+  "replace_existing_cart_items": true
 }
 ```
 
@@ -372,7 +369,7 @@ Defines a return comment.
 
 ```json
 {
-  "comment_text": "abc123",
+  "comment_text": "xyz789",
   "return_uid": "4"
 }
 ```
@@ -413,8 +410,8 @@ Defines tracking information to be added to the return.
 
 ```json
 {
-  "carrier_uid": "4",
-  "return_uid": "4",
+  "carrier_uid": 4,
+  "return_uid": 4,
   "tracking_number": "abc123"
 }
 ```
@@ -462,7 +459,7 @@ Contains the resultant wish list and any error information.
   "add_wishlist_items_to_cart_user_errors": [
     WishlistCartUserInputError
   ],
-  "status": false,
+  "status": true,
   "wishlist": Wishlist
 }
 ```
@@ -487,7 +484,7 @@ A single admin assistance action performed on behalf of the customer.
 {
   "action": "abc123",
   "date": "abc123",
-  "details": "xyz789"
+  "details": "abc123"
 }
 ```
 
@@ -511,7 +508,7 @@ Paginated admin assistance actions for the customer.
 {
   "items": [AdminAssistanceAction],
   "page_info": SearchResultPageInfo,
-  "total_count": 123
+  "total_count": 987
 }
 ```
 
@@ -536,7 +533,7 @@ A bucket that contains information for each filterable option
 {
   "attribute": "abc123",
   "buckets": [Bucket],
-  "title": "abc123",
+  "title": "xyz789",
   "type": "INTELLIGENT"
 }
 ```
@@ -583,13 +580,13 @@ Identifies the data type of the aggregation
 ```json
 {
   "button_styles": ButtonStyles,
-  "code": "abc123",
-  "is_visible": true,
-  "payment_intent": "xyz789",
-  "payment_source": "xyz789",
+  "code": "xyz789",
+  "is_visible": false,
+  "payment_intent": "abc123",
+  "payment_source": "abc123",
   "sdk_params": [SDKParams],
-  "sort_order": "xyz789",
-  "title": "abc123"
+  "sort_order": "abc123",
+  "title": "xyz789"
 }
 ```
 
@@ -611,9 +608,9 @@ Apple Pay inputs
 
 ```json
 {
-  "payment_source": "xyz789",
-  "payments_order_id": "abc123",
-  "paypal_order_id": "abc123"
+  "payment_source": "abc123",
+  "payments_order_id": "xyz789",
+  "paypal_order_id": "xyz789"
 }
 ```
 
@@ -829,8 +826,8 @@ Defines the input required to run the `applyGiftCardToCart` mutation.
 
 ```json
 {
-  "cart_id": "abc123",
-  "gift_card_code": "xyz789"
+  "cart_id": "xyz789",
+  "gift_card_code": "abc123"
 }
 ```
 
@@ -870,7 +867,7 @@ Contains applied gift cards with gift card code and amount.
 ```json
 {
   "applied_balance": Money,
-  "code": "abc123"
+  "code": "xyz789"
 }
 ```
 
@@ -971,7 +968,7 @@ Contains information about an asset image.
   "disabled": true,
   "label": "abc123",
   "position": 123,
-  "url": "xyz789"
+  "url": "abc123"
 }
 ```
 
@@ -1019,10 +1016,7 @@ Defines the input schema for assigning a child company to a parent company.
 #### Example
 
 ```json
-{
-  "child_company_id": 4,
-  "parent_company_id": "4"
-}
+{"child_company_id": 4, "parent_company_id": 4}
 ```
 
 <HorizontalLine />
@@ -1059,7 +1053,7 @@ Contains the results of the request to assign a compare list.
 #### Example
 
 ```json
-{"compare_list": CompareList, "result": false}
+{"compare_list": CompareList, "result": true}
 ```
 
 <HorizontalLine />
@@ -1101,10 +1095,10 @@ List of all entity types. Populated by the modules introducing EAV entities.
 
 ```json
 {
-  "attribute_type": "abc123",
-  "code": 4,
-  "url": "xyz789",
-  "value": "abc123"
+  "attribute_type": "xyz789",
+  "code": "4",
+  "url": "abc123",
+  "value": "xyz789"
 }
 ```
 
@@ -1135,13 +1129,13 @@ An input object that specifies the filters used for attributes.
 
 ```json
 {
-  "is_comparable": false,
-  "is_filterable": true,
-  "is_filterable_in_search": false,
+  "is_comparable": true,
+  "is_filterable": false,
+  "is_filterable_in_search": true,
   "is_html_allowed_on_front": false,
-  "is_searchable": false,
-  "is_used_for_customer_segment": true,
-  "is_used_for_price_rules": false,
+  "is_searchable": true,
+  "is_used_for_customer_segment": false,
+  "is_used_for_price_rules": true,
   "is_used_for_promo_rules": false,
   "is_visible_in_advanced_search": true,
   "is_visible_on_front": false,
@@ -1200,7 +1194,7 @@ EAV attribute frontend input types.
 
 ```json
 {
-  "attribute_type": "abc123",
+  "attribute_type": "xyz789",
   "code": 4,
   "url": "xyz789",
   "value": "xyz789"
@@ -1224,7 +1218,7 @@ Defines the attribute characteristics to search for the `attribute_code` and `en
 
 ```json
 {
-  "attribute_code": "xyz789",
+  "attribute_code": "abc123",
   "entity_type": "xyz789"
 }
 ```
@@ -1244,7 +1238,7 @@ Specifies selected option for a select or multiselect attribute value.
 #### Example
 
 ```json
-{"value": "abc123"}
+{"value": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -1276,9 +1270,9 @@ Base EAV implementation of CustomAttributeMetadataInterface.
   "entity_type": "CATALOG_PRODUCT",
   "frontend_class": "xyz789",
   "frontend_input": "BOOLEAN",
-  "is_required": false,
-  "is_unique": false,
-  "label": "abc123",
+  "is_required": true,
+  "is_unique": true,
+  "label": "xyz789",
   "options": [CustomAttributeOptionInterface]
 }
 ```
@@ -1300,7 +1294,7 @@ Attribute metadata retrieval error.
 
 ```json
 {
-  "message": "xyz789",
+  "message": "abc123",
   "type": "ENTITY_NOT_FOUND"
 }
 ```
@@ -1366,9 +1360,9 @@ Base EAV implementation of CustomAttributeOptionInterface.
 
 ```json
 {
-  "is_default": false,
-  "label": "abc123",
-  "value": "xyz789"
+  "is_default": true,
+  "label": "xyz789",
+  "value": "abc123"
 }
 ```
 
@@ -1388,7 +1382,7 @@ Base EAV implementation of CustomAttributeOptionInterface.
 ```json
 {
   "label": "abc123",
-  "value": "abc123"
+  "value": "xyz789"
 }
 ```
 
@@ -1413,7 +1407,7 @@ Base EAV implementation of CustomAttributeOptionInterface.
 
 ```json
 {
-  "label": "abc123",
+  "label": "xyz789",
   "value": "abc123"
 }
 ```
@@ -1456,9 +1450,9 @@ Base EAV implementation of CustomAttributeOptionInterface.
 
 ```json
 {
-  "attribute_type": "xyz789",
-  "code": 4,
-  "value": "abc123"
+  "attribute_type": "abc123",
+  "code": "4",
+  "value": "xyz789"
 }
 ```
 
@@ -1510,7 +1504,10 @@ Specifies the value for attribute.
 #### Example
 
 ```json
-{"attribute_type": "xyz789", "code": 4}
+{
+  "attribute_type": "xyz789",
+  "code": "4"
+}
 ```
 
 <HorizontalLine />
@@ -1559,6 +1556,22 @@ Metadata of EAV attributes.
 
 <HorizontalLine />
 
+### AuthenticationResult
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `liability_shift` - [`LiabilityShift`](#liabilityshift) | Liability Shift |
+
+#### Example
+
+```json
+{"liability_shift": "NO"}
+```
+
+<HorizontalLine />
+
 ### AvailableCurrency
 
 Defines the code and symbol of a currency that can be used for purchase orders.
@@ -1573,7 +1586,7 @@ Defines the code and symbol of a currency that can be used for purchase orders.
 #### Example
 
 ```json
-{"code": "AFN", "symbol": "abc123"}
+{"code": "AFN", "symbol": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -1595,8 +1608,8 @@ Describes a payment method that the shopper can use to pay for the order.
 
 ```json
 {
-  "code": "abc123",
-  "is_deferred": false,
+  "code": "xyz789",
+  "is_deferred": true,
   "oope_payment_method_config": OopePaymentMethodConfig,
   "title": "abc123"
 }
@@ -1629,9 +1642,9 @@ Contains details about the possible shipping methods and carriers.
 {
   "additional_data": [ShippingAdditionalData],
   "amount": Money,
-  "available": true,
-  "carrier_code": "abc123",
-  "carrier_title": "xyz789",
+  "available": false,
+  "carrier_code": "xyz789",
+  "carrier_title": "abc123",
   "error_message": "xyz789",
   "method_code": "xyz789",
   "method_title": "xyz789",
@@ -1679,10 +1692,10 @@ Defines the billing address.
 ```json
 {
   "address": CartAddressInput,
-  "customer_address_id": 123,
+  "customer_address_id": 987,
   "customer_address_uid": "4",
   "same_as_shipping": true,
-  "use_for_shipping": true
+  "use_for_shipping": false
 }
 ```
 
@@ -1707,12 +1720,12 @@ The billing address information
 
 ```json
 {
-  "address_line_1": "xyz789",
+  "address_line_1": "abc123",
   "address_line_2": "xyz789",
   "city": "abc123",
   "country_code": "xyz789",
   "postal_code": "xyz789",
-  "region": "abc123"
+  "region": "xyz789"
 }
 ```
 
@@ -1749,8 +1762,8 @@ Contains details about the billing address.
 
 ```json
 {
-  "city": "abc123",
-  "company": "xyz789",
+  "city": "xyz789",
+  "company": "abc123",
   "country": CartAddressCountry,
   "custom_attributes": [AttributeValueInterface],
   "customer_address_uid": 4,
@@ -1762,9 +1775,9 @@ Contains details about the billing address.
   "postcode": "xyz789",
   "prefix": "abc123",
   "region": CartAddressRegion,
-  "street": ["abc123"],
-  "suffix": "abc123",
-  "telephone": "abc123",
+  "street": ["xyz789"],
+  "suffix": "xyz789",
+  "telephone": "xyz789",
   "uid": "4",
   "vat_id": "abc123"
 }
@@ -1775,12 +1788,6 @@ Contains details about the billing address.
 ### Boolean
 
 The `Boolean` scalar type represents `true` or `false`.
-
-#### Example
-
-```json
-true
-```
 
 <HorizontalLine />
 
@@ -1805,7 +1812,7 @@ Contains details about an individual category that comprises a breadcrumb.
   "category_level": 123,
   "category_name": "xyz789",
   "category_uid": "4",
-  "category_url_key": "abc123",
+  "category_url_key": "xyz789",
   "category_url_path": "abc123"
 }
 ```
@@ -1835,7 +1842,7 @@ An interface for bucket contents
 #### Example
 
 ```json
-{"title": "xyz789"}
+{"title": "abc123"}
 ```
 
 <HorizontalLine />
@@ -1874,7 +1881,7 @@ An implementation for bundle product cart items.
 ```json
 {
   "available_gift_wrapping": [GiftWrapping],
-  "backorder_message": "abc123",
+  "backorder_message": "xyz789",
   "bundle_options": [SelectedBundleOption],
   "custom_attributes": [CustomAttribute],
   "customizable_options": [SelectedCustomizableOption],
@@ -1885,13 +1892,13 @@ An implementation for bundle product cart items.
   "is_available": false,
   "is_salable": true,
   "max_qty": 987.65,
-  "min_qty": 987.65,
+  "min_qty": 123.45,
   "not_available_message": "abc123",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
-  "quantity": 987.65,
+  "quantity": 123.45,
   "uid": 4
 }
 ```
@@ -1925,10 +1932,10 @@ Defines bundle product options for `CreditMemoItemInterface`.
   "discounts": [Discount],
   "id": 4,
   "order_item": OrderItemInterface,
-  "product_name": "abc123",
+  "product_name": "xyz789",
   "product_sale_price": Money,
   "product_sku": "xyz789",
-  "quantity_refunded": 987.65
+  "quantity_refunded": 123.45
 }
 ```
 
@@ -1961,9 +1968,9 @@ Defines bundle product options for `InvoiceItemInterface`.
   "discounts": [Discount],
   "id": "4",
   "order_item": OrderItemInterface,
-  "product_name": "abc123",
+  "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "abc123",
+  "product_sku": "xyz789",
   "quantity_invoiced": 987.65
 }
 ```
@@ -1992,12 +1999,12 @@ Defines an individual item within a bundle product.
 ```json
 {
   "options": [BundleItemOption],
-  "position": 123,
+  "position": 987,
   "price_range": PriceRange,
-  "required": false,
-  "sku": "xyz789",
-  "title": "abc123",
-  "type": "abc123",
+  "required": true,
+  "sku": "abc123",
+  "title": "xyz789",
+  "type": "xyz789",
   "uid": 4
 }
 ```
@@ -2026,15 +2033,15 @@ Defines the characteristics that comprise a specific bundle item and its options
 
 ```json
 {
-  "can_change_quantity": false,
-  "is_default": true,
+  "can_change_quantity": true,
+  "is_default": false,
   "label": "abc123",
-  "position": 987,
+  "position": 123,
   "price": 123.45,
   "price_type": "FIXED",
   "product": ProductInterface,
   "quantity": 987.65,
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -2092,17 +2099,17 @@ Defines bundle product options for `OrderItemInterface`.
   "product_name": "abc123",
   "product_sale_price": Money,
   "product_sku": "abc123",
-  "product_type": "abc123",
+  "product_type": "xyz789",
   "product_url_key": "abc123",
-  "quantity_canceled": 987.65,
+  "quantity_canceled": 123.45,
   "quantity_invoiced": 123.45,
-  "quantity_ordered": 123.45,
+  "quantity_ordered": 987.65,
   "quantity_refunded": 987.65,
-  "quantity_return_requested": 987.65,
+  "quantity_return_requested": 123.45,
   "quantity_returned": 123.45,
-  "quantity_shipped": 123.45,
+  "quantity_shipped": 987.65,
   "selected_options": [OrderItemOption],
-  "status": "xyz789"
+  "status": "abc123"
 }
 ```
 
@@ -2169,40 +2176,40 @@ Defines basic features of a bundle product and contains multiple BundleItems.
 
 ```json
 {
-  "canonical_url": "abc123",
+  "canonical_url": "xyz789",
   "categories": [CategoryInterface],
-  "country_of_manufacture": "xyz789",
+  "country_of_manufacture": "abc123",
   "crosssell_products": [ProductInterface],
   "custom_attributesV2": ProductCustomAttributes,
   "description": ComplexTextValue,
   "dynamic_price": false,
   "dynamic_sku": false,
-  "dynamic_weight": false,
-  "gift_message_available": false,
-  "gift_wrapping_available": true,
+  "dynamic_weight": true,
+  "gift_message_available": true,
+  "gift_wrapping_available": false,
   "gift_wrapping_price": Money,
   "image": ProductImage,
-  "is_returnable": "xyz789",
+  "is_returnable": "abc123",
   "items": [BundleItem],
   "manufacturer": 987,
-  "max_sale_qty": 123.45,
+  "max_sale_qty": 987.65,
   "media_gallery": [MediaGalleryInterface],
-  "meta_description": "abc123",
-  "meta_keyword": "xyz789",
+  "meta_description": "xyz789",
+  "meta_keyword": "abc123",
   "meta_title": "abc123",
-  "min_sale_qty": 123.45,
+  "min_sale_qty": 987.65,
   "name": "xyz789",
   "new_from_date": "xyz789",
-  "new_to_date": "xyz789",
-  "only_x_left_in_stock": 123.45,
+  "new_to_date": "abc123",
+  "only_x_left_in_stock": 987.65,
   "options": [CustomizableOptionInterface],
-  "options_container": "xyz789",
+  "options_container": "abc123",
   "price_details": PriceDetails,
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
   "price_view": "PRICE_RANGE",
   "product_links": [ProductLinksInterface],
-  "quantity": 123.45,
+  "quantity": 987.65,
   "related_products": [ProductInterface],
   "ship_bundle_items": "TOGETHER",
   "short_description": ComplexTextValue,
@@ -2211,12 +2218,12 @@ Defines basic features of a bundle product and contains multiple BundleItems.
   "special_price": 123.45,
   "special_to_date": "abc123",
   "stock_status": "IN_STOCK",
-  "swatch_image": "xyz789",
+  "swatch_image": "abc123",
   "thumbnail": ProductImage,
-  "uid": "4",
+  "uid": 4,
   "upsell_products": [ProductInterface],
-  "url_key": "xyz789",
-  "weight": 123.45
+  "url_key": "abc123",
+  "weight": 987.65
 }
 ```
 
@@ -2244,7 +2251,7 @@ Contains details about bundle products added to a requisition list.
   "bundle_options": [SelectedBundleOption],
   "customizable_options": [SelectedCustomizableOption],
   "product": ProductInterface,
-  "quantity": 123.45,
+  "quantity": 987.65,
   "sku": "xyz789",
   "uid": "4"
 }
@@ -2273,9 +2280,9 @@ Defines bundle product options for `ShipmentItemInterface`.
 ```json
 {
   "bundle_options": [ItemSelectedBundleOption],
-  "id": "4",
+  "id": 4,
   "order_item": OrderItemInterface,
-  "product_name": "xyz789",
+  "product_name": "abc123",
   "product_sale_price": Money,
   "product_sku": "xyz789",
   "quantity_shipped": 987.65
@@ -2308,9 +2315,9 @@ Defines bundle product options for `WishlistItemInterface`.
   "bundle_options": [SelectedBundleOption],
   "customizable_options": [SelectedCustomizableOption],
   "description": "xyz789",
-  "id": 4,
+  "id": "4",
   "product": ProductInterface,
-  "quantity": 987.65
+  "quantity": 123.45
 }
 ```
 
@@ -2334,11 +2341,11 @@ Defines bundle product options for `WishlistItemInterface`.
 
 ```json
 {
-  "color": "abc123",
-  "height": 987,
+  "color": "xyz789",
+  "height": 123,
   "label": "xyz789",
-  "layout": "abc123",
-  "shape": "abc123",
+  "layout": "xyz789",
+  "shape": "xyz789",
   "tagline": false,
   "use_default_height": false
 }

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-c-e.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-c-e.md
@@ -15,8 +15,8 @@ Specifies the quote template id of the quote template to cancel
 
 ```json
 {
-  "cancellation_comment": "xyz789",
-  "template_id": 4
+  "cancellation_comment": "abc123",
+  "template_id": "4"
 }
 ```
 
@@ -36,7 +36,7 @@ Specifies the quote template id of the quote template to cancel
 ```json
 {
   "code": "ORDER_CANCELLATION_DISABLED",
-  "message": "xyz789"
+  "message": "abc123"
 }
 ```
 
@@ -77,10 +77,7 @@ Defines the order to cancel.
 #### Example
 
 ```json
-{
-  "order_id": "4",
-  "reason": "abc123"
-}
+{"order_id": 4, "reason": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -101,7 +98,7 @@ Contains the updated customer order and error message if any.
 
 ```json
 {
-  "error": "abc123",
+  "error": "xyz789",
   "errorV2": CancelOrderError,
   "order": CustomerOrder
 }
@@ -120,7 +117,7 @@ Contains the updated customer order and error message if any.
 #### Example
 
 ```json
-{"description": "abc123"}
+{"description": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -131,6 +128,7 @@ Contains the updated customer order and error message if any.
 
 | Field Name | Description |
 |------------|-------------|
+| `authentication_result` - [`AuthenticationResult`](#authenticationresult) | Authentication result |
 | `bin_details` - [`CardBin`](#cardbin) | Card bin details |
 | `card_expiry_month` - [`String`](#string) | Expiration month of the card |
 | `card_expiry_year` - [`String`](#string) | Expiration year of the card |
@@ -141,10 +139,11 @@ Contains the updated customer order and error message if any.
 
 ```json
 {
+  "authentication_result": AuthenticationResult,
   "bin_details": CardBin,
-  "card_expiry_month": "abc123",
+  "card_expiry_month": "xyz789",
   "card_expiry_year": "abc123",
-  "last_digits": "xyz789",
+  "last_digits": "abc123",
   "name": "xyz789"
 }
 ```
@@ -162,7 +161,7 @@ Contains the updated customer order and error message if any.
 #### Example
 
 ```json
-{"bin": "abc123"}
+{"bin": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -183,7 +182,7 @@ The card payment source information
 ```json
 {
   "billing_address": BillingAddressPaymentSourceInput,
-  "name": "xyz789"
+  "name": "abc123"
 }
 ```
 
@@ -206,8 +205,8 @@ The card payment source information
 ```json
 {
   "brand": "abc123",
-  "expiry": "abc123",
-  "last_digits": "abc123"
+  "expiry": "xyz789",
+  "last_digits": "xyz789"
 }
 ```
 
@@ -257,17 +256,17 @@ Contains the contents and other details about a guest or customer cart.
   "custom_attributes": [CustomAttribute],
   "email": "xyz789",
   "gift_message": GiftMessage,
-  "gift_receipt_included": true,
+  "gift_receipt_included": false,
   "gift_wrapping": GiftWrapping,
-  "id": 4,
+  "id": "4",
   "is_virtual": true,
   "itemsV2": CartItems,
   "prices": CartPrices,
-  "printed_card_included": false,
+  "printed_card_included": true,
   "rules": [CartRuleStorefront],
   "selected_payment_method": SelectedPaymentMethod,
   "shipping_addresses": [ShippingCartAddress],
-  "total_quantity": 987.65
+  "total_quantity": 123.45
 }
 ```
 
@@ -325,19 +324,19 @@ Defines the billing or shipping address to be applied to the cart.
 
 ```json
 {
-  "city": "xyz789",
+  "city": "abc123",
   "company": "xyz789",
   "country_code": "xyz789",
   "custom_attributes": [AttributeValueInput],
-  "fax": "xyz789",
+  "fax": "abc123",
   "firstname": "xyz789",
-  "lastname": "xyz789",
-  "middlename": "xyz789",
+  "lastname": "abc123",
+  "middlename": "abc123",
   "postcode": "abc123",
   "prefix": "abc123",
   "region": "xyz789",
   "region_id": 123,
-  "save_in_address_book": true,
+  "save_in_address_book": false,
   "street": ["xyz789"],
   "suffix": "xyz789",
   "telephone": "abc123",
@@ -383,24 +382,24 @@ Defines the billing or shipping address to be applied to the cart.
 
 ```json
 {
-  "city": "xyz789",
-  "company": "abc123",
+  "city": "abc123",
+  "company": "xyz789",
   "country": CartAddressCountry,
   "custom_attributes": [AttributeValueInterface],
-  "customer_address_uid": 4,
+  "customer_address_uid": "4",
   "fax": "xyz789",
   "firstname": "abc123",
-  "id": 123,
-  "lastname": "xyz789",
+  "id": 987,
+  "lastname": "abc123",
   "middlename": "xyz789",
   "postcode": "xyz789",
-  "prefix": "xyz789",
+  "prefix": "abc123",
   "region": CartAddressRegion,
   "street": ["abc123"],
   "suffix": "abc123",
-  "telephone": "xyz789",
-  "uid": "4",
-  "vat_id": "xyz789"
+  "telephone": "abc123",
+  "uid": 4,
+  "vat_id": "abc123"
 }
 ```
 
@@ -422,9 +421,9 @@ Contains details about the region in a billing or shipping address.
 
 ```json
 {
-  "code": "xyz789",
-  "label": "abc123",
-  "region_id": 123
+  "code": "abc123",
+  "label": "xyz789",
+  "region_id": 987
 }
 ```
 
@@ -445,7 +444,7 @@ Defines a cart custom attributes.
 
 ```json
 {
-  "cart_id": "xyz789",
+  "cart_id": "abc123",
   "custom_attributes": [CustomAttributeInput]
 }
 ```
@@ -485,8 +484,8 @@ Defines a cart item custom attributes.
 
 ```json
 {
-  "cart_id": "xyz789",
-  "cart_item_id": "abc123",
+  "cart_id": "abc123",
+  "cart_item_id": "xyz789",
   "custom_attributes": [CustomAttributeInput]
 }
 ```
@@ -505,7 +504,7 @@ Defines a cart item custom attributes.
 #### Example
 
 ```json
-{"code": "UNDEFINED", "message": "abc123"}
+{"code": "UNDEFINED", "message": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -547,9 +546,9 @@ Defines an item to be added to the cart.
 ```json
 {
   "entered_options": [EnteredOptionInput],
-  "parent_sku": "abc123",
+  "parent_sku": "xyz789",
   "quantity": 987.65,
-  "selected_options": [4],
+  "selected_options": ["4"],
   "sku": "xyz789"
 }
 ```
@@ -595,20 +594,20 @@ An interface for products in a cart.
 
 ```json
 {
-  "backorder_message": "abc123",
+  "backorder_message": "xyz789",
   "custom_attributes": [CustomAttribute],
   "discount": [Discount],
   "errors": [CartItemError],
-  "is_available": true,
-  "is_salable": true,
-  "max_qty": 123.45,
+  "is_available": false,
+  "is_salable": false,
+  "max_qty": 987.65,
   "min_qty": 987.65,
-  "not_available_message": "xyz789",
+  "not_available_message": "abc123",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
-  "quantity": 987.65,
+  "quantity": 123.45,
   "uid": "4"
 }
 ```
@@ -672,8 +671,8 @@ Contains details about the price of a selected customizable value.
 ```json
 {
   "type": "FIXED",
-  "units": "xyz789",
-  "value": 987.65
+  "units": "abc123",
+  "value": 123.45
 }
 ```
 
@@ -697,7 +696,7 @@ A single item to be updated.
 
 ```json
 {
-  "cart_item_uid": 4,
+  "cart_item_uid": "4",
   "customizable_options": [CustomizableOptionInput],
   "gift_message": GiftMessageInput,
   "gift_wrapping_id": "4",
@@ -738,6 +737,7 @@ Contains details about the final price of items in the cart, including discount 
 | Field Name | Description |
 |------------|-------------|
 | `applied_taxes` - [`[CartTaxItem]`](#carttaxitem) | An array containing the names and amounts of taxes applied to each item in the cart. |
+| `custom_fees` - [`[OopeCustomFee]`](#oopecustomfee) | Custom fees applied to the cart via out-of-process webhooks. |
 | `discounts` - [`[Discount]`](#discount) | An array containing cart rule discounts, store credit and gift cards applied to the cart. |
 | `gift_options` - [`GiftOptionsPrices`](#giftoptionsprices) | The list of prices for the selected gift options. |
 | `grand_total` - [`Money`](#money) | The total, including discounts, taxes, shipping, and other fees. |
@@ -751,6 +751,7 @@ Contains details about the final price of items in the cart, including discount 
 ```json
 {
   "applied_taxes": [CartTaxItem],
+  "custom_fees": [OopeCustomFee],
   "discounts": [Discount],
   "gift_options": GiftOptionsPrices,
   "grand_total": Money,
@@ -774,7 +775,7 @@ Contains details about the final price of items in the cart, including discount 
 #### Example
 
 ```json
-{"uid": 4}
+{"uid": "4"}
 ```
 
 <HorizontalLine />
@@ -904,29 +905,29 @@ Swatch attribute metadata.
 ```json
 {
   "apply_to": ["SIMPLE"],
-  "code": 4,
-  "default_value": "xyz789",
+  "code": "4",
+  "default_value": "abc123",
   "entity_type": "CATALOG_PRODUCT",
-  "frontend_class": "xyz789",
+  "frontend_class": "abc123",
   "frontend_input": "BOOLEAN",
   "is_comparable": false,
   "is_filterable": true,
-  "is_filterable_in_search": false,
+  "is_filterable_in_search": true,
   "is_html_allowed_on_front": false,
   "is_required": false,
   "is_searchable": true,
   "is_unique": false,
-  "is_used_for_price_rules": false,
+  "is_used_for_price_rules": true,
   "is_used_for_promo_rules": true,
-  "is_visible_in_advanced_search": false,
+  "is_visible_in_advanced_search": true,
   "is_visible_on_front": false,
   "is_wysiwyg_enabled": false,
   "label": "abc123",
   "options": [CustomAttributeOptionInterface],
   "swatch_input_type": "BOOLEAN",
-  "update_product_preview_image": false,
+  "update_product_preview_image": true,
   "use_product_image_for_swatch": true,
-  "used_in_product_listing": true
+  "used_in_product_listing": false
 }
 ```
 
@@ -949,9 +950,9 @@ New category bucket for federation
 
 ```json
 {
-  "count": 123,
+  "count": 987,
   "id": 4,
-  "path": "xyz789",
+  "path": "abc123",
   "title": "abc123"
 }
 ```
@@ -1028,27 +1029,27 @@ Contains the full set of attributes that can be returned in a category search.
   "breadcrumbs": [Breadcrumb],
   "canonical_url": "xyz789",
   "children_count": "xyz789",
-  "custom_layout_update_file": "xyz789",
+  "custom_layout_update_file": "abc123",
   "default_sort_by": "xyz789",
-  "description": "xyz789",
-  "display_mode": "abc123",
-  "filter_price_range": 987.65,
+  "description": "abc123",
+  "display_mode": "xyz789",
+  "filter_price_range": 123.45,
   "image": "abc123",
   "include_in_menu": 123,
-  "is_anchor": 987,
-  "landing_page": 987,
+  "is_anchor": 123,
+  "landing_page": 123,
   "level": 987,
   "meta_description": "xyz789",
-  "meta_keywords": "xyz789",
-  "meta_title": "xyz789",
+  "meta_keywords": "abc123",
+  "meta_title": "abc123",
   "name": "xyz789",
-  "path": "abc123",
+  "path": "xyz789",
   "path_in_store": "abc123",
-  "position": 123,
+  "position": 987,
   "product_count": 987,
-  "uid": "4",
+  "uid": 4,
   "url_key": "xyz789",
-  "url_path": "xyz789"
+  "url_path": "abc123"
 }
 ```
 
@@ -1094,29 +1095,29 @@ Contains the hierarchy of categories.
 {
   "available_sort_by": ["abc123"],
   "breadcrumbs": [Breadcrumb],
-  "canonical_url": "abc123",
-  "children_count": "xyz789",
+  "canonical_url": "xyz789",
+  "children_count": "abc123",
   "custom_layout_update_file": "abc123",
-  "default_sort_by": "abc123",
+  "default_sort_by": "xyz789",
   "description": "abc123",
   "display_mode": "abc123",
   "filter_price_range": 123.45,
-  "image": "abc123",
-  "include_in_menu": 123,
+  "image": "xyz789",
+  "include_in_menu": 987,
   "is_anchor": 123,
   "landing_page": 123,
   "level": 987,
-  "meta_description": "xyz789",
+  "meta_description": "abc123",
   "meta_keywords": "xyz789",
-  "meta_title": "xyz789",
+  "meta_title": "abc123",
   "name": "xyz789",
-  "path": "abc123",
-  "path_in_store": "abc123",
-  "position": 987,
-  "product_count": 987,
+  "path": "xyz789",
+  "path_in_store": "xyz789",
+  "position": 123,
+  "product_count": 123,
   "uid": 4,
   "url_key": "xyz789",
-  "url_path": "abc123"
+  "url_path": "xyz789"
 }
 ```
 
@@ -1149,20 +1150,20 @@ Represents a category. Contains information about a category, including the cate
 
 ```json
 {
-  "availableSortBy": ["xyz789"],
-  "children": ["xyz789"],
-  "defaultSortBy": "abc123",
-  "id": "4",
+  "availableSortBy": ["abc123"],
+  "children": ["abc123"],
+  "defaultSortBy": "xyz789",
+  "id": 4,
   "level": 123,
-  "name": "xyz789",
-  "parentId": "xyz789",
+  "name": "abc123",
+  "parentId": "abc123",
   "position": 123,
   "path": "abc123",
-  "roles": ["abc123"],
-  "urlKey": "xyz789",
+  "roles": ["xyz789"],
+  "urlKey": "abc123",
   "urlPath": "abc123",
-  "count": 123,
-  "title": "xyz789"
+  "count": 987,
+  "title": "abc123"
 }
 ```
 
@@ -1196,15 +1197,15 @@ Base interface defining essential category fields shared across all category vie
 
 ```json
 {
-  "availableSortBy": ["abc123"],
-  "defaultSortBy": "xyz789",
+  "availableSortBy": ["xyz789"],
+  "defaultSortBy": "abc123",
   "id": "4",
-  "level": 123,
+  "level": 987,
   "name": "abc123",
-  "path": "abc123",
+  "path": "xyz789",
   "roles": ["xyz789"],
   "urlKey": "abc123",
-  "urlPath": "abc123"
+  "urlPath": "xyz789"
 }
 ```
 
@@ -1233,8 +1234,8 @@ Defines details about an individual checkout agreement.
   "agreement_id": 987,
   "checkbox_text": "abc123",
   "content": "xyz789",
-  "content_height": "abc123",
-  "is_html": true,
+  "content_height": "xyz789",
+  "is_html": false,
   "mode": "AUTO",
   "name": "xyz789"
 }
@@ -1278,7 +1279,7 @@ An error encountered while adding an item to the cart.
 ```json
 {
   "code": "REORDER_NOT_AVAILABLE",
-  "message": "xyz789",
+  "message": "abc123",
   "path": ["xyz789"]
 }
 ```
@@ -1358,7 +1359,7 @@ Contains details about a failed close operation on a negotiable quote.
 ```json
 {
   "errors": [NegotiableQuoteInvalidStateError],
-  "quote_uid": 4
+  "quote_uid": "4"
 }
 ```
 
@@ -1454,7 +1455,7 @@ Commerce Optimizer entities
 #### Example
 
 ```json
-{"priceBookId": "4"}
+{"priceBookId": 4}
 ```
 
 <HorizontalLine />
@@ -1542,10 +1543,10 @@ Contains the output schema for a company.
   "credit_history": CompanyCreditHistory,
   "custom_attributes": [CustomAttribute],
   "email": "xyz789",
-  "id": "4",
+  "id": 4,
   "legal_address": CompanyLegalAddress,
   "legal_name": "xyz789",
-  "name": "abc123",
+  "name": "xyz789",
   "payment_methods": ["abc123"],
   "reseller_id": "abc123",
   "role": CompanyRole,
@@ -1582,7 +1583,7 @@ Contains details about the access control list settings of a resource.
   "children": [CompanyAclResource],
   "id": 4,
   "sort_order": 987,
-  "text": "abc123"
+  "text": "xyz789"
 }
 ```
 
@@ -1610,11 +1611,11 @@ Defines the input schema for creating a company administrator.
 {
   "custom_attributes": [AttributeValueInput],
   "email": "abc123",
-  "firstname": "abc123",
-  "gender": 123,
-  "job_title": "abc123",
-  "lastname": "xyz789",
-  "telephone": "abc123"
+  "firstname": "xyz789",
+  "gender": 987,
+  "job_title": "xyz789",
+  "lastname": "abc123",
+  "telephone": "xyz789"
 }
 ```
 
@@ -1636,7 +1637,7 @@ Describes a carrier-level shipping option available to the company.
 ```json
 {
   "code": "abc123",
-  "title": "abc123"
+  "title": "xyz789"
 }
 ```
 
@@ -1663,7 +1664,7 @@ The minimal required information to identify and display the company.
   "id": 4,
   "is_admin": false,
   "legal_name": "abc123",
-  "name": "xyz789",
+  "name": "abc123",
   "status": "PENDING"
 }
 ```
@@ -1694,9 +1695,9 @@ Defines the input schema for creating a new company.
   "company_email": "xyz789",
   "company_name": "abc123",
   "legal_address": CompanyLegalAddressCreateInput,
-  "legal_name": "abc123",
+  "legal_name": "xyz789",
   "reseller_id": "abc123",
-  "vat_tax_id": "abc123"
+  "vat_tax_id": "xyz789"
 }
 ```
 
@@ -1746,7 +1747,7 @@ Contains details about prior company credit operations.
 {
   "items": [CompanyCreditOperation],
   "page_info": SearchResultPageInfo,
-  "total_count": 123
+  "total_count": 987
 }
 ```
 
@@ -1768,7 +1769,7 @@ Defines a filter for narrowing the results of a credit history search.
 
 ```json
 {
-  "custom_reference_number": "xyz789",
+  "custom_reference_number": "abc123",
   "operation_type": "ALLOCATION",
   "updated_by": "xyz789"
 }
@@ -1901,8 +1902,8 @@ Defines the input schema for accepting the company invitation.
 
 ```json
 {
-  "code": "xyz789",
-  "role_id": 4,
+  "code": "abc123",
+  "role_id": "4",
   "user": CompanyInvitationUserInput
 }
 ```
@@ -1922,7 +1923,7 @@ The result of accepting the company invitation.
 #### Example
 
 ```json
-{"success": false}
+{"success": true}
 ```
 
 <HorizontalLine />
@@ -1945,11 +1946,11 @@ Company user attributes in the invitation.
 
 ```json
 {
-  "company_id": "4",
-  "customer_id": "4",
-  "job_title": "abc123",
+  "company_id": 4,
+  "customer_id": 4,
+  "job_title": "xyz789",
   "status": "ACTIVE",
-  "telephone": "abc123"
+  "telephone": "xyz789"
 }
 ```
 
@@ -2004,11 +2005,11 @@ Defines the input schema for defining a company's legal address.
 
 ```json
 {
-  "city": "abc123",
+  "city": "xyz789",
   "country_id": "AF",
-  "postcode": "abc123",
+  "postcode": "xyz789",
   "region": CustomerAddressRegionInput,
-  "street": ["xyz789"],
+  "street": ["abc123"],
   "telephone": "xyz789"
 }
 ```
@@ -2038,7 +2039,7 @@ Defines the input schema for updating a company's legal address.
   "country_id": "AF",
   "postcode": "xyz789",
   "region": CustomerAddressRegionInput,
-  "street": ["xyz789"],
+  "street": ["abc123"],
   "telephone": "abc123"
 }
 ```
@@ -2062,8 +2063,8 @@ Contails details about a single role.
 
 ```json
 {
-  "id": "4",
-  "name": "abc123",
+  "id": 4,
+  "name": "xyz789",
   "permissions": [CompanyAclResource],
   "users_count": 123
 }
@@ -2086,8 +2087,8 @@ Defines the input schema for creating a company role.
 
 ```json
 {
-  "name": "xyz789",
-  "permissions": ["abc123"]
+  "name": "abc123",
+  "permissions": ["xyz789"]
 }
 ```
 
@@ -2135,7 +2136,7 @@ Contains an array of roles.
 {
   "items": [CompanyRole],
   "page_info": SearchResultPageInfo,
-  "total_count": 987
+  "total_count": 123
 }
 ```
 
@@ -2158,7 +2159,7 @@ Contains details about a company sales representative.
 ```json
 {
   "email": "abc123",
-  "firstname": "xyz789",
+  "firstname": "abc123",
   "lastname": "abc123"
 }
 ```
@@ -2239,7 +2240,7 @@ Defines an individual node in the company structure.
 {
   "entity": CompanyTeam,
   "id": "4",
-  "parent_id": "4"
+  "parent_id": 4
 }
 ```
 
@@ -2259,10 +2260,7 @@ Defines the input schema for updating the company structure.
 #### Example
 
 ```json
-{
-  "parent_tree_id": "4",
-  "tree_id": "4"
-}
+{"parent_tree_id": "4", "tree_id": 4}
 ```
 
 <HorizontalLine />
@@ -2286,8 +2284,8 @@ Describes a company team.
 {
   "description": "xyz789",
   "id": "4",
-  "name": "abc123",
-  "structure_id": "4"
+  "name": "xyz789",
+  "structure_id": 4
 }
 ```
 
@@ -2334,7 +2332,7 @@ Defines the input schema for updating a company team.
 ```json
 {
   "description": "abc123",
-  "id": 4,
+  "id": "4",
   "name": "abc123"
 }
 ```
@@ -2361,9 +2359,9 @@ Defines the input schema for updating a company.
 ```json
 {
   "company_email": "abc123",
-  "company_name": "abc123",
+  "company_name": "xyz789",
   "legal_address": CompanyLegalAddressUpdateInput,
-  "legal_name": "xyz789",
+  "legal_name": "abc123",
   "reseller_id": "abc123",
   "vat_tax_id": "xyz789"
 }
@@ -2392,13 +2390,13 @@ Defines the input schema for creating a company user.
 
 ```json
 {
-  "email": "abc123",
+  "email": "xyz789",
   "firstname": "xyz789",
   "job_title": "xyz789",
   "lastname": "xyz789",
   "role_id": "4",
   "status": "ACTIVE",
-  "target_id": "4",
+  "target_id": 4,
   "telephone": "xyz789"
 }
 ```
@@ -2445,14 +2443,14 @@ Defines the input schema for updating a company user.
 
 ```json
 {
-  "email": "xyz789",
-  "firstname": "xyz789",
+  "email": "abc123",
+  "firstname": "abc123",
   "id": "4",
-  "job_title": "abc123",
-  "lastname": "abc123",
-  "role_id": "4",
+  "job_title": "xyz789",
+  "lastname": "xyz789",
+  "role_id": 4,
   "status": "ACTIVE",
-  "telephone": "xyz789"
+  "telephone": "abc123"
 }
 ```
 
@@ -2515,7 +2513,7 @@ Contains an attribute code that is used for product comparisons.
 
 ```json
 {
-  "code": "abc123",
+  "code": "xyz789",
   "label": "abc123"
 }
 ```
@@ -2540,7 +2538,7 @@ Defines an object used to iterate through items for product comparisons.
 {
   "attributes": [ProductAttribute],
   "product": ProductInterface,
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -2631,30 +2629,30 @@ Represents all product types, except simple products. Complex product prices are
 
 ```json
 {
-  "addToCartAllowed": false,
-  "inStock": false,
+  "addToCartAllowed": true,
+  "inStock": true,
   "lowStock": false,
   "attributes": [ProductViewAttribute],
   "description": "xyz789",
-  "id": "4",
+  "id": 4,
   "images": [ProductViewImage],
   "videos": [ProductViewVideo],
   "lastModifiedAt": "2007-12-03T10:15:30Z",
-  "metaDescription": "xyz789",
+  "metaDescription": "abc123",
   "metaKeyword": "abc123",
   "metaTitle": "xyz789",
-  "name": "abc123",
+  "name": "xyz789",
   "inputOptions": [ProductViewInputOption],
   "options": [ProductViewOption],
   "priceRange": ProductViewPriceRange,
   "shortDescription": "abc123",
-  "sku": "abc123",
-  "externalId": "xyz789",
-  "url": "xyz789",
+  "sku": "xyz789",
+  "externalId": "abc123",
+  "url": "abc123",
   "urlKey": "abc123",
   "links": [ProductViewLink],
   "queryType": "abc123",
-  "visibility": "abc123"
+  "visibility": "xyz789"
 }
 ```
 
@@ -2717,7 +2715,7 @@ Contains details about a configurable product attribute option.
 {
   "code": "abc123",
   "label": "abc123",
-  "uid": "4",
+  "uid": 4,
   "value_index": 123
 }
 ```
@@ -2769,8 +2767,8 @@ An implementation for configurable product cart items.
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
   "is_available": false,
-  "is_salable": false,
-  "max_qty": 123.45,
+  "is_salable": true,
+  "max_qty": 987.65,
   "min_qty": 987.65,
   "not_available_message": "abc123",
   "note_from_buyer": [ItemNote],
@@ -2843,28 +2841,28 @@ Describes configurable options that have been selected and can be selected as a 
 {
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
-  "eligible_for_return": false,
+  "eligible_for_return": true,
   "entered_options": [OrderItemOption],
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
   "id": "4",
-  "parent_sku": "xyz789",
+  "parent_sku": "abc123",
   "prices": OrderItemPrices,
   "product": ProductInterface,
-  "product_name": "xyz789",
+  "product_name": "abc123",
   "product_sale_price": Money,
-  "product_sku": "abc123",
-  "product_type": "xyz789",
-  "product_url_key": "abc123",
-  "quantity_canceled": 123.45,
+  "product_sku": "xyz789",
+  "product_type": "abc123",
+  "product_url_key": "xyz789",
+  "quantity_canceled": 987.65,
   "quantity_invoiced": 987.65,
-  "quantity_ordered": 987.65,
-  "quantity_refunded": 123.45,
+  "quantity_ordered": 123.45,
+  "quantity_refunded": 987.65,
   "quantity_return_requested": 123.45,
   "quantity_returned": 987.65,
   "quantity_shipped": 987.65,
   "selected_options": [OrderItemOption],
-  "status": "abc123"
+  "status": "xyz789"
 }
 ```
 
@@ -2940,17 +2938,17 @@ Defines basic features of a configurable product and its simple product variants
   "gift_wrapping_price": Money,
   "image": ProductImage,
   "is_returnable": "abc123",
-  "manufacturer": 123,
+  "manufacturer": 987,
   "max_sale_qty": 123.45,
   "media_gallery": [MediaGalleryInterface],
   "meta_description": "xyz789",
   "meta_keyword": "abc123",
   "meta_title": "abc123",
   "min_sale_qty": 987.65,
-  "name": "abc123",
+  "name": "xyz789",
   "new_from_date": "abc123",
-  "new_to_date": "xyz789",
-  "only_x_left_in_stock": 123.45,
+  "new_to_date": "abc123",
+  "only_x_left_in_stock": 987.65,
   "options": [CustomizableOptionInterface],
   "options_container": "abc123",
   "price_range": PriceRange,
@@ -2959,14 +2957,14 @@ Defines basic features of a configurable product and its simple product variants
   "quantity": 123.45,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
-  "sku": "abc123",
+  "sku": "xyz789",
   "small_image": ProductImage,
   "special_price": 987.65,
-  "special_to_date": "abc123",
+  "special_to_date": "xyz789",
   "stock_status": "IN_STOCK",
   "swatch_image": "abc123",
   "thumbnail": ProductImage,
-  "uid": "4",
+  "uid": 4,
   "upsell_products": [ProductInterface],
   "url_key": "abc123",
   "variants": [ConfigurableVariant],
@@ -2994,8 +2992,8 @@ Contains details about configurable product options.
 ```json
 {
   "attribute_code": "xyz789",
-  "label": "xyz789",
-  "uid": 4,
+  "label": "abc123",
+  "uid": "4",
   "values": [ConfigurableProductOptionValue]
 }
 ```
@@ -3020,11 +3018,11 @@ Defines a value for a configurable product option.
 
 ```json
 {
-  "is_available": true,
+  "is_available": false,
   "is_use_default": true,
-  "label": "abc123",
+  "label": "xyz789",
   "swatch": SwatchDataInterface,
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -3052,10 +3050,10 @@ Defines configurable attributes for the specified product.
 {
   "attribute_code": "abc123",
   "attribute_uid": 4,
-  "label": "abc123",
+  "label": "xyz789",
   "position": 123,
-  "uid": "4",
-  "use_default": true,
+  "uid": 4,
+  "use_default": false,
   "values": [ConfigurableProductOptionsValues]
 }
 ```
@@ -3109,12 +3107,12 @@ Contains the index number assigned to a configurable product option.
 
 ```json
 {
-  "default_label": "xyz789",
-  "label": "xyz789",
-  "store_label": "abc123",
+  "default_label": "abc123",
+  "label": "abc123",
+  "store_label": "xyz789",
   "swatch_data": SwatchDataInterface,
-  "uid": "4",
-  "use_default_value": false
+  "uid": 4,
+  "use_default_value": true
 }
 ```
 
@@ -3142,9 +3140,9 @@ Contains details about configurable products added to a requisition list.
   "configurable_options": [SelectedConfigurableOption],
   "customizable_options": [SelectedCustomizableOption],
   "product": ProductInterface,
-  "quantity": 987.65,
-  "sku": "abc123",
-  "uid": 4
+  "quantity": 123.45,
+  "sku": "xyz789",
+  "uid": "4"
 }
 ```
 
@@ -3197,8 +3195,8 @@ A configurable product wish list item.
   "configurable_options": [SelectedConfigurableOption],
   "configured_variant": ProductInterface,
   "customizable_options": [SelectedCustomizableOption],
-  "description": "abc123",
-  "id": "4",
+  "description": "xyz789",
+  "id": 4,
   "product": ProductInterface,
   "quantity": 123.45
 }
@@ -3241,8 +3239,8 @@ Contains details about a customer email address to confirm.
 
 ```json
 {
-  "confirmation_key": "abc123",
-  "email": "abc123"
+  "confirmation_key": "xyz789",
+  "email": "xyz789"
 }
 ```
 
@@ -3261,8 +3259,8 @@ Contains details about a customer email address to confirm.
 
 ```json
 {
-  "confirmation_key": "abc123",
-  "order_id": "4"
+  "confirmation_key": "xyz789",
+  "order_id": 4
 }
 ```
 
@@ -3302,7 +3300,7 @@ List of account confirmation statuses.
 
 ```json
 {
-  "comment": "xyz789",
+  "comment": "abc123",
   "email": "xyz789",
   "name": "xyz789",
   "telephone": "xyz789"
@@ -3324,7 +3322,7 @@ Contains the status of the request.
 #### Example
 
 ```json
-{"status": true}
+{"status": false}
 ```
 
 <HorizontalLine />
@@ -3342,7 +3340,7 @@ An input object that defines the items in a requisition list to be copied.
 #### Example
 
 ```json
-{"requisitionListItemUids": [4]}
+{"requisitionListItemUids": ["4"]}
 ```
 
 <HorizontalLine />
@@ -3407,11 +3405,11 @@ Contains the source and target wish lists after copying products.
 ```json
 {
   "available_regions": [Region],
-  "full_name_english": "abc123",
+  "full_name_english": "xyz789",
   "full_name_locale": "xyz789",
   "id": "abc123",
   "three_letter_abbreviation": "xyz789",
-  "two_letter_abbreviation": "xyz789"
+  "two_letter_abbreviation": "abc123"
 }
 ```
 
@@ -3793,8 +3791,8 @@ Defines a new gift registry.
   "dynamic_attributes": [
     GiftRegistryDynamicAttributeInput
   ],
-  "event_name": "xyz789",
-  "gift_registry_type_uid": "4",
+  "event_name": "abc123",
+  "gift_registry_type_uid": 4,
   "message": "xyz789",
   "privacy_settings": "PRIVATE",
   "registrants": [AddGiftRegistryRegistrantInput],
@@ -3834,7 +3832,7 @@ Contains the results of a request to create a gift registry.
 #### Example
 
 ```json
-{"cart_uid": 4}
+{"cart_uid": "4"}
 ```
 
 <HorizontalLine />
@@ -3875,7 +3873,7 @@ Contains payment order details that are used while processing the payment order
 {
   "cartId": "xyz789",
   "location": "PRODUCT_DETAIL",
-  "methodCode": "abc123",
+  "methodCode": "xyz789",
   "paymentSource": "abc123",
   "vaultIntent": true
 }
@@ -3901,9 +3899,9 @@ Contains payment order details that are used while processing the payment order
 
 ```json
 {
-  "amount": 123.45,
+  "amount": 987.65,
   "currency_code": "abc123",
-  "id": "xyz789",
+  "id": "abc123",
   "mp_order_id": "xyz789",
   "status": "abc123"
 }
@@ -3950,7 +3948,7 @@ Defines a set of conditions that apply to a rule.
   "amount": CreatePurchaseOrderApprovalRuleConditionAmountInput,
   "attribute": "GRAND_TOTAL",
   "operator": "MORE_THAN",
-  "quantity": 123
+  "quantity": 987
 }
 ```
 
@@ -3972,7 +3970,7 @@ An input object that identifies and describes a new requisition list.
 ```json
 {
   "description": "abc123",
-  "name": "xyz789"
+  "name": "abc123"
 }
 ```
 
@@ -4011,7 +4009,7 @@ Describe the variables needed to create a vault payment token
 
 ```json
 {
-  "card_description": "xyz789",
+  "card_description": "abc123",
   "setup_token_id": "abc123"
 }
 ```
@@ -4075,7 +4073,7 @@ The setup token id information
 #### Example
 
 ```json
-{"setup_token": "abc123"}
+{"setup_token": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -4138,7 +4136,7 @@ Contains credit memo details.
 {
   "comments": [SalesCommentItem],
   "custom_attributes": [CustomAttribute],
-  "id": 4,
+  "id": "4",
   "items": [CreditMemoItemInterface],
   "number": "xyz789",
   "total": CreditMemoTotal
@@ -4192,9 +4190,9 @@ Defines a credit memo item's custom attributes.
   "discounts": [Discount],
   "id": "4",
   "order_item": OrderItemInterface,
-  "product_name": "abc123",
+  "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
+  "product_sku": "abc123",
   "quantity_refunded": 987.65
 }
 ```
@@ -4218,7 +4216,7 @@ Defines a credit memo's custom attributes.
 ```json
 {
   "credit_memo_id": "abc123",
-  "credit_memo_item_id": "abc123",
+  "credit_memo_item_id": "xyz789",
   "custom_attributes": [CustomAttributeInput]
 }
 ```
@@ -4262,7 +4260,7 @@ Credit memo item details.
   "product_name": "xyz789",
   "product_sale_price": Money,
   "product_sku": "abc123",
-  "quantity_refunded": 987.65
+  "quantity_refunded": 123.45
 }
 ```
 
@@ -4339,11 +4337,11 @@ Contains credit memo price details.
 
 ```json
 {
-  "available_currency_codes": ["abc123"],
-  "base_currency_code": "xyz789",
-  "base_currency_symbol": "abc123",
-  "default_display_currency_code": "abc123",
-  "default_display_currency_symbol": "abc123",
+  "available_currency_codes": ["xyz789"],
+  "base_currency_code": "abc123",
+  "base_currency_symbol": "xyz789",
+  "default_display_currency_code": "xyz789",
+  "default_display_currency_symbol": "xyz789",
   "exchange_rates": [ExchangeRate]
 }
 ```
@@ -4550,7 +4548,7 @@ Attributes of the product currently being viewed on PDP
 #### Example
 
 ```json
-{"sku": "abc123", "price": 123.45}
+{"sku": "xyz789", "price": 987.65}
 ```
 
 <HorizontalLine />
@@ -4571,7 +4569,7 @@ Specifies the custom attribute code and value.
 ```json
 {
   "attribute_code": "abc123",
-  "value": "abc123"
+  "value": "xyz789"
 }
 ```
 
@@ -4592,8 +4590,8 @@ Defines a custom attribute.
 
 ```json
 {
-  "attribute_code": "xyz789",
-  "value": "xyz789"
+  "attribute_code": "abc123",
+  "value": "abc123"
 }
 ```
 
@@ -4630,14 +4628,14 @@ An interface containing fields that define the EAV attribute.
 
 ```json
 {
-  "code": "4",
+  "code": 4,
   "default_value": "abc123",
   "entity_type": "CATALOG_PRODUCT",
   "frontend_class": "xyz789",
   "frontend_input": "BOOLEAN",
   "is_required": true,
-  "is_unique": false,
-  "label": "abc123",
+  "is_unique": true,
+  "label": "xyz789",
   "options": [CustomAttributeOptionInterface]
 }
 ```
@@ -4666,7 +4664,7 @@ An interface containing fields that define the EAV attribute.
 {
   "is_default": false,
   "label": "abc123",
-  "value": "xyz789"
+  "value": "abc123"
 }
 ```
 
@@ -4802,18 +4800,18 @@ Defines the customer name, addresses, and other details.
   "confirmation_status": "ACCOUNT_CONFIRMED",
   "created_at": "abc123",
   "custom_attributes": [AttributeValueInterface],
-  "date_of_birth": "abc123",
-  "default_billing": "xyz789",
-  "default_shipping": "xyz789",
-  "email": "abc123",
+  "date_of_birth": "xyz789",
+  "default_billing": "abc123",
+  "default_shipping": "abc123",
+  "email": "xyz789",
   "firstname": "abc123",
-  "gender": 987,
+  "gender": 123,
   "gift_registries": [GiftRegistry],
   "gift_registry": GiftRegistry,
   "group": CustomerGroupStorefront,
   "id": 4,
-  "is_subscribed": true,
-  "job_title": "abc123",
+  "is_subscribed": false,
+  "job_title": "xyz789",
   "lastname": "xyz789",
   "middlename": "abc123",
   "orders": CustomerOrders,
@@ -4824,7 +4822,7 @@ Defines the customer name, addresses, and other details.
   "purchase_order_approval_rules": PurchaseOrderApprovalRules,
   "purchase_orders": PurchaseOrders,
   "purchase_orders_enabled": false,
-  "quote_enabled": true,
+  "quote_enabled": false,
   "requisition_lists": RequisitionLists,
   "return": Return,
   "returns": Returns,
@@ -4833,8 +4831,8 @@ Defines the customer name, addresses, and other details.
   "segments": [CustomerSegmentStorefront],
   "status": "ACTIVE",
   "store_credit": CustomerStoreCredit,
-  "structure_id": 4,
-  "suffix": "xyz789",
+  "structure_id": "4",
+  "suffix": "abc123",
   "taxvat": "abc123",
   "team": CompanyTeam,
   "telephone": "xyz789",
@@ -4879,26 +4877,26 @@ Contains detailed information about a customer's billing or shipping address.
 
 ```json
 {
-  "city": "xyz789",
+  "city": "abc123",
   "company": "xyz789",
   "country_code": "AF",
   "custom_attributesV2": [AttributeValueInterface],
-  "default_billing": false,
+  "default_billing": true,
   "default_shipping": true,
   "extension_attributes": [CustomerAddressAttribute],
   "fax": "abc123",
   "firstname": "xyz789",
   "id": 123,
-  "lastname": "xyz789",
+  "lastname": "abc123",
   "middlename": "abc123",
   "postcode": "xyz789",
   "prefix": "xyz789",
   "region": CustomerAddressRegion,
-  "region_id": 987,
-  "street": ["xyz789"],
-  "suffix": "abc123",
+  "region_id": 123,
+  "street": ["abc123"],
+  "suffix": "xyz789",
   "telephone": "xyz789",
-  "uid": "4",
+  "uid": 4,
   "vat_id": "xyz789"
 }
 ```
@@ -4921,7 +4919,7 @@ Specifies the attribute code and value of a customer address attribute.
 ```json
 {
   "attribute_code": "xyz789",
-  "value": "xyz789"
+  "value": "abc123"
 }
 ```
 
@@ -4964,16 +4962,16 @@ Contains details about a billing or shipping address.
   "default_billing": false,
   "default_shipping": true,
   "fax": "xyz789",
-  "firstname": "xyz789",
-  "lastname": "xyz789",
+  "firstname": "abc123",
+  "lastname": "abc123",
   "middlename": "abc123",
   "postcode": "xyz789",
-  "prefix": "xyz789",
+  "prefix": "abc123",
   "region": CustomerAddressRegionInput,
   "street": ["xyz789"],
-  "suffix": "abc123",
+  "suffix": "xyz789",
   "telephone": "abc123",
-  "vat_id": "xyz789"
+  "vat_id": "abc123"
 }
 ```
 
@@ -5021,7 +5019,7 @@ Defines the customer's state or province.
 {
   "region": "xyz789",
   "region_code": "abc123",
-  "region_id": 123
+  "region_id": 987
 }
 ```
 
@@ -5075,18 +5073,18 @@ Customer attribute metadata.
 
 ```json
 {
-  "code": 4,
+  "code": "4",
   "default_value": "xyz789",
   "entity_type": "CATALOG_PRODUCT",
-  "frontend_class": "abc123",
+  "frontend_class": "xyz789",
   "frontend_input": "BOOLEAN",
   "input_filter": "NONE",
-  "is_required": false,
-  "is_unique": true,
+  "is_required": true,
+  "is_unique": false,
   "label": "xyz789",
-  "multiline_count": 123,
+  "multiline_count": 987,
   "options": [CustomAttributeOptionInterface],
-  "sort_order": 987,
+  "sort_order": 123,
   "validate_rules": [ValidationRule]
 }
 ```
@@ -5119,19 +5117,19 @@ An input object for creating a customer.
 
 ```json
 {
-  "allow_remote_shopping_assistance": true,
+  "allow_remote_shopping_assistance": false,
   "custom_attributes": [AttributeValueInput],
-  "date_of_birth": "xyz789",
-  "email": "abc123",
+  "date_of_birth": "abc123",
+  "email": "xyz789",
   "firstname": "xyz789",
   "gender": 123,
   "is_subscribed": false,
-  "lastname": "abc123",
-  "middlename": "abc123",
+  "lastname": "xyz789",
+  "middlename": "xyz789",
   "password": "abc123",
   "prefix": "xyz789",
   "suffix": "abc123",
-  "taxvat": "abc123"
+  "taxvat": "xyz789"
 }
 ```
 
@@ -5155,9 +5153,9 @@ Contains details about a single downloadable product.
 
 ```json
 {
-  "date": "xyz789",
+  "date": "abc123",
   "download_url": "abc123",
-  "order_increment_id": "abc123",
+  "order_increment_id": "xyz789",
   "remaining_downloads": "xyz789",
   "status": "xyz789"
 }
@@ -5196,7 +5194,7 @@ Data of customer group.
 #### Example
 
 ```json
-{"uid": "4"}
+{"uid": 4}
 ```
 
 <HorizontalLine />
@@ -5251,12 +5249,12 @@ Contains details about each of the customer's orders.
   "applied_gift_cards": [ApplyGiftCardToOrder],
   "available_actions": ["REORDER"],
   "billing_address": OrderAddress,
-  "carrier": "abc123",
+  "carrier": "xyz789",
   "comments": [SalesCommentItem],
   "credit_memos": [CreditMemo],
   "custom_attributes": [CustomAttribute],
   "customer_info": OrderCustomerInfo,
-  "email": "abc123",
+  "email": "xyz789",
   "gift_message": GiftMessage,
   "gift_receipt_included": true,
   "gift_wrapping": GiftWrapping,
@@ -5266,8 +5264,8 @@ Contains details about each of the customer's orders.
   "items": [OrderItemInterface],
   "items_eligible_for_return": [OrderItemInterface],
   "negotiable_quote": NegotiableQuote,
-  "number": "abc123",
-  "order_date": "abc123",
+  "number": "xyz789",
+  "order_date": "xyz789",
   "order_status_change_date": "abc123",
   "payment_methods": [OrderPaymentMethod],
   "printed_card_included": false,
@@ -5422,7 +5420,7 @@ Customer segment details
 #### Example
 
 ```json
-{"uid": 4}
+{"uid": "4"}
 ```
 
 <HorizontalLine />
@@ -5445,7 +5443,7 @@ Contains store credit information with balance and history.
 {
   "balance_history": CustomerStoreCreditHistory,
   "current_balance": Money,
-  "enabled": false
+  "enabled": true
 }
 ```
 
@@ -5469,7 +5467,7 @@ Lists changes to the amount of store credit available to the customer.
 {
   "items": [CustomerStoreCreditHistoryItem],
   "page_info": SearchResultPageInfo,
-  "total_count": 987
+  "total_count": 123
 }
 ```
 
@@ -5495,7 +5493,7 @@ Contains store credit history information.
   "action": "xyz789",
   "actual_balance": Money,
   "balance_change": Money,
-  "date_time_changed": "xyz789"
+  "date_time_changed": "abc123"
 }
 ```
 
@@ -5543,13 +5541,13 @@ An input object for updating a customer.
 
 ```json
 {
-  "allow_remote_shopping_assistance": true,
+  "allow_remote_shopping_assistance": false,
   "custom_attributes": [AttributeValueInput],
-  "date_of_birth": "xyz789",
-  "firstname": "abc123",
-  "gender": 123,
+  "date_of_birth": "abc123",
+  "firstname": "xyz789",
+  "gender": 987,
   "is_subscribed": true,
-  "lastname": "xyz789",
+  "lastname": "abc123",
   "middlename": "xyz789",
   "prefix": "abc123",
   "suffix": "abc123",
@@ -5578,11 +5576,11 @@ Contains information about a text area that is defined as part of a customizable
 
 ```json
 {
-  "product_sku": "xyz789",
-  "required": false,
+  "product_sku": "abc123",
+  "required": true,
   "sort_order": 987,
-  "title": "abc123",
-  "uid": "4",
+  "title": "xyz789",
+  "uid": 4,
   "value": CustomizableAreaValue
 }
 ```
@@ -5607,11 +5605,11 @@ Defines the price and sku of a product whose page contains a customized text are
 
 ```json
 {
-  "max_characters": 123,
+  "max_characters": 987,
   "price": 987.65,
   "price_type": "FIXED",
-  "sku": "xyz789",
-  "uid": 4
+  "sku": "abc123",
+  "uid": "4"
 }
 ```
 
@@ -5636,9 +5634,9 @@ Contains information about a set of checkbox values that are defined as part of 
 ```json
 {
   "required": true,
-  "sort_order": 987,
+  "sort_order": 123,
   "title": "xyz789",
-  "uid": "4",
+  "uid": 4,
   "value": [CustomizableCheckboxValue]
 }
 ```
@@ -5665,10 +5663,10 @@ Defines the price and sku of a product whose page contains a customized set of c
 
 ```json
 {
-  "option_type_id": 123,
+  "option_type_id": 987,
   "price": 123.45,
   "price_type": "FIXED",
-  "sku": "abc123",
+  "sku": "xyz789",
   "sort_order": 987,
   "title": "abc123",
   "uid": 4
@@ -5696,11 +5694,11 @@ Contains information about a date picker that is defined as part of a customizab
 
 ```json
 {
-  "product_sku": "xyz789",
+  "product_sku": "abc123",
   "required": false,
-  "sort_order": 123,
-  "title": "abc123",
-  "uid": "4",
+  "sort_order": 987,
+  "title": "xyz789",
+  "uid": 4,
   "value": CustomizableDateValue
 }
 ```
@@ -5745,11 +5743,11 @@ Defines the price and sku of a product whose page contains a customized date pic
 
 ```json
 {
-  "price": 123.45,
+  "price": 987.65,
   "price_type": "FIXED",
   "sku": "xyz789",
   "type": "DATE",
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -5803,12 +5801,12 @@ Defines the price and sku of a product whose page contains a customized drop dow
 
 ```json
 {
-  "option_type_id": 123,
-  "price": 123.45,
+  "option_type_id": 987,
+  "price": 987.65,
   "price_type": "FIXED",
-  "sku": "xyz789",
+  "sku": "abc123",
   "sort_order": 123,
-  "title": "xyz789",
+  "title": "abc123",
   "uid": "4"
 }
 ```
@@ -5834,11 +5832,11 @@ Contains information about a text field that is defined as part of a customizabl
 
 ```json
 {
-  "product_sku": "abc123",
-  "required": false,
-  "sort_order": 123,
+  "product_sku": "xyz789",
+  "required": true,
+  "sort_order": 987,
   "title": "abc123",
-  "uid": 4,
+  "uid": "4",
   "value": CustomizableFieldValue
 }
 ```
@@ -5863,11 +5861,11 @@ Defines the price and sku of a product whose page contains a customized text fie
 
 ```json
 {
-  "max_characters": 987,
+  "max_characters": 123,
   "price": 987.65,
   "price_type": "FIXED",
-  "sku": "xyz789",
-  "uid": 4
+  "sku": "abc123",
+  "uid": "4"
 }
 ```
 
@@ -5892,10 +5890,10 @@ Contains information about a file picker that is defined as part of a customizab
 
 ```json
 {
-  "product_sku": "xyz789",
-  "required": false,
-  "sort_order": 987,
-  "title": "xyz789",
+  "product_sku": "abc123",
+  "required": true,
+  "sort_order": 123,
+  "title": "abc123",
   "uid": 4,
   "value": CustomizableFileValue
 }
@@ -5923,13 +5921,13 @@ Defines the price and sku of a product whose page contains a customized file pic
 
 ```json
 {
-  "file_extension": "xyz789",
-  "image_size_x": 123,
+  "file_extension": "abc123",
+  "image_size_x": 987,
   "image_size_y": 123,
   "price": 123.45,
   "price_type": "FIXED",
-  "sku": "xyz789",
-  "uid": "4"
+  "sku": "abc123",
+  "uid": 4
 }
 ```
 
@@ -5954,8 +5952,8 @@ Contains information about a multiselect that is defined as part of a customizab
 ```json
 {
   "required": false,
-  "sort_order": 123,
-  "title": "abc123",
+  "sort_order": 987,
+  "title": "xyz789",
   "uid": "4",
   "value": [CustomizableMultipleValue]
 }
@@ -5983,12 +5981,12 @@ Defines the price and sku of a product whose page contains a customized multisel
 
 ```json
 {
-  "option_type_id": 987,
-  "price": 123.45,
+  "option_type_id": 123,
+  "price": 987.65,
   "price_type": "FIXED",
-  "sku": "xyz789",
+  "sku": "abc123",
   "sort_order": 987,
-  "title": "abc123",
+  "title": "xyz789",
   "uid": 4
 }
 ```
@@ -6045,8 +6043,8 @@ Contains basic information about a customizable option. It can be implemented by
 ```json
 {
   "required": true,
-  "sort_order": 123,
-  "title": "abc123",
+  "sort_order": 987,
+  "title": "xyz789",
   "uid": 4
 }
 ```
@@ -6102,7 +6100,7 @@ Contains information about a set of radio buttons that are defined as part of a 
 {
   "required": false,
   "sort_order": 987,
-  "title": "xyz789",
+  "title": "abc123",
   "uid": 4,
   "value": [CustomizableRadioValue]
 }
@@ -6130,13 +6128,13 @@ Defines the price and sku of a product whose page contains a customized set of r
 
 ```json
 {
-  "option_type_id": 987,
+  "option_type_id": 123,
   "price": 987.65,
   "price_type": "FIXED",
-  "sku": "abc123",
+  "sku": "xyz789",
   "sort_order": 987,
-  "title": "xyz789",
-  "uid": 4
+  "title": "abc123",
+  "uid": "4"
 }
 ```
 
@@ -6167,7 +6165,7 @@ Contains the response to the request to delete the company role.
 #### Example
 
 ```json
-{"success": true}
+{"success": false}
 ```
 
 <HorizontalLine />
@@ -6185,7 +6183,7 @@ Contains the status of the request to delete a company team.
 #### Example
 
 ```json
-{"success": true}
+{"success": false}
 ```
 
 <HorizontalLine />
@@ -6203,7 +6201,7 @@ Contains the response to the request to delete the company user.
 #### Example
 
 ```json
-{"success": true}
+{"success": false}
 ```
 
 <HorizontalLine />
@@ -6260,7 +6258,7 @@ Contains details about a failed delete operation on a negotiable quote.
 ```json
 {
   "errors": [NegotiableQuoteInvalidStateError],
-  "quote_uid": 4
+  "quote_uid": "4"
 }
 ```
 
@@ -6296,7 +6294,7 @@ Specifies the quote template id of the quote template to delete
 #### Example
 
 ```json
-{"template_id": "4"}
+{"template_id": 4}
 ```
 
 <HorizontalLine />
@@ -6312,7 +6310,7 @@ Specifies the quote template id of the quote template to delete
 #### Example
 
 ```json
-{"quote_uids": [4]}
+{"quote_uids": ["4"]}
 ```
 
 <HorizontalLine />
@@ -6414,7 +6412,7 @@ Specifies the IDs of the approval rules to delete.
 #### Example
 
 ```json
-{"approval_rule_uids": [4]}
+{"approval_rule_uids": ["4"]}
 ```
 
 <HorizontalLine />
@@ -6469,7 +6467,7 @@ Indicates whether the request to delete the requisition list was successful.
 #### Example
 
 ```json
-{"requisition_lists": RequisitionLists, "status": true}
+{"requisition_lists": RequisitionLists, "status": false}
 ```
 
 <HorizontalLine />
@@ -6488,7 +6486,7 @@ Contains the status of the request to delete a wish list and an array of the cus
 #### Example
 
 ```json
-{"status": true, "wishlists": [Wishlist]}
+{"status": false, "wishlists": [Wishlist]}
 ```
 
 <HorizontalLine />
@@ -6519,7 +6517,7 @@ Specifies the discount type and value for quote line item.
   "is_discounting_locked": false,
   "label": "xyz789",
   "type": "xyz789",
-  "value": 987.65
+  "value": 123.45
 }
 ```
 
@@ -6556,24 +6554,24 @@ An implementation for downloadable product cart items.
 
 ```json
 {
-  "backorder_message": "xyz789",
+  "backorder_message": "abc123",
   "custom_attributes": [CustomAttribute],
   "customizable_options": [SelectedCustomizableOption],
   "discount": [Discount],
   "errors": [CartItemError],
   "is_available": false,
-  "is_salable": true,
+  "is_salable": false,
   "links": [DownloadableProductLinks],
   "max_qty": 123.45,
-  "min_qty": 987.65,
-  "not_available_message": "xyz789",
+  "min_qty": 123.45,
+  "not_available_message": "abc123",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
-  "quantity": 123.45,
+  "quantity": 987.65,
   "samples": [DownloadableProductSamples],
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -6604,9 +6602,9 @@ Defines downloadable product options for `CreditMemoItemInterface`.
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
   "downloadable_links": [DownloadableItemsLinks],
-  "id": "4",
+  "id": 4,
   "order_item": OrderItemInterface,
-  "product_name": "xyz789",
+  "product_name": "abc123",
   "product_sale_price": Money,
   "product_sku": "xyz789",
   "quantity_refunded": 987.65
@@ -6642,9 +6640,9 @@ Defines downloadable product options for `InvoiceItemInterface`.
   "downloadable_links": [DownloadableItemsLinks],
   "id": 4,
   "order_item": OrderItemInterface,
-  "product_name": "xyz789",
+  "product_name": "abc123",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
+  "product_sku": "abc123",
   "quantity_invoiced": 987.65
 }
 ```
@@ -6667,9 +6665,9 @@ Defines characteristics of the links for downloadable product.
 
 ```json
 {
-  "sort_order": 987,
+  "sort_order": 123,
   "title": "abc123",
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -6719,23 +6717,23 @@ Defines downloadable product options for `OrderItemInterface`.
   "entered_options": [OrderItemOption],
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
-  "id": 4,
+  "id": "4",
   "prices": OrderItemPrices,
   "product": ProductInterface,
-  "product_name": "xyz789",
+  "product_name": "abc123",
   "product_sale_price": Money,
   "product_sku": "xyz789",
-  "product_type": "xyz789",
-  "product_url_key": "xyz789",
+  "product_type": "abc123",
+  "product_url_key": "abc123",
   "quantity_canceled": 123.45,
-  "quantity_invoiced": 987.65,
+  "quantity_invoiced": 123.45,
   "quantity_ordered": 987.65,
-  "quantity_refunded": 123.45,
-  "quantity_return_requested": 987.65,
+  "quantity_refunded": 987.65,
+  "quantity_return_requested": 123.45,
   "quantity_returned": 123.45,
   "quantity_shipped": 123.45,
   "selected_options": [OrderItemOption],
-  "status": "abc123"
+  "status": "xyz789"
 }
 ```
 
@@ -6800,7 +6798,7 @@ Defines a product that the shopper downloads.
 {
   "canonical_url": "xyz789",
   "categories": [CategoryInterface],
-  "country_of_manufacture": "abc123",
+  "country_of_manufacture": "xyz789",
   "crosssell_products": [ProductInterface],
   "custom_attributesV2": ProductCustomAttributes,
   "description": ComplexTextValue,
@@ -6810,40 +6808,40 @@ Defines a product that the shopper downloads.
   "downloadable_product_samples": [
     DownloadableProductSamples
   ],
-  "gift_message_available": false,
-  "gift_wrapping_available": false,
+  "gift_message_available": true,
+  "gift_wrapping_available": true,
   "gift_wrapping_price": Money,
   "image": ProductImage,
-  "is_returnable": "xyz789",
+  "is_returnable": "abc123",
   "links_purchased_separately": 123,
   "links_title": "xyz789",
   "manufacturer": 987,
-  "max_sale_qty": 123.45,
+  "max_sale_qty": 987.65,
   "media_gallery": [MediaGalleryInterface],
   "meta_description": "xyz789",
   "meta_keyword": "abc123",
-  "meta_title": "xyz789",
-  "min_sale_qty": 987.65,
+  "meta_title": "abc123",
+  "min_sale_qty": 123.45,
   "name": "abc123",
-  "new_from_date": "abc123",
-  "new_to_date": "xyz789",
-  "only_x_left_in_stock": 987.65,
+  "new_from_date": "xyz789",
+  "new_to_date": "abc123",
+  "only_x_left_in_stock": 123.45,
   "options": [CustomizableOptionInterface],
-  "options_container": "abc123",
+  "options_container": "xyz789",
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
   "product_links": [ProductLinksInterface],
-  "quantity": 123.45,
+  "quantity": 987.65,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
-  "sku": "abc123",
+  "sku": "xyz789",
   "small_image": ProductImage,
   "special_price": 987.65,
   "special_to_date": "abc123",
   "stock_status": "IN_STOCK",
   "swatch_image": "abc123",
   "thumbnail": ProductImage,
-  "uid": 4,
+  "uid": "4",
   "upsell_products": [ProductInterface],
   "url_key": "xyz789"
 }
@@ -6896,10 +6894,10 @@ Defines characteristics of a downloadable product.
 ```json
 {
   "price": 123.45,
-  "sample_url": "xyz789",
-  "sort_order": 987,
+  "sample_url": "abc123",
+  "sort_order": 123,
   "title": "abc123",
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -6940,7 +6938,7 @@ Defines characteristics of a downloadable product.
 ```json
 {
   "sample_url": "xyz789",
-  "sort_order": 123,
+  "sort_order": 987,
   "title": "xyz789"
 }
 ```
@@ -6970,10 +6968,10 @@ Contains details about downloadable products added to a requisition list.
   "customizable_options": [SelectedCustomizableOption],
   "links": [DownloadableProductLinks],
   "product": ProductInterface,
-  "quantity": 123.45,
+  "quantity": 987.65,
   "samples": [DownloadableProductSamples],
   "sku": "abc123",
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -7000,10 +6998,10 @@ A downloadable product wish list item.
 
 ```json
 {
-  "added_at": "abc123",
+  "added_at": "xyz789",
   "customizable_options": [SelectedCustomizableOption],
-  "description": "xyz789",
-  "id": 4,
+  "description": "abc123",
+  "id": "4",
   "links_v2": [DownloadableProductLinks],
   "product": ProductInterface,
   "quantity": 123.45,
@@ -7029,7 +7027,7 @@ Identifies a quote to be duplicated
 ```json
 {
   "duplicated_quote_uid": "4",
-  "quote_uid": 4
+  "quote_uid": "4"
 }
 ```
 
@@ -7069,7 +7067,7 @@ Contains details about a custom text attribute that the buyer entered.
 ```json
 {
   "attribute_code": "xyz789",
-  "value": "xyz789"
+  "value": "abc123"
 }
 ```
 
@@ -7089,7 +7087,7 @@ Defines a customer-entered option.
 #### Example
 
 ```json
-{"uid": 4, "value": "abc123"}
+{"uid": 4, "value": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -7142,7 +7140,7 @@ An error encountered while adding an item to the the cart.
 #### Example
 
 ```json
-{"message": "xyz789"}
+{"message": "abc123"}
 ```
 
 <HorizontalLine />
@@ -7245,7 +7243,7 @@ Contains customer token for external customer.
 ```json
 {
   "customer": Customer,
-  "token": "xyz789"
+  "token": "abc123"
 }
 ```
 
@@ -7265,7 +7263,7 @@ Lists the exchange rate.
 #### Example
 
 ```json
-{"currency_to": "xyz789", "rate": 123.45}
+{"currency_to": "abc123", "rate": 123.45}
 ```
 
 <HorizontalLine />

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-f-i.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-f-i.md
@@ -19,14 +19,14 @@
 
 ```json
 {
-  "code": "xyz789",
-  "is_visible": true,
+  "code": "abc123",
+  "is_visible": false,
   "payment_intent": "xyz789",
-  "payment_source": "xyz789",
+  "payment_source": "abc123",
   "sdk_params": [SDKParams],
-  "sort_order": "abc123",
+  "sort_order": "xyz789",
   "three_ds_mode": "OFF",
-  "title": "abc123"
+  "title": "xyz789"
 }
 ```
 
@@ -93,7 +93,7 @@ Defines a filter that matches the input exactly.
 ```json
 {
   "eq": "abc123",
-  "in": ["abc123"]
+  "in": ["xyz789"]
 }
 ```
 
@@ -130,7 +130,7 @@ Defines a filter that performs a fuzzy search.
 #### Example
 
 ```json
-{"match": "xyz789", "match_type": "FULL"}
+{"match": "abc123", "match_type": "FULL"}
 ```
 
 <HorizontalLine />
@@ -150,7 +150,7 @@ Defines a filter that matches a range of values, such as prices or dates.
 
 ```json
 {
-  "from": "abc123",
+  "from": "xyz789",
   "to": "xyz789"
 }
 ```
@@ -214,8 +214,8 @@ Defines a filter for an input string.
 ```json
 {
   "eq": "xyz789",
-  "in": ["xyz789"],
-  "match": "abc123"
+  "in": ["abc123"],
+  "match": "xyz789"
 }
 ```
 
@@ -249,19 +249,19 @@ Defines the comparison operators that can be used in a filter.
 ```json
 {
   "eq": "xyz789",
-  "from": "abc123",
+  "from": "xyz789",
   "gt": "abc123",
   "gteq": "xyz789",
-  "in": ["abc123"],
-  "like": "abc123",
+  "in": ["xyz789"],
+  "like": "xyz789",
   "lt": "xyz789",
-  "lteq": "abc123",
-  "moreq": "xyz789",
-  "neq": "abc123",
-  "nin": ["abc123"],
+  "lteq": "xyz789",
+  "moreq": "abc123",
+  "neq": "xyz789",
+  "nin": ["xyz789"],
   "notnull": "abc123",
-  "null": "xyz789",
-  "to": "xyz789"
+  "null": "abc123",
+  "to": "abc123"
 }
 ```
 
@@ -284,9 +284,9 @@ Contains product attributes that can be used for filtering in a `productSearch` 
 
 ```json
 {
-  "attribute": "abc123",
+  "attribute": "xyz789",
   "frontendInput": "xyz789",
-  "label": "xyz789",
+  "label": "abc123",
   "numeric": true
 }
 ```
@@ -309,7 +309,7 @@ A single FPT that can be applied to a product price.
 ```json
 {
   "amount": Money,
-  "label": "xyz789"
+  "label": "abc123"
 }
 ```
 
@@ -344,7 +344,7 @@ The `Float` scalar type represents signed double-precision fractional values as 
 #### Example
 
 ```json
-987.65
+123.45
 ```
 
 <HorizontalLine />
@@ -380,7 +380,7 @@ Contains the generated customer token.
 #### Example
 
 ```json
-{"customer_token": "xyz789"}
+{"customer_token": "abc123"}
 ```
 
 <HorizontalLine />
@@ -457,7 +457,7 @@ Contains details about the gift card account.
 {
   "balance": Money,
   "code": "xyz789",
-  "expiration_date": "abc123"
+  "expiration_date": "xyz789"
 }
 ```
 
@@ -499,10 +499,10 @@ Contains the value of a gift card, the website that generated the card, and rela
 
 ```json
 {
-  "attribute_id": 987,
-  "uid": "4",
-  "value": 123.45,
-  "website_id": 123,
+  "attribute_id": 123,
+  "uid": 4,
+  "value": 987.65,
+  "website_id": 987,
   "website_value": 987.65
 }
 ```
@@ -549,24 +549,24 @@ Contains details about a gift card that has been added to a cart.
 {
   "amount": Money,
   "available_gift_wrapping": [GiftWrapping],
-  "backorder_message": "abc123",
+  "backorder_message": "xyz789",
   "custom_attributes": [CustomAttribute],
   "customizable_options": [SelectedCustomizableOption],
   "discount": [Discount],
   "errors": [CartItemError],
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
-  "is_available": false,
-  "is_salable": true,
-  "max_qty": 123.45,
+  "is_available": true,
+  "is_salable": false,
+  "max_qty": 987.65,
   "message": "xyz789",
-  "min_qty": 123.45,
-  "not_available_message": "xyz789",
+  "min_qty": 987.65,
+  "not_available_message": "abc123",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
-  "quantity": 123.45,
+  "quantity": 987.65,
   "recipient_email": "abc123",
   "recipient_name": "abc123",
   "sender_email": "abc123",
@@ -602,10 +602,10 @@ Contains details about a gift card that has been added to a cart.
   "gift_card": GiftCardItem,
   "id": "4",
   "order_item": OrderItemInterface,
-  "product_name": "abc123",
+  "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "abc123",
-  "quantity_refunded": 987.65
+  "product_sku": "xyz789",
+  "quantity_refunded": 123.45
 }
 ```
 
@@ -636,10 +636,10 @@ Contains details about a gift card that has been added to a cart.
   "gift_card": GiftCardItem,
   "id": "4",
   "order_item": OrderItemInterface,
-  "product_name": "xyz789",
+  "product_name": "abc123",
   "product_sale_price": Money,
   "product_sku": "abc123",
-  "quantity_invoiced": 987.65
+  "quantity_invoiced": 123.45
 }
 ```
 
@@ -664,10 +664,10 @@ Contains details about a gift card.
 ```json
 {
   "message": "abc123",
-  "recipient_email": "xyz789",
-  "recipient_name": "xyz789",
-  "sender_email": "abc123",
-  "sender_name": "xyz789"
+  "recipient_email": "abc123",
+  "recipient_name": "abc123",
+  "sender_email": "xyz789",
+  "sender_name": "abc123"
 }
 ```
 
@@ -697,7 +697,7 @@ Contains details about the sender, recipient, and amount of a gift card.
   "custom_giftcard_amount": Money,
   "message": "xyz789",
   "recipient_email": "xyz789",
-  "recipient_name": "abc123",
+  "recipient_name": "xyz789",
   "sender_email": "xyz789",
   "sender_name": "abc123"
 }
@@ -742,28 +742,28 @@ Contains details about the sender, recipient, and amount of a gift card.
 {
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
-  "eligible_for_return": true,
+  "eligible_for_return": false,
   "entered_options": [OrderItemOption],
   "gift_card": GiftCardItem,
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
-  "id": 4,
+  "id": "4",
   "prices": OrderItemPrices,
   "product": ProductInterface,
   "product_name": "abc123",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
-  "product_type": "abc123",
-  "product_url_key": "abc123",
+  "product_sku": "abc123",
+  "product_type": "xyz789",
+  "product_url_key": "xyz789",
   "quantity_canceled": 987.65,
   "quantity_invoiced": 987.65,
   "quantity_ordered": 987.65,
-  "quantity_refunded": 123.45,
+  "quantity_refunded": 987.65,
   "quantity_return_requested": 987.65,
   "quantity_returned": 987.65,
   "quantity_shipped": 987.65,
   "selected_options": [OrderItemOption],
-  "status": "xyz789"
+  "status": "abc123"
 }
 ```
 
@@ -834,56 +834,56 @@ Defines properties of a gift card.
 ```json
 {
   "allow_message": true,
-  "allow_open_amount": false,
+  "allow_open_amount": true,
   "canonical_url": "abc123",
   "categories": [CategoryInterface],
-  "country_of_manufacture": "xyz789",
+  "country_of_manufacture": "abc123",
   "crosssell_products": [ProductInterface],
   "custom_attributesV2": ProductCustomAttributes,
   "description": ComplexTextValue,
   "gift_card_options": [CustomizableOptionInterface],
-  "gift_message_available": false,
+  "gift_message_available": true,
   "gift_wrapping_available": false,
   "gift_wrapping_price": Money,
   "giftcard_amounts": [GiftCardAmounts],
   "giftcard_type": "VIRTUAL",
   "image": ProductImage,
-  "is_redeemable": true,
+  "is_redeemable": false,
   "is_returnable": "xyz789",
-  "lifetime": 123,
+  "lifetime": 987,
   "manufacturer": 123,
   "max_sale_qty": 123.45,
   "media_gallery": [MediaGalleryInterface],
-  "message_max_length": 987,
-  "meta_description": "xyz789",
+  "message_max_length": 123,
+  "meta_description": "abc123",
   "meta_keyword": "abc123",
-  "meta_title": "xyz789",
-  "min_sale_qty": 123.45,
-  "name": "xyz789",
+  "meta_title": "abc123",
+  "min_sale_qty": 987.65,
+  "name": "abc123",
   "new_from_date": "abc123",
-  "new_to_date": "abc123",
+  "new_to_date": "xyz789",
   "only_x_left_in_stock": 987.65,
   "open_amount_max": 987.65,
-  "open_amount_min": 123.45,
+  "open_amount_min": 987.65,
   "options": [CustomizableOptionInterface],
   "options_container": "xyz789",
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
   "product_links": [ProductLinksInterface],
-  "quantity": 123.45,
+  "quantity": 987.65,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
-  "sku": "xyz789",
+  "sku": "abc123",
   "small_image": ProductImage,
-  "special_price": 987.65,
-  "special_to_date": "abc123",
+  "special_price": 123.45,
+  "special_to_date": "xyz789",
   "stock_status": "IN_STOCK",
-  "swatch_image": "xyz789",
+  "swatch_image": "abc123",
   "thumbnail": ProductImage,
-  "uid": "4",
+  "uid": 4,
   "upsell_products": [ProductInterface],
-  "url_key": "abc123",
-  "weight": 123.45
+  "url_key": "xyz789",
+  "weight": 987.65
 }
 ```
 
@@ -913,7 +913,7 @@ Contains details about gift cards added to a requisition list.
   "product": ProductInterface,
   "quantity": 123.45,
   "sku": "xyz789",
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -938,12 +938,12 @@ Contains details about gift cards added to a requisition list.
 ```json
 {
   "gift_card": GiftCardItem,
-  "id": 4,
+  "id": "4",
   "order_item": OrderItemInterface,
-  "product_name": "xyz789",
+  "product_name": "abc123",
   "product_sale_price": Money,
   "product_sku": "xyz789",
-  "quantity_shipped": 123.45
+  "quantity_shipped": 987.65
 }
 ```
 
@@ -989,13 +989,13 @@ A single gift card added to a wish list.
 
 ```json
 {
-  "added_at": "abc123",
+  "added_at": "xyz789",
   "customizable_options": [SelectedCustomizableOption],
-  "description": "abc123",
+  "description": "xyz789",
   "gift_card_options": GiftCardOptions,
   "id": "4",
   "product": ProductInterface,
-  "quantity": 123.45
+  "quantity": 987.65
 }
 ```
 
@@ -1019,7 +1019,7 @@ Contains the text of a gift message, its sender, and recipient
 {
   "from": "xyz789",
   "message": "xyz789",
-  "to": "abc123"
+  "to": "xyz789"
 }
 ```
 
@@ -1042,8 +1042,8 @@ Defines a gift message.
 ```json
 {
   "from": "xyz789",
-  "message": "abc123",
-  "to": "xyz789"
+  "message": "xyz789",
+  "to": "abc123"
 }
 ```
 
@@ -1104,11 +1104,11 @@ Contains details about a gift registry.
 
 ```json
 {
-  "created_at": "abc123",
+  "created_at": "xyz789",
   "dynamic_attributes": [GiftRegistryDynamicAttribute],
   "event_name": "xyz789",
   "items": [GiftRegistryItemInterface],
-  "message": "xyz789",
+  "message": "abc123",
   "owner_name": "abc123",
   "privacy_settings": "PRIVATE",
   "registrants": [GiftRegistryRegistrant],
@@ -1136,10 +1136,10 @@ Contains details about a gift registry.
 
 ```json
 {
-  "code": 4,
+  "code": "4",
   "group": "EVENT_INFORMATION",
-  "label": "abc123",
-  "value": "abc123"
+  "label": "xyz789",
+  "value": "xyz789"
 }
 ```
 
@@ -1182,10 +1182,7 @@ Defines a dynamic attribute.
 #### Example
 
 ```json
-{
-  "code": "4",
-  "value": "abc123"
-}
+{"code": 4, "value": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -1212,7 +1209,7 @@ Defines a dynamic attribute.
 ```json
 {
   "code": 4,
-  "label": "abc123",
+  "label": "xyz789",
   "value": "xyz789"
 }
 ```
@@ -1236,12 +1233,12 @@ Defines a dynamic attribute.
 
 ```json
 {
-  "attribute_group": "xyz789",
-  "code": 4,
-  "input_type": "xyz789",
+  "attribute_group": "abc123",
+  "code": "4",
+  "input_type": "abc123",
   "is_required": true,
-  "label": "xyz789",
-  "sort_order": 123
+  "label": "abc123",
+  "sort_order": 987
 }
 ```
 
@@ -1270,12 +1267,12 @@ Defines a dynamic attribute.
 
 ```json
 {
-  "attribute_group": "abc123",
-  "code": "4",
-  "input_type": "abc123",
+  "attribute_group": "xyz789",
+  "code": 4,
+  "input_type": "xyz789",
   "is_required": true,
   "label": "xyz789",
-  "sort_order": 987
+  "sort_order": 123
 }
 ```
 
@@ -1299,11 +1296,11 @@ Defines a dynamic attribute.
 ```json
 {
   "created_at": "abc123",
-  "note": "xyz789",
+  "note": "abc123",
   "product": ProductInterface,
   "quantity": 123.45,
-  "quantity_fulfilled": 987.65,
-  "uid": "4"
+  "quantity_fulfilled": 123.45,
+  "uid": 4
 }
 ```
 
@@ -1333,7 +1330,7 @@ Defines a dynamic attribute.
 ```json
 {
   "created_at": "abc123",
-  "note": "abc123",
+  "note": "xyz789",
   "product": ProductInterface,
   "quantity": 123.45,
   "quantity_fulfilled": 123.45,
@@ -1390,10 +1387,10 @@ Contains details about an error that occurred when processing a gift registry it
 ```json
 {
   "code": "OUT_OF_STOCK",
-  "gift_registry_item_uid": "4",
-  "gift_registry_uid": 4,
+  "gift_registry_item_uid": 4,
+  "gift_registry_uid": "4",
   "message": "abc123",
-  "product_uid": 4
+  "product_uid": "4"
 }
 ```
 
@@ -1486,7 +1483,7 @@ Contains details about a registrant.
   "email": "xyz789",
   "firstname": "xyz789",
   "lastname": "xyz789",
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -1506,9 +1503,9 @@ Contains details about a registrant.
 
 ```json
 {
-  "code": "4",
+  "code": 4,
   "label": "abc123",
-  "value": "xyz789"
+  "value": "abc123"
 }
 ```
 
@@ -1536,7 +1533,7 @@ Contains the results of a gift registry search.
   "event_date": "xyz789",
   "event_title": "abc123",
   "gift_registry_uid": 4,
-  "location": "xyz789",
+  "location": "abc123",
   "name": "xyz789",
   "type": "abc123"
 }
@@ -1561,7 +1558,7 @@ Defines a shipping address for a gift registry. Specify either `address_data` or
 ```json
 {
   "address_data": CustomerAddressInput,
-  "address_id": "4",
+  "address_id": 4,
   "customer_address_uid": 4
 }
 ```
@@ -1606,8 +1603,8 @@ Contains details about a gift registry type.
   "dynamic_attributes_metadata": [
     GiftRegistryDynamicAttributeMetadataInterface
   ],
-  "label": "abc123",
-  "uid": 4
+  "label": "xyz789",
+  "uid": "4"
 }
 ```
 
@@ -1630,10 +1627,10 @@ Contains details about the selected or available gift wrapping options.
 
 ```json
 {
-  "design": "abc123",
+  "design": "xyz789",
   "image": GiftWrappingImage,
   "price": Money,
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -1654,7 +1651,7 @@ Points to an image associated with a gift wrapping option.
 
 ```json
 {
-  "label": "xyz789",
+  "label": "abc123",
   "url": "abc123"
 }
 ```
@@ -1677,7 +1674,7 @@ Points to an image associated with a gift wrapping option.
 {
   "color": "abc123",
   "height": 987,
-  "type": "abc123"
+  "type": "xyz789"
 }
 ```
 
@@ -1691,6 +1688,7 @@ Points to an image associated with a gift wrapping option.
 |------------|-------------|
 | `button_styles` - [`GooglePayButtonStyles`](#googlepaybuttonstyles) | The styles for the GooglePay Button configuration |
 | `code` - [`String`](#string) | The payment method code as defined in the payment gateway |
+| `google_pay_mode` - [`GooglePayMode`](#googlepaymode) | Google Pay mode |
 | `is_visible` - [`Boolean`](#boolean) | Indicates whether the payment method is displayed |
 | `payment_intent` - [`String`](#string) | Defines the payment intent (Authorize or Capture |
 | `payment_source` - [`String`](#string) | The payment source for the payment method |
@@ -1705,13 +1703,14 @@ Points to an image associated with a gift wrapping option.
 {
   "button_styles": GooglePayButtonStyles,
   "code": "abc123",
+  "google_pay_mode": "TEST",
   "is_visible": false,
   "payment_intent": "abc123",
-  "payment_source": "abc123",
+  "payment_source": "xyz789",
   "sdk_params": [SDKParams],
   "sort_order": "xyz789",
   "three_ds_mode": "OFF",
-  "title": "abc123"
+  "title": "xyz789"
 }
 ```
 
@@ -1734,9 +1733,28 @@ Google Pay inputs
 ```json
 {
   "payment_source": "xyz789",
-  "payments_order_id": "xyz789",
+  "payments_order_id": "abc123",
   "paypal_order_id": "abc123"
 }
+```
+
+<HorizontalLine />
+
+### GooglePayMode
+
+Google Pay mode.
+
+#### Values
+
+| Enum Value | Description |
+|------------|-------------|
+| `TEST` |  |
+| `PRODUCTION` |  |
+
+#### Example
+
+```json
+""TEST""
 ```
 
 <HorizontalLine />
@@ -1807,17 +1825,17 @@ Defines a grouped product, which consists of simple standalone products that are
   "image": ProductImage,
   "is_returnable": "abc123",
   "items": [GroupedProductItem],
-  "manufacturer": 987,
-  "max_sale_qty": 987.65,
+  "manufacturer": 123,
+  "max_sale_qty": 123.45,
   "media_gallery": [MediaGalleryInterface],
-  "meta_description": "xyz789",
-  "meta_keyword": "abc123",
-  "meta_title": "xyz789",
+  "meta_description": "abc123",
+  "meta_keyword": "xyz789",
+  "meta_title": "abc123",
   "min_sale_qty": 123.45,
   "name": "abc123",
-  "new_from_date": "xyz789",
-  "new_to_date": "xyz789",
-  "only_x_left_in_stock": 987.65,
+  "new_from_date": "abc123",
+  "new_to_date": "abc123",
+  "only_x_left_in_stock": 123.45,
   "options_container": "xyz789",
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
@@ -1825,17 +1843,17 @@ Defines a grouped product, which consists of simple standalone products that are
   "quantity": 987.65,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
-  "sku": "abc123",
+  "sku": "xyz789",
   "small_image": ProductImage,
-  "special_price": 123.45,
-  "special_to_date": "xyz789",
+  "special_price": 987.65,
+  "special_to_date": "abc123",
   "stock_status": "IN_STOCK",
-  "swatch_image": "xyz789",
+  "swatch_image": "abc123",
   "thumbnail": ProductImage,
-  "uid": "4",
+  "uid": 4,
   "upsell_products": [ProductInterface],
-  "url_key": "abc123",
-  "weight": 123.45
+  "url_key": "xyz789",
+  "weight": 987.65
 }
 ```
 
@@ -1857,9 +1875,9 @@ Contains information about an individual grouped product item.
 
 ```json
 {
-  "position": 123,
+  "position": 987,
   "product": ProductInterface,
-  "qty": 123.45
+  "qty": 987.65
 }
 ```
 
@@ -1886,7 +1904,7 @@ A grouped product wish list item.
 {
   "added_at": "xyz789",
   "customizable_options": [SelectedCustomizableOption],
-  "description": "xyz789",
+  "description": "abc123",
   "id": "4",
   "product": ProductInterface,
   "quantity": 987.65
@@ -1910,8 +1928,8 @@ Input to retrieve a guest order based on token.
 
 ```json
 {
-  "reason": "abc123",
-  "token": "abc123"
+  "reason": "xyz789",
+  "token": "xyz789"
 }
 ```
 
@@ -1933,9 +1951,9 @@ Input to retrieve an order based on details.
 
 ```json
 {
-  "email": "abc123",
-  "lastname": "abc123",
-  "number": "abc123"
+  "email": "xyz789",
+  "lastname": "xyz789",
+  "number": "xyz789"
 }
 ```
 
@@ -1957,9 +1975,9 @@ An object that provides highlighted text for matched words
 
 ```json
 {
-  "attribute": "abc123",
+  "attribute": "xyz789",
   "matched_words": ["xyz789"],
-  "value": "abc123"
+  "value": "xyz789"
 }
 ```
 
@@ -1984,10 +2002,10 @@ Item note data that is added to the negotiable quote history object.
 
 ```json
 {
-  "created_at": "xyz789",
+  "created_at": "abc123",
   "creator_name": "xyz789",
   "creator_type": "xyz789",
-  "item_id": 123,
+  "item_id": 987,
   "note": "abc123",
   "product_name": "xyz789"
 }
@@ -2017,11 +2035,11 @@ Item note data that is added to the negotiable quote history object.
 
 ```json
 {
-  "cc_vault_code": "abc123",
-  "code": "xyz789",
+  "cc_vault_code": "xyz789",
+  "code": "abc123",
   "is_vault_enabled": false,
   "is_visible": true,
-  "payment_intent": "abc123",
+  "payment_intent": "xyz789",
   "payment_source": "xyz789",
   "requires_card_details": true,
   "sdk_params": [SDKParams],
@@ -2055,15 +2073,15 @@ Hosted Fields payment inputs
 
 ```json
 {
-  "cardBin": "xyz789",
-  "cardExpiryMonth": "abc123",
+  "cardBin": "abc123",
+  "cardExpiryMonth": "xyz789",
   "cardExpiryYear": "abc123",
   "cardLast4": "xyz789",
-  "holderName": "abc123",
-  "is_active_payment_token_enabler": true,
+  "holderName": "xyz789",
+  "is_active_payment_token_enabler": false,
   "payment_source": "xyz789",
   "payments_order_id": "abc123",
-  "paypal_order_id": "xyz789"
+  "paypal_order_id": "abc123"
 }
 ```
 
@@ -2192,7 +2210,7 @@ Contains an error message when an internal error occurred.
 #### Example
 
 ```json
-{"message": "abc123"}
+{"message": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -2218,9 +2236,9 @@ Contains invoice details.
 {
   "comments": [SalesCommentItem],
   "custom_attributes": [CustomAttribute],
-  "id": 4,
+  "id": "4",
   "items": [InvoiceItemInterface],
-  "number": "xyz789",
+  "number": "abc123",
   "total": InvoiceTotal
 }
 ```
@@ -2243,7 +2261,7 @@ Defines an invoice custom attributes.
 ```json
 {
   "custom_attributes": [CustomAttributeInput],
-  "invoice_id": "abc123"
+  "invoice_id": "xyz789"
 }
 ```
 
@@ -2270,12 +2288,12 @@ Defines an invoice custom attributes.
 {
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
-  "id": 4,
+  "id": "4",
   "order_item": OrderItemInterface,
-  "product_name": "abc123",
+  "product_name": "xyz789",
   "product_sale_price": Money,
   "product_sku": "xyz789",
-  "quantity_invoiced": 123.45
+  "quantity_invoiced": 987.65
 }
 ```
 
@@ -2298,8 +2316,8 @@ Defines an invoice item custom attributes.
 ```json
 {
   "custom_attributes": [CustomAttributeInput],
-  "invoice_id": "xyz789",
-  "invoice_item_id": "xyz789"
+  "invoice_id": "abc123",
+  "invoice_item_id": "abc123"
 }
 ```
 
@@ -2337,11 +2355,11 @@ Contains detailes about invoiced items.
 {
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
-  "id": "4",
+  "id": 4,
   "order_item": OrderItemInterface,
   "product_name": "abc123",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
+  "product_sku": "abc123",
   "quantity_invoiced": 123.45
 }
 ```
@@ -2467,7 +2485,7 @@ Contains the response of a company user email validation query.
 #### Example
 
 ```json
-{"is_email_available": false}
+{"is_email_available": true}
 ```
 
 <HorizontalLine />
@@ -2485,7 +2503,7 @@ Contains the result of the `isEmailAvailable` query.
 #### Example
 
 ```json
-{"is_email_available": true}
+{"is_email_available": false}
 ```
 
 <HorizontalLine />
@@ -2536,7 +2554,7 @@ Contains the result of the `isEmailAvailable` query.
 #### Example
 
 ```json
-{"isSubscribed": true, "message": "abc123"}
+{"isSubscribed": true, "message": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -2562,9 +2580,9 @@ The note object for quote line item.
 ```json
 {
   "created_at": "abc123",
-  "creator_id": 987,
-  "creator_name": "abc123",
-  "creator_type": 987,
+  "creator_id": 123,
+  "creator_name": "xyz789",
+  "creator_type": 123,
   "negotiable_quote_item_uid": "4",
   "note": "xyz789",
   "note_uid": "4"
@@ -2589,8 +2607,8 @@ A list of options of the selected bundle product.
 
 ```json
 {
-  "label": "xyz789",
-  "uid": "4",
+  "label": "abc123",
+  "uid": 4,
   "values": [ItemSelectedBundleOptionValue]
 }
 ```
@@ -2618,8 +2636,8 @@ A list of values for the selected bundle product.
   "price": Money,
   "product_name": "abc123",
   "product_sku": "xyz789",
-  "quantity": 123.45,
-  "uid": 4
+  "quantity": 987.65,
+  "uid": "4"
 }
 ```
 
@@ -2650,7 +2668,7 @@ A JSON scalar
 
 ```json
 {
-  "key": "abc123",
+  "key": "xyz789",
   "media_resource_type": "NEGOTIABLE_QUOTE_ATTACHMENT"
 }
 ```
@@ -2673,7 +2691,7 @@ A JSON scalar
 {
   "key": "abc123",
   "message": "abc123",
-  "success": true
+  "success": false
 }
 ```
 
@@ -2692,7 +2710,7 @@ A JSON scalar
 
 ```json
 {
-  "key": "abc123",
+  "key": "xyz789",
   "media_resource_type": "NEGOTIABLE_QUOTE_ATTACHMENT"
 }
 ```
@@ -2713,7 +2731,7 @@ A JSON scalar
 
 ```json
 {
-  "expires_at": "abc123",
+  "expires_at": "xyz789",
   "key": "xyz789",
   "upload_url": "xyz789"
 }

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-k-p.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-k-p.md
@@ -15,9 +15,29 @@ Contains a key-value pair.
 
 ```json
 {
-  "name": "abc123",
+  "name": "xyz789",
   "value": "abc123"
 }
+```
+
+<HorizontalLine />
+
+### LiabilityShift
+
+Defines the possible values of liability shift
+
+#### Values
+
+| Enum Value | Description |
+|------------|-------------|
+| `NO` |  |
+| `POSSIBLE` |  |
+| `UNKNOWN` |  |
+
+#### Example
+
+```json
+""NO""
 ```
 
 <HorizontalLine />
@@ -38,9 +58,9 @@ Sets quote item note.
 
 ```json
 {
-  "note": "xyz789",
-  "quote_item_uid": "4",
-  "quote_uid": "4"
+  "note": "abc123",
+  "quote_item_uid": 4,
+  "quote_uid": 4
 }
 ```
 
@@ -73,9 +93,9 @@ Contains basic information about a product image or video.
 ```json
 {
   "disabled": true,
-  "label": "xyz789",
+  "label": "abc123",
   "position": 123,
-  "url": "xyz789"
+  "url": "abc123"
 }
 ```
 
@@ -114,7 +134,7 @@ Enumeration of media resource types
 #### Example
 
 ```json
-{"type": "xyz789"}
+{"type": "abc123"}
 ```
 
 <HorizontalLine />
@@ -132,7 +152,7 @@ Enumeration of media resource types
 
 ```json
 {
-  "layout": "abc123",
+  "layout": "xyz789",
   "logo": MessageStyleLogo
 }
 ```
@@ -195,7 +215,7 @@ An input object that defines the items in a requisition list to be moved.
 #### Example
 
 ```json
-{"requisitionListItemUids": [4]}
+{"requisitionListItemUids": ["4"]}
 ```
 
 <HorizontalLine />
@@ -238,9 +258,9 @@ Move Line Item to Requisition List.
 
 ```json
 {
-  "quote_item_uid": "4",
+  "quote_item_uid": 4,
   "quote_uid": "4",
-  "requisition_list_uid": "4"
+  "requisition_list_uid": 4
 }
 ```
 
@@ -331,19 +351,19 @@ Contains details about a negotiable quote.
   "created_at": "xyz789",
   "custom_attributes": [CustomAttribute],
   "email": "abc123",
-  "expiration_date": "xyz789",
+  "expiration_date": "abc123",
   "history": [NegotiableQuoteHistoryEntry],
-  "is_virtual": true,
+  "is_virtual": false,
   "items": [CartItemInterface],
-  "name": "xyz789",
+  "name": "abc123",
   "order": CustomerOrder,
   "prices": CartPrices,
-  "sales_rep_name": "abc123",
+  "sales_rep_name": "xyz789",
   "selected_payment_method": SelectedPaymentMethod,
   "shipping_addresses": [NegotiableQuoteShippingAddress],
   "status": "SUBMITTED",
   "template_id": 4,
-  "template_name": "abc123",
+  "template_name": "xyz789",
   "total_quantity": 987.65,
   "uid": 4,
   "updated_at": "xyz789"
@@ -368,7 +388,7 @@ Defines the company's country.
 ```json
 {
   "code": "xyz789",
-  "label": "xyz789"
+  "label": "abc123"
 }
 ```
 
@@ -404,20 +424,20 @@ Defines the billing or shipping address to be applied to the cart.
 
 ```json
 {
-  "city": "xyz789",
+  "city": "abc123",
   "company": "xyz789",
   "country_code": "xyz789",
   "custom_attributes": [AttributeValueInput],
   "fax": "abc123",
   "firstname": "xyz789",
   "lastname": "abc123",
-  "middlename": "abc123",
-  "postcode": "xyz789",
-  "prefix": "xyz789",
+  "middlename": "xyz789",
+  "postcode": "abc123",
+  "prefix": "abc123",
   "region": "abc123",
-  "region_id": 123,
-  "save_in_address_book": false,
-  "street": ["abc123"],
+  "region_id": 987,
+  "save_in_address_book": true,
+  "street": ["xyz789"],
   "suffix": "xyz789",
   "telephone": "xyz789",
   "vat_id": "abc123"
@@ -465,13 +485,13 @@ Defines the billing or shipping address to be applied to the cart.
   "company": "abc123",
   "country": NegotiableQuoteAddressCountry,
   "custom_attributes": [AttributeValueInterface],
-  "customer_address_uid": 4,
-  "fax": "xyz789",
-  "firstname": "xyz789",
+  "customer_address_uid": "4",
+  "fax": "abc123",
+  "firstname": "abc123",
   "lastname": "xyz789",
   "middlename": "abc123",
   "postcode": "xyz789",
-  "prefix": "abc123",
+  "prefix": "xyz789",
   "region": NegotiableQuoteAddressRegion,
   "street": ["abc123"],
   "suffix": "xyz789",
@@ -500,7 +520,7 @@ Defines the company's state or province.
 ```json
 {
   "code": "xyz789",
-  "label": "xyz789",
+  "label": "abc123",
   "region_id": 987
 }
 ```
@@ -535,21 +555,21 @@ Defines the company's state or province.
 
 ```json
 {
-  "city": "abc123",
+  "city": "xyz789",
   "company": "xyz789",
   "country": NegotiableQuoteAddressCountry,
   "custom_attributes": [AttributeValueInterface],
-  "customer_address_uid": 4,
+  "customer_address_uid": "4",
   "fax": "xyz789",
   "firstname": "xyz789",
-  "lastname": "xyz789",
+  "lastname": "abc123",
   "middlename": "xyz789",
-  "postcode": "abc123",
+  "postcode": "xyz789",
   "prefix": "xyz789",
   "region": NegotiableQuoteAddressRegion,
-  "street": ["xyz789"],
+  "street": ["abc123"],
   "suffix": "xyz789",
-  "telephone": "abc123",
+  "telephone": "xyz789",
   "uid": 4,
   "vat_id": "abc123"
 }
@@ -576,8 +596,8 @@ Defines the billing address.
 {
   "address": NegotiableQuoteAddressInput,
   "customer_address_uid": 4,
-  "same_as_shipping": true,
-  "use_for_shipping": false
+  "same_as_shipping": false,
+  "use_for_shipping": true
 }
 ```
 
@@ -606,7 +626,7 @@ Contains a single plain text comment from either the buyer or seller.
   "author": NegotiableQuoteUser,
   "created_at": "abc123",
   "creator_type": "BUYER",
-  "text": "xyz789",
+  "text": "abc123",
   "uid": 4
 }
 ```
@@ -629,7 +649,7 @@ Negotiable quote comment file attachment.
 ```json
 {
   "name": "xyz789",
-  "url": "abc123"
+  "url": "xyz789"
 }
 ```
 
@@ -648,7 +668,7 @@ Negotiable quote comment file attachment.
 #### Example
 
 ```json
-{"key": "abc123"}
+{"key": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -686,7 +706,7 @@ Contains the commend provided by the buyer.
 ```json
 {
   "attachments": [NegotiableQuoteCommentAttachmentInput],
-  "comment": "xyz789"
+  "comment": "abc123"
 }
 ```
 
@@ -781,7 +801,7 @@ Contains a comment submitted by a seller or buyer.
 #### Example
 
 ```json
-{"comment": "xyz789"}
+{"comment": "abc123"}
 ```
 
 <HorizontalLine />
@@ -808,9 +828,9 @@ Contains details about a change for a negotiable quote.
   "author": NegotiableQuoteUser,
   "change_type": "CREATED",
   "changes": NegotiableQuoteHistoryChanges,
-  "created_at": "xyz789",
+  "created_at": "abc123",
   "item_note": HistoryItemNoteData,
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -851,7 +871,7 @@ Contains a new expiration date and the previous date.
 ```json
 {
   "new_expiration": "abc123",
-  "old_expiration": "abc123"
+  "old_expiration": "xyz789"
 }
 ```
 
@@ -872,7 +892,7 @@ Contains lists of products that have been removed from the catalog and negotiabl
 
 ```json
 {
-  "products_removed_from_catalog": ["4"],
+  "products_removed_from_catalog": [4],
   "products_removed_from_quote": [ProductInterface]
 }
 ```
@@ -951,7 +971,7 @@ An error indicating that an operation was attempted on a negotiable quote in an 
 #### Example
 
 ```json
-{"message": "abc123"}
+{"message": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -970,7 +990,7 @@ Specifies the updated quantity of an item.
 #### Example
 
 ```json
-{"quantity": 123.45, "quote_item_uid": 4}
+{"quantity": 123.45, "quote_item_uid": "4"}
 ```
 
 <HorizontalLine />
@@ -990,8 +1010,8 @@ Defines the payment method to be applied to the negotiable quote.
 
 ```json
 {
-  "code": "xyz789",
-  "purchase_order_number": "xyz789"
+  "code": "abc123",
+  "purchase_order_number": "abc123"
 }
 ```
 
@@ -1014,9 +1034,9 @@ Contains a reference document link for a negotiable quote template.
 
 ```json
 {
-  "document_identifier": "xyz789",
-  "document_name": "xyz789",
-  "link_id": 4,
+  "document_identifier": "abc123",
+  "document_name": "abc123",
+  "link_id": "4",
   "reference_document_url": "xyz789"
 }
 ```
@@ -1054,20 +1074,20 @@ Contains a reference document link for a negotiable quote template.
 ```json
 {
   "available_shipping_methods": [AvailableShippingMethod],
-  "city": "xyz789",
-  "company": "abc123",
+  "city": "abc123",
+  "company": "xyz789",
   "country": NegotiableQuoteAddressCountry,
   "custom_attributes": [AttributeValueInterface],
   "customer_address_uid": "4",
   "fax": "abc123",
-  "firstname": "abc123",
+  "firstname": "xyz789",
   "lastname": "xyz789",
   "middlename": "abc123",
-  "postcode": "abc123",
+  "postcode": "xyz789",
   "prefix": "xyz789",
   "region": NegotiableQuoteAddressRegion,
   "selected_shipping_method": SelectedShippingMethod,
-  "street": ["abc123"],
+  "street": ["xyz789"],
   "suffix": "xyz789",
   "telephone": "xyz789",
   "uid": 4,
@@ -1094,7 +1114,7 @@ Defines shipping addresses for the negotiable quote.
 ```json
 {
   "address": NegotiableQuoteAddressInput,
-  "customer_address_uid": "4",
+  "customer_address_uid": 4,
   "customer_notes": "xyz789"
 }
 ```
@@ -1200,13 +1220,13 @@ Contains details about a negotiable quote template.
   "buyer": NegotiableQuoteUser,
   "comments": [NegotiableQuoteComment],
   "created_at": "abc123",
-  "expiration_date": "abc123",
+  "expiration_date": "xyz789",
   "history": [NegotiableQuoteHistoryEntry],
   "historyV2": [NegotiableQuoteTemplateHistoryEntry],
   "is_min_max_qty_used": false,
   "is_virtual": false,
   "items": [CartItemInterface],
-  "max_order_commitment": 987,
+  "max_order_commitment": 123,
   "min_order_commitment": 987,
   "name": "xyz789",
   "notifications": [QuoteTemplateNotificationMessage],
@@ -1214,13 +1234,13 @@ Contains details about a negotiable quote template.
   "reference_document_links": [
     NegotiableQuoteReferenceDocumentLink
   ],
-  "sales_rep_name": "abc123",
+  "sales_rep_name": "xyz789",
   "shipping_addresses": [NegotiableQuoteShippingAddress],
   "status": "xyz789",
-  "template_id": "4",
+  "template_id": 4,
   "total_quantity": 123.45,
   "uid": 4,
-  "updated_at": "abc123"
+  "updated_at": "xyz789"
 }
 ```
 
@@ -1286,20 +1306,20 @@ Contains data for a negotiable quote template in a grid.
   "created_at": "abc123",
   "expiration_date": "abc123",
   "is_min_max_qty_used": false,
-  "last_ordered_at": "abc123",
+  "last_ordered_at": "xyz789",
   "last_shared_at": "xyz789",
-  "max_order_commitment": 123,
+  "max_order_commitment": 987,
   "min_negotiated_grand_total": 123.45,
   "min_order_commitment": 987,
-  "name": "xyz789",
-  "orders_placed": 987,
+  "name": "abc123",
+  "orders_placed": 123,
   "prices": CartPrices,
-  "sales_rep_name": "xyz789",
+  "sales_rep_name": "abc123",
   "state": "abc123",
-  "status": "xyz789",
-  "submitted_by": "abc123",
-  "template_id": 4,
-  "uid": "4",
+  "status": "abc123",
+  "submitted_by": "xyz789",
+  "template_id": "4",
+  "uid": 4,
   "updated_at": "xyz789"
 }
 ```
@@ -1357,7 +1377,7 @@ Contains details about a change for a negotiable quote template.
   "author": NegotiableQuoteUser,
   "change_type": "CREATED",
   "changes": NegotiableQuoteTemplateHistoryChanges,
-  "created_at": "abc123",
+  "created_at": "xyz789",
   "uid": 4
 }
 ```
@@ -1379,8 +1399,8 @@ Lists a new status change applied to a negotiable quote template and the previou
 
 ```json
 {
-  "new_status": "xyz789",
-  "old_status": "xyz789"
+  "new_status": "abc123",
+  "old_status": "abc123"
 }
 ```
 
@@ -1420,7 +1440,7 @@ Specifies the updated quantity of an item.
 #### Example
 
 ```json
-{"item_id": 4, "max_qty": 987.65, "min_qty": 987.65, "quantity": 123.45}
+{"item_id": 4, "max_qty": 123.45, "min_qty": 987.65, "quantity": 987.65}
 ```
 
 <HorizontalLine />
@@ -1442,7 +1462,7 @@ Defines the reference document link to add to a negotiable quote template.
 
 ```json
 {
-  "document_identifier": "xyz789",
+  "document_identifier": "abc123",
   "document_name": "abc123",
   "link_id": "4",
   "reference_document_url": "abc123"
@@ -1469,7 +1489,7 @@ Defines shipping addresses for the negotiable quote template.
 {
   "address": NegotiableQuoteAddressInput,
   "customer_address_uid": 4,
-  "customer_notes": "abc123"
+  "customer_notes": "xyz789"
 }
 ```
 
@@ -1554,7 +1574,7 @@ Contains a list of negotiable templates that match the specified filter.
 #### Example
 
 ```json
-{"quote_uid": 4}
+{"quote_uid": "4"}
 ```
 
 <HorizontalLine />
@@ -1592,7 +1612,7 @@ A limited view of a Buyer or Seller in the negotiable quote process.
 
 ```json
 {
-  "firstname": "xyz789",
+  "firstname": "abc123",
   "lastname": "abc123"
 }
 ```
@@ -1619,7 +1639,7 @@ Contains a list of negotiable that match the specified filter.
   "items": [NegotiableQuote],
   "page_info": SearchResultPageInfo,
   "sort_fields": SortFields,
-  "total_count": 123
+  "total_count": 987
 }
 ```
 
@@ -1639,10 +1659,7 @@ Contains an error message when an invalid UID was specified.
 #### Example
 
 ```json
-{
-  "message": "xyz789",
-  "uid": "4"
-}
+{"message": "xyz789", "uid": 4}
 ```
 
 <HorizontalLine />
@@ -1681,6 +1698,30 @@ Contains an error message when an invalid UID was specified.
 
 <HorizontalLine />
 
+### OopeCustomFee
+
+A custom fee applied to the cart by an out-of-process webhook.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `amount` - [`Money!`](#money) | The fee amount in the cart currency. |
+| `code` - [`String!`](#string) | The unique identifier for this fee. |
+| `label` - [`String!`](#string) | The display label for this fee. |
+
+#### Example
+
+```json
+{
+  "amount": Money,
+  "code": "abc123",
+  "label": "xyz789"
+}
+```
+
+<HorizontalLine />
+
 ### OopePaymentMethodConfig
 
 #### Fields
@@ -1694,7 +1735,7 @@ Contains an error message when an invalid UID was specified.
 
 ```json
 {
-  "backend_integration_url": "xyz789",
+  "backend_integration_url": "abc123",
   "custom_config": [CustomConfigKeyValue]
 }
 ```
@@ -1714,7 +1755,7 @@ Specifies the quote template id to open quote template.
 #### Example
 
 ```json
-{"template_id": "4"}
+{"template_id": 4}
 ```
 
 <HorizontalLine />
@@ -1758,7 +1799,7 @@ Contains the order ID.
 #### Example
 
 ```json
-{"order_number": "abc123"}
+{"order_number": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -1812,22 +1853,22 @@ Contains detailed information about an order's billing and shipping addresses.
 
 ```json
 {
-  "city": "xyz789",
+  "city": "abc123",
   "company": "xyz789",
   "country_code": "AF",
   "custom_attributesV2": [AttributeValueInterface],
-  "fax": "abc123",
-  "firstname": "abc123",
-  "lastname": "abc123",
-  "middlename": "xyz789",
+  "fax": "xyz789",
+  "firstname": "xyz789",
+  "lastname": "xyz789",
+  "middlename": "abc123",
   "postcode": "abc123",
-  "prefix": "xyz789",
-  "region": "abc123",
-  "region_id": 4,
-  "street": ["xyz789"],
-  "suffix": "xyz789",
-  "telephone": "abc123",
-  "vat_id": "abc123"
+  "prefix": "abc123",
+  "region": "xyz789",
+  "region_id": "4",
+  "street": ["abc123"],
+  "suffix": "abc123",
+  "telephone": "xyz789",
+  "vat_id": "xyz789"
 }
 ```
 
@@ -1849,10 +1890,10 @@ Contains detailed information about an order's billing and shipping addresses.
 
 ```json
 {
-  "firstname": "abc123",
-  "lastname": "abc123",
-  "middlename": "xyz789",
-  "prefix": "abc123",
+  "firstname": "xyz789",
+  "lastname": "xyz789",
+  "middlename": "abc123",
+  "prefix": "xyz789",
   "suffix": "abc123"
 }
 ```
@@ -1895,7 +1936,7 @@ Contains detailed information about an order's billing and shipping addresses.
 {
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
-  "eligible_for_return": true,
+  "eligible_for_return": false,
   "entered_options": [OrderItemOption],
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
@@ -1904,16 +1945,16 @@ Contains detailed information about an order's billing and shipping addresses.
   "product": ProductInterface,
   "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
-  "product_type": "xyz789",
-  "product_url_key": "xyz789",
-  "quantity_canceled": 987.65,
+  "product_sku": "abc123",
+  "product_type": "abc123",
+  "product_url_key": "abc123",
+  "quantity_canceled": 123.45,
   "quantity_invoiced": 123.45,
   "quantity_ordered": 123.45,
   "quantity_refunded": 987.65,
   "quantity_return_requested": 987.65,
   "quantity_returned": 123.45,
-  "quantity_shipped": 987.65,
+  "quantity_shipped": 123.45,
   "selected_options": [OrderItemOption],
   "status": "xyz789"
 }
@@ -1969,27 +2010,27 @@ Order item details.
 {
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
-  "eligible_for_return": true,
+  "eligible_for_return": false,
   "entered_options": [OrderItemOption],
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
-  "id": "4",
+  "id": 4,
   "prices": OrderItemPrices,
   "product": ProductInterface,
-  "product_name": "xyz789",
+  "product_name": "abc123",
   "product_sale_price": Money,
-  "product_sku": "abc123",
+  "product_sku": "xyz789",
   "product_type": "abc123",
-  "product_url_key": "abc123",
-  "quantity_canceled": 123.45,
+  "product_url_key": "xyz789",
+  "quantity_canceled": 987.65,
   "quantity_invoiced": 987.65,
-  "quantity_ordered": 987.65,
-  "quantity_refunded": 987.65,
-  "quantity_return_requested": 123.45,
+  "quantity_ordered": 123.45,
+  "quantity_refunded": 123.45,
+  "quantity_return_requested": 987.65,
   "quantity_returned": 123.45,
   "quantity_shipped": 123.45,
   "selected_options": [OrderItemOption],
-  "status": "xyz789"
+  "status": "abc123"
 }
 ```
 
@@ -2011,7 +2052,7 @@ Represents order item options like selected or entered.
 ```json
 {
   "label": "abc123",
-  "value": "abc123"
+  "value": "xyz789"
 }
 ```
 
@@ -2072,7 +2113,7 @@ Contains details about the payment method used to pay for the order.
 ```json
 {
   "additional_data": [KeyValue],
-  "name": "abc123",
+  "name": "xyz789",
   "type": "abc123"
 }
 ```
@@ -2250,7 +2291,7 @@ Contains payment fields that are common to all types of payment methods.
   "payment_intent": "abc123",
   "sdk_params": [SDKParams],
   "sort_order": "xyz789",
-  "title": "xyz789"
+  "title": "abc123"
 }
 ```
 
@@ -2296,6 +2337,7 @@ Defines the origin location for that payment request
 | `MINICART` |  |
 | `CART` |  |
 | `CHECKOUT` |  |
+| `START_OF_CHECKOUT` |  |
 | `ADMIN` |  |
 
 #### Example
@@ -2329,14 +2371,14 @@ Defines the payment method.
 ```json
 {
   "additional_data": [PaymentAttributeInput],
-  "code": "xyz789",
+  "code": "abc123",
   "payment_services_paypal_apple_pay": ApplePayMethodInput,
   "payment_services_paypal_fastlane": FastlaneMethodInput,
   "payment_services_paypal_google_pay": GooglePayMethodInput,
   "payment_services_paypal_hosted_fields": HostedFieldsInput,
   "payment_services_paypal_smart_buttons": SmartButtonMethodInput,
   "payment_services_paypal_vault": VaultMethodInput,
-  "purchase_order_number": "abc123"
+  "purchase_order_number": "xyz789"
 }
 ```
 
@@ -2360,7 +2402,7 @@ Contains the payment order details
 ```json
 {
   "id": "xyz789",
-  "mp_order_id": "abc123",
+  "mp_order_id": "xyz789",
   "payment_source_details": PaymentSourceDetails,
   "status": "xyz789"
 }
@@ -2381,7 +2423,7 @@ Contains the payment order details
 
 ```json
 {
-  "code": "xyz789",
+  "code": "abc123",
   "params": [SDKParams]
 }
 ```
@@ -2457,7 +2499,7 @@ The stored payment method available to the customer.
 
 ```json
 {
-  "details": "abc123",
+  "details": "xyz789",
   "payment_method_code": "abc123",
   "public_hash": "xyz789",
   "type": "card"
@@ -2508,7 +2550,7 @@ Contains attributes specific to tangible products.
 #### Example
 
 ```json
-{"weight": 123.45}
+{"weight": 987.65}
 ```
 
 <HorizontalLine />
@@ -2541,20 +2583,20 @@ Defines Pickup Location information.
 
 ```json
 {
-  "city": "abc123",
-  "contact_name": "abc123",
+  "city": "xyz789",
+  "contact_name": "xyz789",
   "country_id": "xyz789",
-  "description": "xyz789",
+  "description": "abc123",
   "email": "xyz789",
   "fax": "xyz789",
-  "latitude": 123.45,
+  "latitude": 987.65,
   "longitude": 123.45,
   "name": "abc123",
   "phone": "abc123",
-  "pickup_location_code": "xyz789",
-  "postcode": "abc123",
-  "region": "xyz789",
-  "region_id": 123,
+  "pickup_location_code": "abc123",
+  "postcode": "xyz789",
+  "region": "abc123",
+  "region_id": 987,
   "street": "xyz789"
 }
 ```
@@ -2682,7 +2724,7 @@ Specifies the negotiable quote to convert to an order.
 #### Example
 
 ```json
-{"quote_uid": 4}
+{"quote_uid": "4"}
 ```
 
 <HorizontalLine />
@@ -2743,7 +2785,7 @@ An error encountered while placing an order.
 ```json
 {
   "code": "CART_NOT_FOUND",
-  "message": "xyz789"
+  "message": "abc123"
 }
 ```
 
@@ -2782,7 +2824,7 @@ Specifies the purchase order to convert to an order.
 #### Example
 
 ```json
-{"purchase_order_uid": "4"}
+{"purchase_order_uid": 4}
 ```
 
 <HorizontalLine />
@@ -2818,7 +2860,7 @@ Specifies the quote to be converted to an order.
 #### Example
 
 ```json
-{"cart_id": "abc123"}
+{"cart_id": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -2939,8 +2981,8 @@ Can be used to retrieve the main price details in case of bundle product
 ```json
 {
   "discount_percentage": 987.65,
-  "main_final_price": 987.65,
-  "main_price": 987.65
+  "main_final_price": 123.45,
+  "main_price": 123.45
 }
 ```
 
@@ -3018,7 +3060,7 @@ Defines whether a bundle product's price is displayed as the lowest possible val
 #### Example
 
 ```json
-{"sku": "xyz789"}
+{"sku": "abc123"}
 ```
 
 <HorizontalLine />
@@ -3034,7 +3076,7 @@ Defines whether a bundle product's price is displayed as the lowest possible val
 #### Example
 
 ```json
-{"sku": "abc123"}
+{"sku": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -3051,7 +3093,7 @@ Defines whether a bundle product's price is displayed as the lowest possible val
 #### Example
 
 ```json
-{"message": "abc123", "success": false}
+{"message": "xyz789", "success": true}
 ```
 
 <HorizontalLine />
@@ -3072,7 +3114,7 @@ Contains a product attribute code and value.
 ```json
 {
   "code": "abc123",
-  "value": "xyz789"
+  "value": "abc123"
 }
 ```
 
@@ -3093,7 +3135,7 @@ Contains a product attribute code and value.
 
 ```json
 {
-  "attribute_type": "xyz789",
+  "attribute_type": "abc123",
   "code": 4,
   "url": "xyz789",
   "value": "abc123"
@@ -3138,7 +3180,7 @@ Contains the discount applied to a product price.
 #### Example
 
 ```json
-{"amount_off": 987.65, "percent_off": 987.65}
+{"amount_off": 123.45, "percent_off": 123.45}
 ```
 
 <HorizontalLine />
@@ -3161,7 +3203,7 @@ Contains product image information, including the image URL and label.
 ```json
 {
   "disabled": false,
-  "label": "xyz789",
+  "label": "abc123",
   "position": 123,
   "url": "abc123"
 }
@@ -3199,7 +3241,7 @@ Product Information used for Pickup Locations search.
 #### Example
 
 ```json
-{"sku": "abc123"}
+{"sku": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -3268,29 +3310,29 @@ Contains fields that are common to all types of products.
 
 ```json
 {
-  "canonical_url": "xyz789",
+  "canonical_url": "abc123",
   "categories": [CategoryInterface],
   "country_of_manufacture": "abc123",
   "crosssell_products": [ProductInterface],
   "custom_attributesV2": ProductCustomAttributes,
   "description": ComplexTextValue,
-  "gift_message_available": false,
-  "gift_wrapping_available": true,
+  "gift_message_available": true,
+  "gift_wrapping_available": false,
   "gift_wrapping_price": Money,
   "image": ProductImage,
-  "is_returnable": "xyz789",
-  "manufacturer": 987,
-  "max_sale_qty": 123.45,
+  "is_returnable": "abc123",
+  "manufacturer": 123,
+  "max_sale_qty": 987.65,
   "media_gallery": [MediaGalleryInterface],
   "meta_description": "abc123",
-  "meta_keyword": "xyz789",
+  "meta_keyword": "abc123",
   "meta_title": "abc123",
   "min_sale_qty": 123.45,
   "name": "xyz789",
   "new_from_date": "xyz789",
-  "new_to_date": "abc123",
+  "new_to_date": "xyz789",
   "only_x_left_in_stock": 987.65,
-  "options_container": "abc123",
+  "options_container": "xyz789",
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
   "product_links": [ProductLinksInterface],
@@ -3306,7 +3348,7 @@ Contains fields that are common to all types of products.
   "thumbnail": ProductImage,
   "uid": 4,
   "upsell_products": [ProductInterface],
-  "url_key": "xyz789"
+  "url_key": "abc123"
 }
 ```
 
@@ -3332,9 +3374,9 @@ An implementation of `ProductLinksInterface`.
 {
   "link_type": "xyz789",
   "linked_product_sku": "abc123",
-  "linked_product_type": "xyz789",
+  "linked_product_type": "abc123",
   "position": 987,
-  "sku": "xyz789"
+  "sku": "abc123"
 }
 ```
 
@@ -3365,9 +3407,9 @@ Contains information about linked products, including the link type and product 
 ```json
 {
   "link_type": "abc123",
-  "linked_product_sku": "xyz789",
-  "linked_product_type": "xyz789",
-  "position": 987,
+  "linked_product_sku": "abc123",
+  "linked_product_type": "abc123",
+  "position": 123,
   "sku": "abc123"
 }
 ```
@@ -3390,9 +3432,9 @@ Contains basic information about the image asset.
 
 ```json
 {
-  "asset_id": "abc123",
+  "asset_id": "xyz789",
   "media_type": "xyz789",
-  "media_url": "xyz789"
+  "media_url": "abc123"
 }
 ```
 
@@ -3414,9 +3456,9 @@ Contains basic information about the video asset.
 
 ```json
 {
-  "media_type": "xyz789",
+  "media_type": "abc123",
   "video_asset_id": "abc123",
-  "video_media_url": "abc123"
+  "video_media_url": "xyz789"
 }
 ```
 
@@ -3442,11 +3484,11 @@ Contains a link to a video file and basic information about the video.
 ```json
 {
   "media_type": "abc123",
-  "video_description": "abc123",
+  "video_description": "xyz789",
   "video_metadata": "xyz789",
-  "video_provider": "abc123",
-  "video_title": "abc123",
-  "video_url": "abc123"
+  "video_provider": "xyz789",
+  "video_title": "xyz789",
+  "video_url": "xyz789"
 }
 ```
 
@@ -3548,7 +3590,7 @@ The product attribute to sort on
 #### Example
 
 ```json
-{"attribute": "abc123", "direction": "ASC"}
+{"attribute": "xyz789", "direction": "ASC"}
 ```
 
 <HorizontalLine />
@@ -3569,7 +3611,7 @@ Structured warning with code and message for easier client handling
 ```json
 {
   "code": "xyz789",
-  "message": "xyz789"
+  "message": "abc123"
 }
 ```
 
@@ -3612,10 +3654,10 @@ Contains information about a product video.
 
 ```json
 {
-  "disabled": false,
-  "label": "xyz789",
+  "disabled": true,
+  "label": "abc123",
   "position": 987,
-  "url": "xyz789",
+  "url": "abc123",
   "video_content": ProductMediaGalleryEntriesVideoContent
 }
 ```
@@ -3665,27 +3707,27 @@ Defines the product fields available to the SimpleProductView and ComplexProduct
 ```json
 {
   "addToCartAllowed": false,
-  "inStock": true,
+  "inStock": false,
   "lowStock": false,
   "attributes": [ProductViewAttribute],
-  "description": "abc123",
-  "id": "4",
+  "description": "xyz789",
+  "id": 4,
   "images": [ProductViewImage],
   "videos": [ProductViewVideo],
   "lastModifiedAt": "2007-12-03T10:15:30Z",
   "metaDescription": "abc123",
   "metaKeyword": "xyz789",
-  "metaTitle": "xyz789",
-  "name": "xyz789",
-  "shortDescription": "xyz789",
+  "metaTitle": "abc123",
+  "name": "abc123",
+  "shortDescription": "abc123",
   "inputOptions": [ProductViewInputOption],
-  "sku": "abc123",
+  "sku": "xyz789",
   "externalId": "abc123",
   "url": "xyz789",
   "urlKey": "abc123",
   "links": [ProductViewLink],
-  "queryType": "abc123",
-  "visibility": "abc123"
+  "queryType": "xyz789",
+  "visibility": "xyz789"
 }
 ```
 
@@ -3709,8 +3751,8 @@ A container for customer-defined attributes that are displayed the storefront.
 ```json
 {
   "label": "xyz789",
-  "name": "abc123",
-  "roles": ["abc123"],
+  "name": "xyz789",
+  "roles": ["xyz789"],
   "value": {}
 }
 ```
@@ -3920,7 +3962,7 @@ Contains details about a product image.
 
 ```json
 {
-  "label": "xyz789",
+  "label": "abc123",
   "roles": ["xyz789"],
   "url": "abc123"
 }
@@ -3952,15 +3994,15 @@ Product options provide a way to configure products by making selections of part
 ```json
 {
   "id": "4",
-  "title": "abc123",
+  "title": "xyz789",
   "required": false,
-  "type": "xyz789",
-  "markupAmount": 987.65,
-  "suffix": "abc123",
+  "type": "abc123",
+  "markupAmount": 123.45,
+  "suffix": "xyz789",
   "sortOrder": 123,
   "range": ProductViewInputOptionRange,
   "imageSize": ProductViewInputOptionImageSize,
-  "fileExtensions": "abc123"
+  "fileExtensions": "xyz789"
 }
 ```
 
@@ -3999,7 +4041,7 @@ Lists the value range associated with a `ProductViewInputOption`. For example, i
 #### Example
 
 ```json
-{"from": 987.65, "to": 123.45}
+{"from": 987.65, "to": 987.65}
 ```
 
 <HorizontalLine />
@@ -4040,7 +4082,7 @@ Defines a monetary value, including a numeric value and a currency code.
 #### Example
 
 ```json
-{"currency": "AED", "value": 987.65}
+{"currency": "AED", "value": 123.45}
 ```
 
 <HorizontalLine />
@@ -4063,8 +4105,8 @@ Product options provide a way to configure products by making selections of part
 
 ```json
 {
-  "id": "4",
-  "multi": true,
+  "id": 4,
+  "multi": false,
   "required": true,
   "title": "abc123",
   "values": [ProductViewOptionValue]
@@ -4099,7 +4141,7 @@ Defines the product fields available to the ProductViewOptionValueProduct and Pr
 {
   "id": "4",
   "title": "xyz789",
-  "inStock": true
+  "inStock": false
 }
 ```
 
@@ -4122,8 +4164,8 @@ An implementation of ProductViewOptionValue for configuration values.
 ```json
 {
   "id": "4",
-  "title": "abc123",
-  "inStock": true
+  "title": "xyz789",
+  "inStock": false
 }
 ```
 
@@ -4141,6 +4183,7 @@ An implementation of ProductViewOptionValue that adds details about a simple pro
 | `isDefault` - [`Boolean`](#boolean) | Indicates whether the option value is the default. |
 | `product` - [`SimpleProductView`](#simpleproductview) | Details about a simple product. For example, a product with a SKU of `123`, a name of `Product 1`, a price of `100.00`. |
 | `quantity` - [`Float`](#float) | Default quantity of an option value. |
+| `canEditQuantity` - [`Boolean`](#boolean) | Indicates if the quantity of the option value can be edited. |
 | `title` - [`String`](#string) | The display name of the option value. For example, `Red`, `Blue` or `Green` |
 | `inStock` - [`Boolean`](#boolean) | Indicates whether the remaining quantity of the product option value has reached the out-of-stock threshold. |
 
@@ -4152,7 +4195,8 @@ An implementation of ProductViewOptionValue that adds details about a simple pro
   "isDefault": true,
   "product": SimpleProductView,
   "quantity": 123.45,
-  "title": "abc123",
+  "canEditQuantity": false,
+  "title": "xyz789",
   "inStock": true
 }
 ```
@@ -4177,11 +4221,11 @@ An implementation of ProductViewOptionValueSwatch for swatches.
 
 ```json
 {
-  "id": "4",
-  "title": "abc123",
+  "id": 4,
+  "title": "xyz789",
   "type": "TEXT",
   "value": "abc123",
-  "inStock": true
+  "inStock": false
 }
 ```
 
@@ -4207,7 +4251,7 @@ Base product price view. Contains the final price after discounts, the regular p
   "final": Price,
   "regular": Price,
   "tiers": [ProductViewTierPrice],
-  "roles": ["xyz789"]
+  "roles": ["abc123"]
 }
 ```
 
@@ -4265,7 +4309,7 @@ Minimum quantity (inclusive) required to activate this tier price. For example, 
 #### Example
 
 ```json
-{"in": [987.65]}
+{"in": [123.45]}
 ```
 
 <HorizontalLine />
@@ -4349,7 +4393,7 @@ Represents the results of a product variant search.
 ```json
 {
   "variants": [ProductViewVariant],
-  "cursor": "abc123"
+  "cursor": "xyz789"
 }
 ```
 
@@ -4373,8 +4417,8 @@ Contains details about a product video. For example, a video of the product bein
 ```json
 {
   "preview": ProductViewImage,
-  "url": "xyz789",
-  "description": "xyz789",
+  "url": "abc123",
+  "description": "abc123",
   "title": "abc123"
 }
 ```
@@ -4390,7 +4434,7 @@ User purchase history
 | Input Field | Description |
 |-------------|-------------|
 | `date` - [`DateTime`](#datetime) |  |
-| `items` - [`[String]!`](#string) |  |
+| `items` - [`[String]`](#string) |  |
 
 #### Example
 
@@ -4431,15 +4475,15 @@ Contains details about a purchase order.
   "approval_flow": [PurchaseOrderRuleApprovalFlow],
   "available_actions": ["REJECT"],
   "comments": [PurchaseOrderComment],
-  "created_at": "xyz789",
+  "created_at": "abc123",
   "created_by": Customer,
   "history_log": [PurchaseOrderHistoryItem],
-  "number": "abc123",
+  "number": "xyz789",
   "order": CustomerOrder,
   "quote": Cart,
   "status": "PENDING",
   "uid": "4",
-  "updated_at": "abc123"
+  "updated_at": "xyz789"
 }
 ```
 
@@ -4502,11 +4546,11 @@ Contains details about a single event in the approval flow of the purchase order
 
 ```json
 {
-  "message": "abc123",
+  "message": "xyz789",
   "name": "abc123",
   "role": "xyz789",
   "status": "PENDING",
-  "updated_at": "abc123"
+  "updated_at": "xyz789"
 }
 ```
 
@@ -4556,13 +4600,13 @@ Contains details about a purchase order approval rule.
   "applies_to_roles": [CompanyRole],
   "approver_roles": [CompanyRole],
   "condition": PurchaseOrderApprovalRuleConditionInterface,
-  "created_at": "abc123",
+  "created_at": "xyz789",
   "created_by": "abc123",
-  "description": "abc123",
+  "description": "xyz789",
   "name": "abc123",
   "status": "ENABLED",
-  "uid": 4,
-  "updated_at": "xyz789"
+  "uid": "4",
+  "updated_at": "abc123"
 }
 ```
 
@@ -4789,7 +4833,7 @@ Contains details about a comment.
 {
   "author": Customer,
   "created_at": "xyz789",
-  "text": "abc123",
+  "text": "xyz789",
   "uid": "4"
 }
 ```
@@ -4834,9 +4878,9 @@ Contains details about a status change.
 ```json
 {
   "activity": "xyz789",
-  "created_at": "abc123",
+  "created_at": "xyz789",
   "message": "abc123",
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -4858,7 +4902,7 @@ Contains details about approval roles applied to the purchase order and status c
 ```json
 {
   "events": [PurchaseOrderApprovalFlowEvent],
-  "rule_name": "abc123"
+  "rule_name": "xyz789"
 }
 ```
 
@@ -4925,7 +4969,7 @@ Defines which purchase orders to act on.
 #### Example
 
 ```json
-{"purchase_order_uids": [4]}
+{"purchase_order_uids": ["4"]}
 ```
 
 <HorizontalLine />
@@ -4970,7 +5014,7 @@ Defines the criteria to use to filter the list of purchase orders.
 
 ```json
 {
-  "company_purchase_orders": false,
+  "company_purchase_orders": true,
   "created_date": FilterRangeTypeInput,
   "my_approvals": true,
   "require_my_approval": true,

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-q-s.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-q-s.md
@@ -54,7 +54,7 @@ Sets quote template expiration date.
 
 ```json
 {
-  "expiration_date": "xyz789",
+  "expiration_date": "abc123",
   "template_id": 4
 }
 ```
@@ -80,7 +80,7 @@ Sets quote item note.
 {
   "item_id": 4,
   "item_uid": 4,
-  "note": "abc123",
+  "note": "xyz789",
   "templateId": 4
 }
 ```
@@ -102,7 +102,7 @@ Contains a notification message for a negotiable quote template.
 
 ```json
 {
-  "message": "abc123",
+  "message": "xyz789",
   "type": "xyz789"
 }
 ```
@@ -126,10 +126,10 @@ For use on numeric product fields
 
 ```json
 {
-  "count": 123,
-  "from": 987.65,
-  "title": "xyz789",
-  "to": 123.45
+  "count": 987,
+  "from": 123.45,
+  "title": "abc123",
+  "to": 987.65
 }
 ```
 
@@ -183,7 +183,7 @@ For use on numeric product fields
 #### Example
 
 ```json
-{"from": 123.45, "to": 987.65}
+{"from": 123.45, "to": 123.45}
 ```
 
 <HorizontalLine />
@@ -229,12 +229,12 @@ Contains reCAPTCHA form configuration details.
 
 ```json
 {
-  "badge_position": "xyz789",
+  "badge_position": "abc123",
   "language_code": "abc123",
   "minimum_score": 987.65,
   "re_captcha_type": "INVISIBLE",
-  "technical_failure_message": "xyz789",
-  "theme": "xyz789",
+  "technical_failure_message": "abc123",
+  "theme": "abc123",
   "validation_failure_message": "xyz789",
   "website_key": "xyz789"
 }
@@ -263,12 +263,12 @@ Contains reCAPTCHA V3-Invisible configuration details.
 
 ```json
 {
-  "badge_position": "abc123",
+  "badge_position": "xyz789",
   "failure_message": "xyz789",
   "forms": ["PLACE_ORDER"],
   "is_enabled": false,
   "language_code": "xyz789",
-  "minimum_score": 987.65,
+  "minimum_score": 123.45,
   "theme": "abc123",
   "website_key": "xyz789"
 }
@@ -368,12 +368,12 @@ Recommendation Unit containing product and other details
 ```json
 {
   "displayOrder": 123,
-  "pageType": "abc123",
+  "pageType": "xyz789",
   "productsView": [ProductView],
   "storefrontLabel": "abc123",
-  "totalProducts": 123,
+  "totalProducts": 987,
   "typeId": "xyz789",
-  "unitId": "xyz789",
+  "unitId": "abc123",
   "unitName": "abc123",
   "userError": "abc123"
 }
@@ -395,7 +395,7 @@ Recommendations response
 #### Example
 
 ```json
-{"results": [RecommendationUnit], "totalResults": 123}
+{"results": [RecommendationUnit], "totalResults": 987}
 ```
 
 <HorizontalLine />
@@ -414,8 +414,8 @@ Recommendations response
 
 ```json
 {
-  "code": "abc123",
-  "id": 987,
+  "code": "xyz789",
+  "id": 123,
   "name": "xyz789"
 }
 ```
@@ -473,7 +473,7 @@ Remove coupons from the cart.
 
 ```json
 {
-  "cart_id": "abc123",
+  "cart_id": "xyz789",
   "coupon_codes": ["abc123"]
 }
 ```
@@ -496,7 +496,7 @@ Defines the input required to run the `removeGiftCardFromCart` mutation.
 ```json
 {
   "cart_id": "xyz789",
-  "gift_card_code": "xyz789"
+  "gift_card_code": "abc123"
 }
 ```
 
@@ -551,7 +551,7 @@ Contains the results of a request to delete a gift registry.
 #### Example
 
 ```json
-{"success": true}
+{"success": false}
 ```
 
 <HorizontalLine />
@@ -588,7 +588,10 @@ Specifies which items to remove from the cart.
 #### Example
 
 ```json
-{"cart_id": "abc123", "cart_item_uid": 4}
+{
+  "cart_id": "abc123",
+  "cart_item_uid": "4"
+}
 ```
 
 <HorizontalLine />
@@ -625,7 +628,7 @@ Defines the items to remove from the specified negotiable quote.
 #### Example
 
 ```json
-{"quote_item_uids": [4], "quote_uid": 4}
+{"quote_item_uids": [4], "quote_uid": "4"}
 ```
 
 <HorizontalLine />
@@ -662,7 +665,10 @@ Defines the items to remove from the specified negotiable quote.
 #### Example
 
 ```json
-{"item_uids": [4], "template_id": 4}
+{
+  "item_uids": ["4"],
+  "template_id": "4"
+}
 ```
 
 <HorizontalLine />
@@ -721,7 +727,7 @@ Defines the tracking information to delete.
 #### Example
 
 ```json
-{"return_shipping_tracking_uid": 4}
+{"return_shipping_tracking_uid": "4"}
 ```
 
 <HorizontalLine />
@@ -775,7 +781,7 @@ Defines the input required to run the `removeStoreCreditFromCart` mutation.
 #### Example
 
 ```json
-{"cart_id": "xyz789"}
+{"cart_id": "abc123"}
 ```
 
 <HorizontalLine />
@@ -816,7 +822,7 @@ Sets new name for a negotiable quote.
 {
   "quote_comment": "abc123",
   "quote_name": "xyz789",
-  "quote_uid": 4
+  "quote_uid": "4"
 }
 ```
 
@@ -880,7 +886,7 @@ Contains information needed to start a return request.
 ```json
 {
   "comment_text": "xyz789",
-  "contact_email": "abc123",
+  "contact_email": "xyz789",
   "items": [RequestReturnItemInput],
   "token": "abc123"
 }
@@ -905,9 +911,9 @@ Defines properties of a negotiable quote request.
 
 ```json
 {
-  "cart_id": "4",
+  "cart_id": 4,
   "comment": NegotiableQuoteCommentInput,
-  "is_draft": false,
+  "is_draft": true,
   "quote_name": "abc123"
 }
 ```
@@ -945,7 +951,7 @@ Defines properties of a negotiable quote template request.
 #### Example
 
 ```json
-{"cart_id": 4}
+{"cart_id": "4"}
 ```
 
 <HorizontalLine />
@@ -968,7 +974,7 @@ Contains information needed to start a return request.
 ```json
 {
   "comment_text": "abc123",
-  "contact_email": "abc123",
+  "contact_email": "xyz789",
   "items": [RequestReturnItemInput],
   "order_uid": 4
 }
@@ -997,7 +1003,7 @@ Contains details about an item to be returned.
     EnteredCustomAttributeInput
   ],
   "order_item_uid": 4,
-  "quantity_to_return": 123.45,
+  "quantity_to_return": 987.65,
   "selected_custom_attributes": [
     SelectedCustomAttributeInput
   ]
@@ -1047,12 +1053,12 @@ Defines the contents of a requisition list.
 
 ```json
 {
-  "description": "xyz789",
+  "description": "abc123",
   "items": RequistionListItems,
-  "items_count": 987,
-  "name": "abc123",
+  "items_count": 123,
+  "name": "xyz789",
   "uid": "4",
-  "updated_at": "xyz789"
+  "updated_at": "abc123"
 }
 ```
 
@@ -1111,8 +1117,8 @@ The interface for requisition list items.
 {
   "customizable_options": [SelectedCustomizableOption],
   "product": ProductInterface,
-  "quantity": 987.65,
-  "sku": "abc123",
+  "quantity": 123.45,
+  "sku": "xyz789",
   "uid": "4"
 }
 ```
@@ -1138,10 +1144,10 @@ Defines the items to add.
 ```json
 {
   "entered_options": [EnteredOptionInput],
-  "parent_sku": "abc123",
-  "quantity": 123.45,
+  "parent_sku": "xyz789",
+  "quantity": 987.65,
   "selected_options": ["xyz789"],
-  "sku": "abc123"
+  "sku": "xyz789"
 }
 ```
 
@@ -1203,7 +1209,7 @@ Defines customer requisition lists.
   "items": [RequisitionList],
   "page_info": SearchResultPageInfo,
   "sort_fields": SortFields,
-  "total_count": 123
+  "total_count": 987
 }
 ```
 
@@ -1227,7 +1233,7 @@ Contains an array of items added to a requisition list.
 {
   "items": [RequisitionListItemInterface],
   "page_info": SearchResultPageInfo,
-  "total_pages": 123
+  "total_pages": 987
 }
 ```
 
@@ -1258,7 +1264,7 @@ Contains details about a return.
 {
   "available_shipping_carriers": [ReturnShippingCarrier],
   "comments": [ReturnComment],
-  "created_at": "xyz789",
+  "created_at": "abc123",
   "customer": ReturnCustomer,
   "items": [ReturnItem],
   "number": "abc123",
@@ -1288,10 +1294,10 @@ Contains details about a return comment.
 
 ```json
 {
-  "author_name": "xyz789",
-  "created_at": "xyz789",
-  "text": "abc123",
-  "uid": "4"
+  "author_name": "abc123",
+  "created_at": "abc123",
+  "text": "xyz789",
+  "uid": 4
 }
 ```
 
@@ -1345,7 +1351,7 @@ Contains details about a product being returned.
   "quantity": 123.45,
   "request_quantity": 123.45,
   "status": "PENDING",
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -1377,18 +1383,18 @@ Return Item attribute metadata.
 
 ```json
 {
-  "code": 4,
-  "default_value": "xyz789",
+  "code": "4",
+  "default_value": "abc123",
   "entity_type": "CATALOG_PRODUCT",
-  "frontend_class": "xyz789",
+  "frontend_class": "abc123",
   "frontend_input": "BOOLEAN",
   "input_filter": "NONE",
-  "is_required": false,
-  "is_unique": false,
+  "is_required": true,
+  "is_unique": true,
   "label": "abc123",
-  "multiline_count": 123,
+  "multiline_count": 987,
   "options": [CustomAttributeOptionInterface],
-  "sort_order": 123,
+  "sort_order": 987,
   "validate_rules": [ValidationRule]
 }
 ```
@@ -1458,10 +1464,10 @@ Contains details about the shipping address used for receiving returned items.
 
 ```json
 {
-  "city": "abc123",
-  "contact_name": "xyz789",
+  "city": "xyz789",
+  "contact_name": "abc123",
   "country": Country,
-  "postcode": "abc123",
+  "postcode": "xyz789",
   "region": Region,
   "street": ["xyz789"],
   "telephone": "abc123"
@@ -1484,10 +1490,7 @@ Contains details about the carrier on a return.
 #### Example
 
 ```json
-{
-  "label": "xyz789",
-  "uid": "4"
-}
+{"label": "xyz789", "uid": 4}
 ```
 
 <HorizontalLine />
@@ -1512,7 +1515,7 @@ Contains shipping and tracking details.
   "carrier": ReturnShippingCarrier,
   "status": ReturnShippingTrackingStatus,
   "tracking_number": "xyz789",
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -1532,7 +1535,7 @@ Contains the status of a shipment.
 #### Example
 
 ```json
-{"text": "abc123", "type": "INFORMATION"}
+{"text": "xyz789", "type": "INFORMATION"}
 ```
 
 <HorizontalLine />
@@ -1600,7 +1603,7 @@ Contains a list of customer return requests.
 {
   "items": [Return],
   "page_info": SearchResultPageInfo,
-  "total_count": 123
+  "total_count": 987
 }
 ```
 
@@ -1685,7 +1688,7 @@ Contain details about the reward points transaction.
 ```json
 {
   "balance": RewardPointsAmount,
-  "change_reason": "xyz789",
+  "change_reason": "abc123",
   "date": "xyz789",
   "points_change": 987.65
 }
@@ -1789,7 +1792,7 @@ Defines the name and value of a SDK parameter
 ```json
 {
   "name": "xyz789",
-  "value": "xyz789"
+  "value": "abc123"
 }
 ```
 
@@ -1810,7 +1813,7 @@ Contains details about a comment.
 
 ```json
 {
-  "message": "abc123",
+  "message": "xyz789",
   "timestamp": "abc123"
 }
 ```
@@ -1832,7 +1835,11 @@ For use on string and other scalar product fields
 #### Example
 
 ```json
-{"count": 987, "id": 4, "title": "xyz789"}
+{
+  "count": 123,
+  "id": "4",
+  "title": "xyz789"
+}
 ```
 
 <HorizontalLine />
@@ -1876,9 +1883,9 @@ A product attribute to filter on
 
 ```json
 {
-  "attribute": "xyz789",
-  "contains": "abc123",
-  "eq": "abc123",
+  "attribute": "abc123",
+  "contains": "xyz789",
+  "eq": "xyz789",
   "in": ["abc123"],
   "range": SearchRangeInput,
   "startsWith": "abc123"
@@ -1901,7 +1908,7 @@ A range of numeric values for use in a search
 #### Example
 
 ```json
-{"from": 987.65, "to": 123.45}
+{"from": 987.65, "to": 987.65}
 ```
 
 <HorizontalLine />
@@ -1921,7 +1928,7 @@ Provides navigation for the query response.
 #### Example
 
 ```json
-{"current_page": 123, "page_size": 123, "total_pages": 123}
+{"current_page": 123, "page_size": 123, "total_pages": 987}
 ```
 
 <HorizontalLine />
@@ -1943,9 +1950,9 @@ Contains details about a selected bundle option.
 
 ```json
 {
-  "label": "xyz789",
+  "label": "abc123",
   "type": "abc123",
-  "uid": "4",
+  "uid": 4,
   "values": [SelectedBundleOptionValue]
 }
 ```
@@ -1997,9 +2004,9 @@ Contains details about a selected configurable option.
 
 ```json
 {
-  "configurable_product_option_uid": "4",
-  "configurable_product_option_value_uid": "4",
-  "option_label": "xyz789",
+  "configurable_product_option_uid": 4,
+  "configurable_product_option_value_uid": 4,
+  "option_label": "abc123",
   "value_label": "abc123"
 }
 ```
@@ -2022,7 +2029,7 @@ Contains details about an attribute the buyer selected.
 ```json
 {
   "attribute_code": "abc123",
-  "value": "xyz789"
+  "value": "abc123"
 }
 ```
 
@@ -2047,11 +2054,11 @@ Identifies a customized product that has been placed in a cart.
 
 ```json
 {
-  "customizable_option_uid": 4,
-  "is_required": false,
-  "label": "xyz789",
-  "sort_order": 987,
-  "type": "abc123",
+  "customizable_option_uid": "4",
+  "is_required": true,
+  "label": "abc123",
+  "sort_order": 123,
+  "type": "xyz789",
   "values": [SelectedCustomizableOptionValue]
 }
 ```
@@ -2103,8 +2110,8 @@ Describes the payment method selected by the shopper.
 {
   "code": "xyz789",
   "oope_payment_method_config": OopePaymentMethodConfig,
-  "purchase_order_number": "xyz789",
-  "title": "abc123"
+  "purchase_order_number": "abc123",
+  "title": "xyz789"
 }
 ```
 
@@ -2134,9 +2141,9 @@ Contains details about the selected shipping method and carrier.
   "additional_data": [ShippingAdditionalData],
   "amount": Money,
   "carrier_code": "abc123",
-  "carrier_title": "xyz789",
+  "carrier_title": "abc123",
   "method_code": "xyz789",
-  "method_title": "xyz789",
+  "method_title": "abc123",
   "price_excl_tax": Money,
   "price_incl_tax": Money
 }
@@ -2299,7 +2306,7 @@ Defines the negotiable quote custom attributes.
 ```json
 {
   "custom_attributes": [CustomAttributeInput],
-  "quote_uid": "4"
+  "quote_uid": 4
 }
 ```
 
@@ -2341,10 +2348,10 @@ Defines the gift options applied to the cart.
 
 ```json
 {
-  "cart_id": "xyz789",
+  "cart_id": "abc123",
   "gift_message": GiftMessageInput,
   "gift_receipt_included": false,
-  "gift_wrapping_id": "4",
+  "gift_wrapping_id": 4,
   "printed_card_included": true
 }
 ```
@@ -2384,8 +2391,8 @@ Defines the guest email and cart.
 
 ```json
 {
-  "cart_id": "abc123",
-  "email": "xyz789"
+  "cart_id": "xyz789",
+  "email": "abc123"
 }
 ```
 
@@ -2443,7 +2450,7 @@ Sets the billing address.
 ```json
 {
   "billing_address": NegotiableQuoteBillingAddressInput,
-  "quote_uid": "4"
+  "quote_uid": 4
 }
 ```
 
@@ -2522,7 +2529,7 @@ Defines the shipping address to assign to the negotiable quote.
 
 ```json
 {
-  "quote_uid": 4,
+  "quote_uid": "4",
   "shipping_addresses": [
     NegotiableQuoteShippingAddressInput
   ]
@@ -2605,7 +2612,7 @@ Defines the shipping address to assign to the negotiable quote template.
 ```json
 {
   "shipping_address": NegotiableQuoteTemplateShippingAddressInput,
-  "template_id": "4"
+  "template_id": 4
 }
 ```
 
@@ -2666,7 +2673,7 @@ Specifies an array of addresses to use for shipping.
 
 ```json
 {
-  "cart_id": "abc123",
+  "cart_id": "xyz789",
   "shipping_addresses": [ShippingAddressInput]
 }
 ```
@@ -2746,7 +2753,7 @@ Defines a gift registry invitee.
 
 ```json
 {
-  "email": "abc123",
+  "email": "xyz789",
   "name": "abc123"
 }
 ```
@@ -2766,7 +2773,7 @@ Contains the results of a request to share a gift registry.
 #### Example
 
 ```json
-{"is_shared": true}
+{"is_shared": false}
 ```
 
 <HorizontalLine />
@@ -2786,7 +2793,7 @@ Defines the sender of an invitation to view a gift registry.
 
 ```json
 {
-  "message": "abc123",
+  "message": "xyz789",
   "name": "abc123"
 }
 ```
@@ -2809,7 +2816,7 @@ An input object that defines which requisition list shared with company users th
 ```json
 {
   "customerUids": ["4"],
-  "requisitionListUid": "4"
+  "requisitionListUid": 4
 }
 ```
 
@@ -2830,7 +2837,7 @@ Result of sharing a requisition list by email.
 
 ```json
 {
-  "sent_count": 987,
+  "sent_count": 123,
   "user_errors": [ShareRequisitionListUserError]
 }
 ```
@@ -2850,7 +2857,7 @@ The result of sharing a requisition list by token.
 #### Example
 
 ```json
-{"token": "xyz789"}
+{"token": "abc123"}
 ```
 
 <HorizontalLine />
@@ -2958,10 +2965,10 @@ Defines whether bundle items must be shipped together.
 {
   "id": 4,
   "order_item": OrderItemInterface,
-  "product_name": "abc123",
+  "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "abc123",
-  "quantity_shipped": 123.45
+  "product_sku": "xyz789",
+  "quantity_shipped": 987.65
 }
 ```
 
@@ -2994,7 +3001,7 @@ Order shipment item details.
 
 ```json
 {
-  "id": 4,
+  "id": "4",
   "order_item": OrderItemInterface,
   "product_name": "abc123",
   "product_sale_price": Money,
@@ -3022,10 +3029,10 @@ Contains order shipment tracking details.
 
 ```json
 {
-  "carrier": "xyz789",
+  "carrier": "abc123",
   "number": "abc123",
-  "title": "xyz789",
-  "tracking_url": "xyz789"
+  "title": "abc123",
+  "tracking_url": "abc123"
 }
 ```
 
@@ -3046,8 +3053,8 @@ A simple key value object.
 
 ```json
 {
-  "key": "abc123",
-  "value": "abc123"
+  "key": "xyz789",
+  "value": "xyz789"
 }
 ```
 
@@ -3074,8 +3081,8 @@ Defines a single shipping address.
   "address": CartAddressInput,
   "customer_address_id": 123,
   "customer_address_uid": 4,
-  "customer_notes": "xyz789",
-  "pickup_location_code": "xyz789"
+  "customer_notes": "abc123",
+  "pickup_location_code": "abc123"
 }
 ```
 
@@ -3120,20 +3127,20 @@ Contains shipping addresses and methods.
 {
   "available_shipping_methods": [AvailableShippingMethod],
   "cart_items_v2": [CartItemInterface],
-  "city": "xyz789",
+  "city": "abc123",
   "company": "xyz789",
   "country": CartAddressCountry,
   "custom_attributes": [AttributeValueInterface],
-  "customer_address_uid": 4,
-  "customer_notes": "xyz789",
-  "fax": "abc123",
-  "firstname": "abc123",
+  "customer_address_uid": "4",
+  "customer_notes": "abc123",
+  "fax": "xyz789",
+  "firstname": "xyz789",
   "id": 987,
-  "lastname": "xyz789",
+  "lastname": "abc123",
   "middlename": "xyz789",
   "pickup_location_code": "xyz789",
-  "postcode": "xyz789",
-  "prefix": "abc123",
+  "postcode": "abc123",
+  "prefix": "xyz789",
   "region": CartAddressRegion,
   "same_as_billing": true,
   "selected_shipping_method": SelectedShippingMethod,
@@ -3141,7 +3148,7 @@ Contains shipping addresses and methods.
   "suffix": "xyz789",
   "telephone": "abc123",
   "uid": 4,
-  "vat_id": "abc123"
+  "vat_id": "xyz789"
 }
 ```
 
@@ -3255,17 +3262,17 @@ An implementation for simple product cart items.
   "errors": [CartItemError],
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
-  "is_available": false,
-  "is_salable": false,
+  "is_available": true,
+  "is_salable": true,
   "max_qty": 987.65,
   "min_qty": 123.45,
-  "not_available_message": "xyz789",
+  "not_available_message": "abc123",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
   "quantity": 123.45,
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -3325,28 +3332,28 @@ Defines a simple product, which is tangible and is usually sold in single units 
 
 ```json
 {
-  "canonical_url": "xyz789",
+  "canonical_url": "abc123",
   "categories": [CategoryInterface],
   "country_of_manufacture": "xyz789",
   "crosssell_products": [ProductInterface],
   "custom_attributesV2": ProductCustomAttributes,
   "description": ComplexTextValue,
   "gift_message_available": true,
-  "gift_wrapping_available": false,
+  "gift_wrapping_available": true,
   "gift_wrapping_price": Money,
   "image": ProductImage,
-  "is_returnable": "abc123",
+  "is_returnable": "xyz789",
   "manufacturer": 123,
   "max_sale_qty": 123.45,
   "media_gallery": [MediaGalleryInterface],
-  "meta_description": "abc123",
-  "meta_keyword": "xyz789",
-  "meta_title": "xyz789",
+  "meta_description": "xyz789",
+  "meta_keyword": "abc123",
+  "meta_title": "abc123",
   "min_sale_qty": 123.45,
   "name": "abc123",
-  "new_from_date": "abc123",
-  "new_to_date": "xyz789",
-  "only_x_left_in_stock": 987.65,
+  "new_from_date": "xyz789",
+  "new_to_date": "abc123",
+  "only_x_left_in_stock": 123.45,
   "options": [CustomizableOptionInterface],
   "options_container": "abc123",
   "price_range": PriceRange,
@@ -3358,14 +3365,14 @@ Defines a simple product, which is tangible and is usually sold in single units 
   "sku": "xyz789",
   "small_image": ProductImage,
   "special_price": 123.45,
-  "special_to_date": "abc123",
+  "special_to_date": "xyz789",
   "stock_status": "IN_STOCK",
   "swatch_image": "xyz789",
   "thumbnail": ProductImage,
   "uid": "4",
   "upsell_products": [ProductInterface],
   "url_key": "xyz789",
-  "weight": 987.65
+  "weight": 123.45
 }
 ```
 
@@ -3407,8 +3414,8 @@ Represents a single-SKU product without selectable variants. Because there are n
 
 ```json
 {
-  "addToCartAllowed": false,
-  "inStock": true,
+  "addToCartAllowed": true,
+  "inStock": false,
   "lowStock": true,
   "attributes": [ProductViewAttribute],
   "description": "abc123",
@@ -3419,17 +3426,17 @@ Represents a single-SKU product without selectable variants. Because there are n
   "lastModifiedAt": "2007-12-03T10:15:30Z",
   "metaDescription": "xyz789",
   "metaKeyword": "abc123",
-  "metaTitle": "xyz789",
+  "metaTitle": "abc123",
   "name": "xyz789",
   "price": ProductViewPrice,
   "shortDescription": "xyz789",
-  "sku": "abc123",
+  "sku": "xyz789",
   "externalId": "abc123",
-  "url": "xyz789",
-  "urlKey": "xyz789",
+  "url": "abc123",
+  "urlKey": "abc123",
   "links": [ProductViewLink],
   "queryType": "xyz789",
-  "visibility": "xyz789"
+  "visibility": "abc123"
 }
 ```
 
@@ -3455,7 +3462,7 @@ Contains details about simple products added to a requisition list.
 {
   "customizable_options": [SelectedCustomizableOption],
   "product": ProductInterface,
-  "quantity": 987.65,
+  "quantity": 123.45,
   "sku": "xyz789",
   "uid": "4"
 }
@@ -3539,11 +3546,11 @@ Smart button payment inputs
 
 ```json
 {
-  "app_switch_when_available": true,
+  "app_switch_when_available": false,
   "button_styles": ButtonStyles,
-  "code": "abc123",
+  "code": "xyz789",
   "display_message": false,
-  "display_venmo": false,
+  "display_venmo": true,
   "is_visible": false,
   "message_styles": MessageStyles,
   "payment_intent": "abc123",
@@ -3589,7 +3596,7 @@ Defines a possible sort field.
 
 ```json
 {
-  "label": "abc123",
+  "label": "xyz789",
   "value": "abc123"
 }
 ```
@@ -3686,9 +3693,9 @@ Contains product attributes that be used for sorting in a `productSearch` query
 ```json
 {
   "attribute": "abc123",
-  "frontendInput": "xyz789",
-  "label": "abc123",
-  "numeric": false
+  "frontendInput": "abc123",
+  "label": "xyz789",
+  "numeric": true
 }
 ```
 
@@ -3711,7 +3718,7 @@ For retrieving statistics across multiple buckets
 ```json
 {
   "max": 987.65,
-  "min": 123.45,
+  "min": 987.65,
   "title": "abc123"
 }
 ```
@@ -3877,152 +3884,152 @@ Contains information about a store's configuration.
 
 ```json
 {
-  "allow_company_registration": true,
+  "allow_company_registration": false,
   "allow_gift_receipt": "abc123",
-  "allow_gift_wrapping_on_order": "abc123",
-  "allow_gift_wrapping_on_order_items": "abc123",
+  "allow_gift_wrapping_on_order": "xyz789",
+  "allow_gift_wrapping_on_order_items": "xyz789",
   "allow_items": "abc123",
   "allow_order": "abc123",
   "allow_printed_card": "abc123",
   "autocomplete_on_storefront": true,
-  "base_currency_code": "abc123",
-  "base_link_url": "xyz789",
+  "base_currency_code": "xyz789",
+  "base_link_url": "abc123",
   "base_media_url": "abc123",
   "base_static_url": "xyz789",
   "base_url": "abc123",
   "cart_expires_in_days": 123,
-  "cart_gift_wrapping": "abc123",
-  "cart_merge_preference": "xyz789",
+  "cart_gift_wrapping": "xyz789",
+  "cart_merge_preference": "abc123",
   "cart_printed_card": "abc123",
   "cart_summary_display_quantity": 123,
   "catalog_default_sort_by": "xyz789",
   "category_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
-  "category_url_suffix": "xyz789",
+  "category_url_suffix": "abc123",
   "check_money_order_enable_for_specific_countries": false,
-  "check_money_order_enabled": false,
+  "check_money_order_enabled": true,
   "check_money_order_make_check_payable_to": "abc123",
-  "check_money_order_max_order_total": "abc123",
+  "check_money_order_max_order_total": "xyz789",
   "check_money_order_min_order_total": "xyz789",
   "check_money_order_new_order_status": "xyz789",
   "check_money_order_payment_from_specific_countries": "xyz789",
-  "check_money_order_send_check_to": "xyz789",
-  "check_money_order_sort_order": 987,
-  "check_money_order_title": "abc123",
-  "company_credit_enabled": true,
-  "company_enabled": true,
+  "check_money_order_send_check_to": "abc123",
+  "check_money_order_sort_order": 123,
+  "check_money_order_title": "xyz789",
+  "company_credit_enabled": false,
+  "company_enabled": false,
   "configurable_product_image": "ITSELF",
-  "configurable_thumbnail_source": "abc123",
+  "configurable_thumbnail_source": "xyz789",
   "contact_enabled": true,
   "countries_with_required_region": "xyz789",
   "create_account_confirmation": true,
   "customer_access_token_lifetime": 123.45,
   "default_country": "abc123",
-  "default_display_currency_code": "abc123",
-  "display_product_prices_in_catalog": 123,
+  "default_display_currency_code": "xyz789",
+  "display_product_prices_in_catalog": 987,
   "display_shipping_prices": 987,
   "display_state_if_optional": false,
   "enable_multiple_wishlists": "xyz789",
-  "fixed_product_taxes_apply_tax_to_fpt": false,
-  "fixed_product_taxes_display_prices_in_emails": 987,
-  "fixed_product_taxes_display_prices_in_product_lists": 987,
-  "fixed_product_taxes_display_prices_in_sales_modules": 987,
+  "fixed_product_taxes_apply_tax_to_fpt": true,
+  "fixed_product_taxes_display_prices_in_emails": 123,
+  "fixed_product_taxes_display_prices_in_product_lists": 123,
+  "fixed_product_taxes_display_prices_in_sales_modules": 123,
   "fixed_product_taxes_display_prices_on_product_view_page": 123,
-  "fixed_product_taxes_enable": false,
+  "fixed_product_taxes_enable": true,
   "fixed_product_taxes_include_fpt_in_subtotal": true,
-  "graphql_share_customer_group": true,
-  "grid_per_page": 987,
-  "grid_per_page_values": "abc123",
+  "graphql_share_customer_group": false,
+  "grid_per_page": 123,
+  "grid_per_page_values": "xyz789",
   "grouped_product_image": "ITSELF",
-  "is_checkout_agreements_enabled": false,
+  "is_checkout_agreements_enabled": true,
   "is_default_store": true,
   "is_default_store_group": true,
   "is_guest_checkout_enabled": true,
-  "is_negotiable_quote_active": false,
-  "is_one_page_checkout_enabled": false,
-  "is_requisition_list_active": "xyz789",
-  "list_mode": "xyz789",
-  "list_per_page": 987,
-  "list_per_page_values": "xyz789",
+  "is_negotiable_quote_active": true,
+  "is_one_page_checkout_enabled": true,
+  "is_requisition_list_active": "abc123",
+  "list_mode": "abc123",
+  "list_per_page": 123,
+  "list_per_page_values": "abc123",
   "locale": "abc123",
   "magento_reward_general_is_enabled": "abc123",
-  "magento_reward_general_is_enabled_on_front": "abc123",
+  "magento_reward_general_is_enabled_on_front": "xyz789",
   "magento_reward_general_min_points_balance": "abc123",
   "magento_reward_general_publish_history": "abc123",
   "magento_reward_points_invitation_customer": "xyz789",
   "magento_reward_points_invitation_customer_limit": "xyz789",
-  "magento_reward_points_invitation_order": "xyz789",
-  "magento_reward_points_invitation_order_limit": "abc123",
-  "magento_reward_points_newsletter": "abc123",
+  "magento_reward_points_invitation_order": "abc123",
+  "magento_reward_points_invitation_order_limit": "xyz789",
+  "magento_reward_points_newsletter": "xyz789",
   "magento_reward_points_order": "abc123",
-  "magento_reward_points_register": "abc123",
-  "magento_reward_points_review": "abc123",
+  "magento_reward_points_register": "xyz789",
+  "magento_reward_points_review": "xyz789",
   "magento_reward_points_review_limit": "abc123",
-  "magento_wishlist_general_is_enabled": "xyz789",
-  "max_items_in_order_summary": 987,
+  "magento_wishlist_general_is_enabled": "abc123",
+  "max_items_in_order_summary": 123,
   "maximum_number_of_wishlists": "abc123",
-  "minicart_display": false,
+  "minicart_display": true,
   "minicart_max_items": 123,
-  "minimum_password_length": "xyz789",
+  "minimum_password_length": "abc123",
   "newsletter_enabled": true,
   "optional_zip_countries": "xyz789",
   "order_cancellation_enabled": true,
   "order_cancellation_reasons": [CancellationReason],
-  "orders_invoices_credit_memos_display_full_summary": true,
-  "orders_invoices_credit_memos_display_grandtotal": true,
+  "orders_invoices_credit_memos_display_full_summary": false,
+  "orders_invoices_credit_memos_display_grandtotal": false,
   "orders_invoices_credit_memos_display_price": 123,
-  "orders_invoices_credit_memos_display_shipping_amount": 987,
+  "orders_invoices_credit_memos_display_shipping_amount": 123,
   "orders_invoices_credit_memos_display_subtotal": 123,
-  "orders_invoices_credit_memos_display_zero_tax": false,
+  "orders_invoices_credit_memos_display_zero_tax": true,
   "printed_card_priceV2": Money,
   "product_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
-  "product_url_suffix": "abc123",
+  "product_url_suffix": "xyz789",
   "quickorder_active": false,
-  "quote_minimum_amount": 987.65,
+  "quote_minimum_amount": 123.45,
   "quote_minimum_amount_message": "abc123",
   "required_character_classes_number": "abc123",
   "requisition_list_share_link_validity_days": 123,
-  "requisition_list_share_max_recipients": 987,
-  "requisition_list_share_storefront_path": "xyz789",
-  "requisition_list_sharing_enabled": false,
-  "returns_enabled": "xyz789",
-  "root_category_uid": "4",
+  "requisition_list_share_max_recipients": 123,
+  "requisition_list_share_storefront_path": "abc123",
+  "requisition_list_sharing_enabled": true,
+  "returns_enabled": "abc123",
+  "root_category_uid": 4,
   "sales_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
   "sales_gift_wrapping": "abc123",
-  "sales_printed_card": "abc123",
+  "sales_printed_card": "xyz789",
   "secure_base_link_url": "abc123",
   "secure_base_media_url": "xyz789",
-  "secure_base_static_url": "xyz789",
-  "secure_base_url": "xyz789",
+  "secure_base_static_url": "abc123",
+  "secure_base_url": "abc123",
   "share_active_segments": false,
   "share_applied_cart_rule": true,
-  "shopping_assistance_checkbox_title": "abc123",
-  "shopping_assistance_checkbox_tooltip": "abc123",
-  "shopping_assistance_enabled": false,
+  "shopping_assistance_checkbox_title": "xyz789",
+  "shopping_assistance_checkbox_tooltip": "xyz789",
+  "shopping_assistance_enabled": true,
   "shopping_cart_display_full_summary": false,
-  "shopping_cart_display_grand_total": false,
-  "shopping_cart_display_price": 987,
-  "shopping_cart_display_shipping": 987,
-  "shopping_cart_display_subtotal": 987,
+  "shopping_cart_display_grand_total": true,
+  "shopping_cart_display_price": 123,
+  "shopping_cart_display_shipping": 123,
+  "shopping_cart_display_subtotal": 123,
   "shopping_cart_display_tax_gift_wrapping": "DISPLAY_EXCLUDING_TAX",
   "shopping_cart_display_zero_tax": false,
-  "store_code": 4,
-  "store_group_code": 4,
-  "store_group_name": "abc123",
-  "store_name": "xyz789",
-  "store_sort_order": 123,
+  "store_code": "4",
+  "store_group_code": "4",
+  "store_group_name": "xyz789",
+  "store_name": "abc123",
+  "store_sort_order": 987,
   "timezone": "abc123",
   "title_separator": "abc123",
-  "use_store_in_url": false,
-  "website_code": 4,
+  "use_store_in_url": true,
+  "website_code": "4",
   "website_name": "abc123",
-  "weight_unit": "xyz789",
-  "zero_subtotal_enable_for_specific_countries": false,
+  "weight_unit": "abc123",
+  "zero_subtotal_enable_for_specific_countries": true,
   "zero_subtotal_enabled": false,
   "zero_subtotal_new_order_status": "xyz789",
   "zero_subtotal_payment_action": "xyz789",
-  "zero_subtotal_payment_from_specific_countries": "abc123",
-  "zero_subtotal_sort_order": 123,
-  "zero_subtotal_title": "xyz789"
+  "zero_subtotal_payment_from_specific_countries": "xyz789",
+  "zero_subtotal_sort_order": 987,
+  "zero_subtotal_title": "abc123"
 }
 ```
 
@@ -4035,7 +4042,7 @@ The `String` scalar type represents textual data, represented as UTF-8 character
 #### Example
 
 ```json
-"abc123"
+"xyz789"
 ```
 
 <HorizontalLine />
@@ -4095,14 +4102,14 @@ Specifies the quote template properties to update.
 ```json
 {
   "attachments": [NegotiableQuoteCommentAttachmentInput],
-  "comment": "xyz789",
+  "comment": "abc123",
   "max_order_commitment": 123,
-  "min_order_commitment": 987,
-  "name": "xyz789",
+  "min_order_commitment": 123,
+  "name": "abc123",
   "reference_document_links": [
     NegotiableQuoteTemplateReferenceDocumentLinkInput
   ],
-  "template_id": 4
+  "template_id": "4"
 }
 ```
 
@@ -4161,7 +4168,7 @@ Represents the subtree of the categories to retrieve.
 #### Example
 
 ```json
-{"depth": 123, "startLevel": 123}
+{"depth": 987, "startLevel": 123}
 ```
 
 <HorizontalLine />

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-t-z.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-t-z.md
@@ -17,8 +17,8 @@ Contains tax item details.
 ```json
 {
   "amount": Money,
-  "rate": 987.65,
-  "title": "abc123"
+  "rate": 123.45,
+  "title": "xyz789"
 }
 ```
 
@@ -158,8 +158,8 @@ Contains the response to the request to unassign a child company.
 ```json
 {
   "unitName": "xyz789",
-  "storefrontLabel": "xyz789",
-  "pagePlacement": "xyz789",
+  "storefrontLabel": "abc123",
+  "pagePlacement": "abc123",
   "displayNumber": 123,
   "pageType": "xyz789",
   "unitStatus": "abc123",
@@ -326,8 +326,8 @@ Defines updates to a `GiftRegistry` object.
   "dynamic_attributes": [
     GiftRegistryDynamicAttributeInput
   ],
-  "event_name": "abc123",
-  "message": "abc123",
+  "event_name": "xyz789",
+  "message": "xyz789",
   "privacy_settings": "PRIVATE",
   "shipping_address": GiftRegistryShippingAddressInput,
   "status": "ACTIVE"
@@ -353,8 +353,8 @@ Defines updates to an item in a gift registry.
 ```json
 {
   "gift_registry_item_uid": 4,
-  "note": "abc123",
-  "quantity": 987.65
+  "note": "xyz789",
+  "quantity": 123.45
 }
 ```
 
@@ -418,9 +418,9 @@ Defines updates to an existing registrant.
     GiftRegistryDynamicAttributeInput
   ],
   "email": "abc123",
-  "firstname": "abc123",
-  "gift_registry_registrant_uid": 4,
-  "lastname": "abc123"
+  "firstname": "xyz789",
+  "gift_registry_registrant_uid": "4",
+  "lastname": "xyz789"
 }
 ```
 
@@ -478,7 +478,7 @@ Specifies the items to update.
 ```json
 {
   "items": [NegotiableQuoteItemQuantityInput],
-  "quote_uid": "4"
+  "quote_uid": 4
 }
 ```
 
@@ -567,7 +567,7 @@ Defines the changes to be made to an approval rule.
 ```json
 {
   "applies_to": ["4"],
-  "approvers": [4],
+  "approvers": ["4"],
   "condition": CreatePurchaseOrderApprovalRuleConditionInput,
   "description": "abc123",
   "name": "abc123",
@@ -593,7 +593,7 @@ An input object that defines which requistion list characteristics to update.
 
 ```json
 {
-  "description": "xyz789",
+  "description": "abc123",
   "name": "abc123"
 }
 ```
@@ -678,8 +678,8 @@ Contains the name and visibility of an updated wish list.
 
 ```json
 {
-  "name": "abc123",
-  "uid": "4",
+  "name": "xyz789",
+  "uid": 4,
   "visibility": "PUBLIC"
 }
 ```
@@ -702,8 +702,8 @@ Defines the input for returning matching companies the customer is assigned to.
 
 ```json
 {
-  "currentPage": 123,
-  "pageSize": 987,
+  "currentPage": 987,
+  "pageSize": 123,
   "sort": [CompaniesSortInput]
 }
 ```
@@ -746,7 +746,7 @@ Contains details about a failed validation attempt.
 #### Example
 
 ```json
-{"message": "abc123", "type": "NOT_FOUND"}
+{"message": "xyz789", "type": "NOT_FOUND"}
 ```
 
 <HorizontalLine />
@@ -891,7 +891,7 @@ Retrieves the vault configuration
 
 ```json
 {
-  "is_vault_enabled": true,
+  "is_vault_enabled": false,
   "sdk_params": [SDKParams],
   "three_ds_mode": "OFF"
 }
@@ -916,8 +916,8 @@ Vault payment inputs
 
 ```json
 {
-  "payment_source": "abc123",
-  "payments_order_id": "xyz789",
+  "payment_source": "xyz789",
+  "payments_order_id": "abc123",
   "paypal_order_id": "xyz789",
   "public_hash": "xyz789"
 }
@@ -952,14 +952,14 @@ User view history
 | Input Field | Description |
 |-------------|-------------|
 | `date` - [`DateTime`](#datetime) |  |
-| `sku` - [`String!`](#string) |  |
+| `sku` - [`String`](#string) |  |
 
 #### Example
 
 ```json
 {
   "date": "2007-12-03T10:15:30Z",
-  "sku": "abc123"
+  "sku": "xyz789"
 }
 ```
 
@@ -1023,9 +1023,9 @@ An implementation for virtual product cart items.
   "errors": [CartItemError],
   "is_available": false,
   "is_salable": true,
-  "max_qty": 987.65,
+  "max_qty": 123.45,
   "min_qty": 123.45,
-  "not_available_message": "abc123",
+  "not_available_message": "xyz789",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
@@ -1090,9 +1090,9 @@ Defines a virtual product, which is a non-tangible product that does not require
 
 ```json
 {
-  "canonical_url": "xyz789",
+  "canonical_url": "abc123",
   "categories": [CategoryInterface],
-  "country_of_manufacture": "abc123",
+  "country_of_manufacture": "xyz789",
   "crosssell_products": [ProductInterface],
   "custom_attributesV2": ProductCustomAttributes,
   "description": ComplexTextValue,
@@ -1100,36 +1100,36 @@ Defines a virtual product, which is a non-tangible product that does not require
   "gift_wrapping_available": false,
   "gift_wrapping_price": Money,
   "image": ProductImage,
-  "is_returnable": "abc123",
-  "manufacturer": 123,
-  "max_sale_qty": 123.45,
+  "is_returnable": "xyz789",
+  "manufacturer": 987,
+  "max_sale_qty": 987.65,
   "media_gallery": [MediaGalleryInterface],
   "meta_description": "abc123",
-  "meta_keyword": "abc123",
-  "meta_title": "xyz789",
+  "meta_keyword": "xyz789",
+  "meta_title": "abc123",
   "min_sale_qty": 987.65,
   "name": "xyz789",
-  "new_from_date": "xyz789",
-  "new_to_date": "xyz789",
-  "only_x_left_in_stock": 987.65,
+  "new_from_date": "abc123",
+  "new_to_date": "abc123",
+  "only_x_left_in_stock": 123.45,
   "options": [CustomizableOptionInterface],
-  "options_container": "xyz789",
+  "options_container": "abc123",
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
   "product_links": [ProductLinksInterface],
   "quantity": 123.45,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
-  "sku": "abc123",
+  "sku": "xyz789",
   "small_image": ProductImage,
   "special_price": 987.65,
-  "special_to_date": "abc123",
+  "special_to_date": "xyz789",
   "stock_status": "IN_STOCK",
   "swatch_image": "abc123",
   "thumbnail": ProductImage,
-  "uid": 4,
+  "uid": "4",
   "upsell_products": [ProductInterface],
-  "url_key": "xyz789"
+  "url_key": "abc123"
 }
 ```
 
@@ -1155,7 +1155,7 @@ Contains details about virtual products added to a requisition list.
 {
   "customizable_options": [SelectedCustomizableOption],
   "product": ProductInterface,
-  "quantity": 123.45,
+  "quantity": 987.65,
   "sku": "xyz789",
   "uid": "4"
 }
@@ -1209,7 +1209,7 @@ An error encountered while performing operations with WishList.
 ```json
 {
   "code": "PRODUCT_NOT_FOUND",
-  "message": "abc123"
+  "message": "xyz789"
 }
 ```
 
@@ -1257,9 +1257,9 @@ Contains a customer wish list.
   "id": "4",
   "items_count": 123,
   "items_v2": WishlistItems,
-  "name": "xyz789",
+  "name": "abc123",
   "sharing_code": "xyz789",
-  "updated_at": "abc123",
+  "updated_at": "xyz789",
   "visibility": "PUBLIC"
 }
 ```
@@ -1352,10 +1352,10 @@ Defines the items to add to a wish list.
 ```json
 {
   "entered_options": [EnteredOptionInput],
-  "parent_sku": "xyz789",
-  "quantity": 987.65,
-  "selected_options": [4],
-  "sku": "xyz789"
+  "parent_sku": "abc123",
+  "quantity": 123.45,
+  "selected_options": ["4"],
+  "sku": "abc123"
 }
 ```
 
@@ -1395,9 +1395,9 @@ The interface for wish list items.
   "added_at": "xyz789",
   "customizable_options": [SelectedCustomizableOption],
   "description": "abc123",
-  "id": "4",
+  "id": 4,
   "product": ProductInterface,
-  "quantity": 123.45
+  "quantity": 987.65
 }
 ```
 
@@ -1417,10 +1417,7 @@ Specifies the IDs of the items to move and their quantities.
 #### Example
 
 ```json
-{
-  "quantity": 987.65,
-  "wishlist_item_id": "4"
-}
+{"quantity": 123.45, "wishlist_item_id": 4}
 ```
 
 <HorizontalLine />
@@ -1447,7 +1444,7 @@ Defines updates to items in a wish list.
   "entered_options": [EnteredOptionInput],
   "quantity": 123.45,
   "selected_options": ["4"],
-  "wishlist_item_id": 4
+  "wishlist_item_id": "4"
 }
 ```
 


### PR DESCRIPTION
Updates the ACCS REST and GraphQL schemas for the July update.

The updates contain the following changes:

## New REST Endpoints

| Method | Path |
|---|---|
| GET | /V1/custom-email/templates |
| POST | /V1/custom-email/templates |
| GET | /V1/custom-email/templates/{templateId} |
| POST | /V1/orderChain/{id}/cancel |
| GET | /V1/orderChain/{id}/comments |
| POST | /V1/orderChain/{id}/comments |
| POST | /V1/orderChain/{id}/emails |
| POST | /V1/orderChain/{id}/hold |
| GET | /V1/orderChain/{id}/statuses |
| POST | /V1/orderChain/{id}/unhold |
| POST | /V1/orderChain/{orderId}/invoice |
| POST | /V1/orders/{orderId}/edit/start |
| POST | /V1/orders/{orderId}/edit/submit |
| POST | /V1/products/external-media/sync-asset |

## New GraphQL Types

- AuthenticationResult
- GooglePayMode
- LiabilityShift
- NominatedSourceError
- NominatedSourceErrorCode
- OopeCustomFee
- RejectedNomination
- SourceAddress
- SourceAvailability