### PR TITLE
Product alert schema is now available on SCP

### DIFF
--- a/src/pages/graphql/schema/products/mutations/subscribe-product-alert-price.md
+++ b/src/pages/graphql/schema/products/mutations/subscribe-product-alert-price.md
@@ -4,9 +4,11 @@ description: The subscribeProductAlertPrice mutation subscribes the logged-in cu
 
 ---
 
-<Fragment src="../../../../includes/saas-only.md"/>
-
 # subscribeProductAlertPrice mutation
+
+<InlineAlert variant="info" slots="text1"/>
+
+This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
 
 The `subscribeProductAlertPrice` mutation subscribes the logged-in customer to a price drop alert for the specified product. When the product price decreases, the customer receives an email notification.
 

--- a/src/pages/graphql/schema/products/mutations/subscribe-product-alert-price.md
+++ b/src/pages/graphql/schema/products/mutations/subscribe-product-alert-price.md
@@ -6,9 +6,7 @@ description: The subscribeProductAlertPrice mutation subscribes the logged-in cu
 
 # subscribeProductAlertPrice mutation
 
-<InlineAlert variant="info" slots="text1"/>
-
-This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
+<Fragment src="/includes/scp-mutation.md" />
 
 The `subscribeProductAlertPrice` mutation subscribes the logged-in customer to a price drop alert for the specified product. When the product price decreases, the customer receives an email notification.
 

--- a/src/pages/graphql/schema/products/mutations/subscribe-product-alert-stock.md
+++ b/src/pages/graphql/schema/products/mutations/subscribe-product-alert-stock.md
@@ -6,9 +6,7 @@ description: The subscribeProductAlertStock mutation subscribes the logged-in cu
 
 # subscribeProductAlertStock mutation
 
-<InlineAlert variant="info" slots="text1"/>
-
-This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
+<Fragment src="/includes/scp-mutation.md" />
 
 The `subscribeProductAlertStock` mutation subscribes the logged-in customer to a stock availability alert for the specified product. When the product comes back in stock, the customer receives an email notification.
 

--- a/src/pages/graphql/schema/products/mutations/subscribe-product-alert-stock.md
+++ b/src/pages/graphql/schema/products/mutations/subscribe-product-alert-stock.md
@@ -4,9 +4,11 @@ description: The subscribeProductAlertStock mutation subscribes the logged-in cu
 
 ---
 
-<Fragment src="../../../../includes/saas-only.md"/>
-
 # subscribeProductAlertStock mutation
+
+<InlineAlert variant="info" slots="text1"/>
+
+This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
 
 The `subscribeProductAlertStock` mutation subscribes the logged-in customer to a stock availability alert for the specified product. When the product comes back in stock, the customer receives an email notification.
 

--- a/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-price-all.md
+++ b/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-price-all.md
@@ -6,9 +6,7 @@ description: The unsubscribeProductAlertPriceAll mutation removes all price drop
 
 # unsubscribeProductAlertPriceAll mutation
 
-<InlineAlert variant="info" slots="text1"/>
-
-This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
+<Fragment src="/includes/scp-mutation.md" />
 
 The `unsubscribeProductAlertPriceAll` mutation removes all price drop alert subscriptions for the logged-in customer across the current website. After calling this mutation, the customer no longer receives any price alert email notifications.
 

--- a/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-price-all.md
+++ b/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-price-all.md
@@ -4,9 +4,11 @@ description: The unsubscribeProductAlertPriceAll mutation removes all price drop
 
 ---
 
-<Fragment src="../../../../includes/saas-only.md"/>
-
 # unsubscribeProductAlertPriceAll mutation
+
+<InlineAlert variant="info" slots="text1"/>
+
+This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
 
 The `unsubscribeProductAlertPriceAll` mutation removes all price drop alert subscriptions for the logged-in customer across the current website. After calling this mutation, the customer no longer receives any price alert email notifications.
 

--- a/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-price.md
+++ b/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-price.md
@@ -4,9 +4,11 @@ description: The unsubscribeProductAlertPrice mutation removes the logged-in cus
 
 ---
 
-<Fragment src="../../../../includes/saas-only.md"/>
-
 # unsubscribeProductAlertPrice mutation
+
+<InlineAlert variant="info" slots="text1"/>
+
+This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
 
 The `unsubscribeProductAlertPrice` mutation removes the logged-in customer's subscription to a price drop alert for the specified product. After unsubscribing, the customer no longer receives email notifications when the product price decreases.
 

