### PR TITLE
Clarify experimental notes

### DIFF
--- a/src/pages/graphql/schema/attributes/mutations/index.md
+++ b/src/pages/graphql/schema/attributes/mutations/index.md
@@ -5,7 +5,7 @@ description: This functionality is automatically available on Adobe Commerce as 
 
 # Custom attribute mutations
 
-<InlineAlert variant="important" slots="text" />
+<InlineAlert variant="warning" slots="text" />
 
 This functionality is automatically available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) (SaaS) projects. Adobe Commerce on-premises and Cloud infrastructure (PaaS) projects can [install separate modules](index.md) to provide this functionality.
 

--- a/src/pages/graphql/schema/products/queries/categories.md
+++ b/src/pages/graphql/schema/products/queries/categories.md
@@ -8,7 +8,7 @@ description: Adobe Commerce as a Cloud Service (SaaS) does not support this cate
 
 # categories query
 
-<InlineAlert variant="important" slots="text" />
+<InlineAlert variant="warning" slots="text" />
 
 Adobe Commerce as a Cloud Service (SaaS) does not support this `categories` query. Use the Catalog Service [`categories` query](../../catalog-service/queries/categories.md) instead. If you are migrating from PaaS to SaaS, you must update your applications to use the Catalog Service query.
 

--- a/src/pages/graphql/schema/products/queries/index.md
+++ b/src/pages/graphql/schema/products/queries/index.md
@@ -18,6 +18,6 @@ This section describes the following queries:
 * [`route`](route.md)
 * [`urlResolver`](url-resolver.md)
 
-<InlineAlert variant="important" slots="text" />
+<InlineAlert variant="warning" slots="text" />
 
 Adobe Commerce as a Cloud Service (SaaS) does not support the `products` or `categories` query. Use the Catalog Service [`products` query](../../catalog-service/queries/products.md) or [categories query](../../catalog-service/queries/categories.md) instead. If you are migrating from PaaS to SaaS, you must update your applications to use the Catalog Service queries.

--- a/src/pages/graphql/schema/products/queries/products.md
+++ b/src/pages/graphql/schema/products/queries/products.md
@@ -8,7 +8,7 @@ description: Adobe Commerce as a Cloud Service (SaaS) does not support this prod
 
 # products query
 
-<InlineAlert variant="important" slots="text" />
+<InlineAlert variant="warning" slots="text" />
 
 Adobe Commerce as a Cloud Service (SaaS) does not support this `products` query. Use the Catalog Service [`products` query](../../catalog-service/queries/products.md) instead. If you are migrating from PaaS to SaaS, you must update your applications to use the Catalog Service query.
 

--- a/src/pages/includes/graphql/custom-attribute-availability.md
+++ b/src/pages/includes/graphql/custom-attribute-availability.md
@@ -1,3 +1,3 @@
-<InlineAlert variant="important" slots="text" />
+<InlineAlert variant="warning" slots="text" />
 
 This mutation is automatically available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) (SaaS) projects. Adobe Commerce on-premises and Cloud infrastructure (PaaS) projects can [install separate modules](../../graphql/schema/attributes/mutations/index.md) to provide this functionality.

--- a/src/pages/rest/modules/custom-attributes.md
+++ b/src/pages/rest/modules/custom-attributes.md
@@ -7,7 +7,7 @@ keywords:
 
 # Custom attributes
 
-<InlineAlert variant="important" slots="text" />
+<InlineAlert variant="warning" slots="text" />
 
 This functionality is automatically available on [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) (SaaS) projects. Adobe Commerce on-premises and Cloud infrastructure (PaaS) projects can [install separate modules](#install-custom-attribute-support) to provide this functionality.
 
@@ -23,7 +23,7 @@ The following sections describe the REST endpoints that support custom attribute
 
 ### Cart
 
-<InlineAlert variant="important" slots="text" />
+<InlineAlert variant="warning" slots="text" />
 
 Adobe Commerce as a Cloud Service does not support REST endpoints that modify the cart on behalf of a customer or guest user. Use the GraphQL [`setCustomAttributesOnCart` mutation](../../graphql/schema/attributes/mutations/set-custom-cart.md) and the [`setCustomAttributesOnCartItem` mutation](../../graphql/schema/attributes/mutations/set-custom-cart-item.md) instead for these types of users. Admin users can use the REST endpoints to set custom attributes on the cart and cart items.
 

--- a/src/pages/rest/saas-integrations/order-management/index.md
+++ b/src/pages/rest/saas-integrations/order-management/index.md
@@ -18,9 +18,9 @@ These two capabilities work together: editing an order produces a chain of linke
 
 When you edit an order, Commerce cancels the original order and creates a new child order that is linked to its predecessor by the original order's increment ID. Across multiple edits, these orders form an order chain. The order chain endpoints let integrations act on an order using its ID and automatically resolve the operation across the full chain of edited orders, so you do not have to track the latest child order yourself.
 
-<InlineAlert variant="important" slots="text" />
+<InlineAlert variant="warning" slots="text" />
 
-This feature is experimental and must be enabled by Adobe. To request access, contact your Adobe Commerce Customer Success Manager or create a support ticket.
+This feature is experimental and is disabled by default. This feature is subject to change based on future development. To request access, contact your Adobe Commerce Customer Success Manager or create a support ticket.
 
 The `orderChain` endpoints extend the standard order management endpoints, so each request and response body matches its standard `/V1/order/{id}/...` counterpart.
 
@@ -217,9 +217,9 @@ GET /V1/invoices?searchCriteria[filterGroups][0][filters][0][field]=order_origin
 
 The following REST endpoints replicate the Commerce Admin **Edit Order** feature, allowing integrations to edit an existing order programmatically. Editing an order copies it into a new cart, then submits the modified cart as a new order that replaces the original.
 
-<InlineAlert variant="important" slots="text" />
+<InlineAlert variant="warning" slots="text" />
 
-This feature is disabled by default and must be enabled by Adobe. To request access, contact your Adobe Commerce Customer Success Manager or create a support ticket.
+This feature is experimental and is disabled by default. This feature is subject to change based on future development. To request access, contact your Adobe Commerce Customer Success Manager or create a support ticket.
 
 | Method | Endpoint | Description |
 | --- | --- | --- |


### PR DESCRIPTION
This PR makes the notes on experimental features more explicit based on dev feedback.

I also fixed a few notes using `variant="important"` which is not demonstrated by the aio-theme: https://github.com/adobe/aio-theme?tab=readme-ov-file#inlinealert-block-updated-2022-06-08 