--- a/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-price.md
+++ b/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-price.md
@@ -6,9 +6,7 @@ description: The unsubscribeProductAlertPrice mutation removes the logged-in cus
 
 # unsubscribeProductAlertPrice mutation
 
-<InlineAlert variant="info" slots="text1"/>
-
-This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
+<Fragment src="/includes/scp-mutation.md" />
 
 The `unsubscribeProductAlertPrice` mutation removes the logged-in customer's subscription to a price drop alert for the specified product. After unsubscribing, the customer no longer receives email notifications when the product price decreases.
 

--- a/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-stock-all.md
+++ b/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-stock-all.md
@@ -4,9 +4,11 @@ description: The unsubscribeProductAlertStockAll mutation removes all stock avai
 
 ---
 
-<Fragment src="../../../../includes/saas-only.md"/>
-
 # unsubscribeProductAlertStockAll mutation
+
+<InlineAlert variant="info" slots="text1"/>
+
+This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
 
 The `unsubscribeProductAlertStockAll` mutation removes all stock availability alert subscriptions for the logged-in customer across the current website. After calling this mutation, the customer no longer receives any stock alert email notifications.
 

--- a/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-stock-all.md
+++ b/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-stock-all.md
@@ -6,9 +6,7 @@ description: The unsubscribeProductAlertStockAll mutation removes all stock avai
 
 # unsubscribeProductAlertStockAll mutation
 
-<InlineAlert variant="info" slots="text1"/>
-
-This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
+<Fragment src="/includes/scp-mutation.md" />
 
 The `unsubscribeProductAlertStockAll` mutation removes all stock availability alert subscriptions for the logged-in customer across the current website. After calling this mutation, the customer no longer receives any stock alert email notifications.
 

--- a/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-stock.md
+++ b/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-stock.md
@@ -6,9 +6,7 @@ description: The unsubscribeProductAlertStock mutation removes the logged-in cus
 
 # unsubscribeProductAlertStock mutation
 
-<InlineAlert variant="info" slots="text1"/>
-
-This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
+<Fragment src="/includes/scp-mutation.md" />
 
 The `unsubscribeProductAlertStock` mutation removes the logged-in customer's subscription to a stock availability alert for the specified product. After unsubscribing, the customer no longer receives email notifications when the product comes back in stock.
 

--- a/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-stock.md
+++ b/src/pages/graphql/schema/products/mutations/unsubscribe-product-alert-stock.md
@@ -4,9 +4,11 @@ description: The unsubscribeProductAlertStock mutation removes the logged-in cus
 
 ---
 
-<Fragment src="../../../../includes/saas-only.md"/>
-
 # unsubscribeProductAlertStock mutation
+
+<InlineAlert variant="info" slots="text1"/>
+
+This mutation is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
 
 The `unsubscribeProductAlertStock` mutation removes the logged-in customer's subscription to a stock availability alert for the specified product. After unsubscribing, the customer no longer receives email notifications when the product comes back in stock.
 

--- a/src/pages/graphql/schema/products/queries/is-subscribed-product-alert-price.md
+++ b/src/pages/graphql/schema/products/queries/is-subscribed-product-alert-price.md
@@ -6,9 +6,7 @@ description: The isSubscribedProductAlertPrice query checks whether the logged-i
 
 # isSubscribedProductAlertPrice query
 
-<InlineAlert variant="info" slots="text1"/>
-
-This query is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
+<Fragment src="/includes/scp-query.md" />
 
 The `isSubscribedProductAlertPrice` query checks whether the logged-in customer is subscribed to a price drop alert for the specified product. Use this query to determine whether to show a subscribe or unsubscribe option in the storefront UI.
 

--- a/src/pages/graphql/schema/products/queries/is-subscribed-product-alert-price.md
+++ b/src/pages/graphql/schema/products/queries/is-subscribed-product-alert-price.md
@@ -4,9 +4,11 @@ description: The isSubscribedProductAlertPrice query checks whether the logged-i
 
 ---
 
-<Fragment src="../../../../includes/saas-only.md"/>
-
 # isSubscribedProductAlertPrice query
+
+<InlineAlert variant="info" slots="text1"/>
+
+This query is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
 
 The `isSubscribedProductAlertPrice` query checks whether the logged-in customer is subscribed to a price drop alert for the specified product. Use this query to determine whether to show a subscribe or unsubscribe option in the storefront UI.
 

--- a/src/pages/graphql/schema/products/queries/is-subscribed-product-alert-stock.md
+++ b/src/pages/graphql/schema/products/queries/is-subscribed-product-alert-stock.md
@@ -6,9 +6,7 @@ description: The isSubscribedProductAlertStock query checks whether the logged-i
 
 # isSubscribedProductAlertStock query
 
-<InlineAlert variant="info" slots="text1"/>
-
-This query is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
+<Fragment src="/includes/scp-query.md" />
 
 The `isSubscribedProductAlertStock` query checks whether the logged-in customer is subscribed to a stock availability alert for the specified product. Use this query to determine whether to show a subscribe or unsubscribe option in the storefront UI.
 

--- a/src/pages/graphql/schema/products/queries/is-subscribed-product-alert-stock.md
+++ b/src/pages/graphql/schema/products/queries/is-subscribed-product-alert-stock.md
@@ -4,9 +4,11 @@ description: The isSubscribedProductAlertStock query checks whether the logged-i
 
 ---
 
-<Fragment src="../../../../includes/saas-only.md"/>
-
 # isSubscribedProductAlertStock query
+
+<InlineAlert variant="info" slots="text1"/>
+
+This query is part of the Storefront Compatibility Package and is available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and [Adobe Commerce Optimizer](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) on Adobe Commerce on Cloud or on-premises.
 
 The `isSubscribedProductAlertStock` query checks whether the logged-in customer is subscribed to a stock availability alert for the specified product. Use this query to determine whether to show a subscribe or unsubscribe option in the storefront UI.
 

--- a/src/pages/includes/scp-mutation.md
+++ b/src/pages/includes/scp-mutation.md
@@ -1,0 +1,3 @@
+<InlineAlert variant="info" slots="text1"/>
+
+This mutation is part of the Storefront Compatibility Package. It is available in [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and in Adobe Commerce on Cloud or on-premises projects with [Adobe Commerce Optimizer Connector](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) enabled.

--- a/src/pages/includes/scp-query.md
+++ b/src/pages/includes/scp-query.md
@@ -1,0 +1,3 @@
+<InlineAlert variant="info" slots="text1"/>
+
+This mutation is part of the Storefront Compatibility Package. It is available in [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and in Adobe Commerce on Cloud or on-premises projects with [Adobe Commerce Optimizer Connector](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) enabled.

--- a/src/pages/includes/scp-query.md
+++ b/src/pages/includes/scp-query.md
@@ -1,3 +1,3 @@
 <InlineAlert variant="info" slots="text1"/>
 
-This mutation is part of the Storefront Compatibility Package. It is available in [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and in Adobe Commerce on Cloud or on-premises projects with [Adobe Commerce Optimizer Connector](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) enabled.
+This query is part of the Storefront Compatibility Package. It is available in [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) and in Adobe Commerce on Cloud or on-premises projects with [Adobe Commerce Optimizer Connector](https://experienceleague.adobe.com/en/docs/commerce/aco-optimizer-connector/overview) enabled.


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes the SaaS-only restriction on the product alert GraphQL mutations and queries, replacing it with an inline alert noting that this part of the schema is now available via the Storefront Compatibility Package on Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer (Cloud or on-premises).

## Affected pages

- https://developer.adobe.com/commerce/webapi/graphql/schema/products/mutations/subscribe-product-alert-price/
- https://developer.adobe.com/commerce/webapi/graphql/schema/products/mutations/subscribe-product-alert-stock/
- https://developer.adobe.com/commerce/webapi/graphql/schema/products/mutations/unsubscribe-product-alert-price/
- https://developer.adobe.com/commerce/webapi/graphql/schema/products/mutations/unsubscribe-product-alert-price-all/
- https://developer.adobe.com/commerce/webapi/graphql/schema/products/mutations/unsubscribe-product-alert-stock/
- https://developer.adobe.com/commerce/webapi/graphql/schema/products/mutations/unsubscribe-product-alert-stock-all/
- https://developer.adobe.com/commerce/webapi/graphql/schema/products/queries/is-subscribed-product-alert-price/
- https://developer.adobe.com/commerce/webapi/graphql/schema/products/queries/is-subscribed-product-alert-stock/

