### PR TITLE
USF-4290: document search filter on customer.orders

### DIFF
--- a/src/pages/graphql/schema/customer/queries/customer.md
+++ b/src/pages/graphql/schema/customer/queries/customer.md
@@ -592,6 +592,60 @@ These topics contain examples with fragments and provide even more details:
 }
 ```
 
+### Search a customer's order history
+
+The following example uses the `search` filter to return orders matching a term against the order number or an item's product name or SKU. `search` is combined with other filters, such as `status`, using AND logic. The matched item is included in the response to show why the order matched the search term.
+
+**Request:**
+
+```graphql
+{
+  customer {
+    orders(filter: {search: "shirt", status: {eq: "complete"}}) {
+      total_count
+      items {
+        id
+        number
+        order_date
+        status
+        items {
+          product_name
+          product_sku
+        }
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "customer": {
+      "orders": {
+        "total_count": 1,
+        "items": [
+          {
+            "id": "MQ==",
+            "number": "000000001",
+            "order_date": "2020-11-14 22:25:48",
+            "status": "Complete",
+            "items": [
+              {
+                "product_name": "Aria Flannel Shirt",
+                "product_sku": "MS12-M-Blue"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
 ### Retrieve the store credit history
 
 The following example returns the store credit history for the logged-in user.

--- a/src/pages/graphql/schema/customer/queries/customer.md
+++ b/src/pages/graphql/schema/customer/queries/customer.md
@@ -594,6 +594,8 @@ These topics contain examples with fragments and provide even more details:
 
 ### Search a customer's order history
 
+<Fragment src="../includes/saas-only.md"/>
+
 The following example uses the `search` filter to return orders matching a term against the order number or an item's product name or SKU. `search` is combined with other filters, such as `status`, using AND logic. The matched item is included in the response to show why the order matched the search term.
 
 **Request:**


### PR DESCRIPTION
## Purpose of this pull request

Documents the new optional `search` field on `CustomerOrdersFilterInput`, added via the Storefront Compatibility Package (SCP 4.7/4.8/4.9), that lets a signed-in customer search their order history by order number, product name, or SKU.

Related ticket: [USF-4290](https://jira.corp.adobe.com/browse/USF-4290)

Reference: [GSUSA - Customer Order History Search](https://wiki.corp.adobe.com/spaces/ACCSS/pages/3984503377/GSUSA+-+Customer+Order+History+Search)

Related PRs:

- SCP 4.8: https://github.com/magento-commerce/storefront-compatibility/pull/340
- SCP 4.7: https://github.com/magento-commerce/storefront-compatibility/pull/346
- SCP 4.9: https://github.com/magento-commerce/storefront-compatibility/pull/347

**Changed page:**

- Added a "Search a customer's order history" example to the `customer` query page, alongside the existing filter examples.

## Affected pages

- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer/

## Links to Magento Open Source code

N/A — SCP-only change (storefront-compatibility repo), not yet released. This PR documents the field ahead of release; do not merge before the SCP 4.7/4.8/4.9 packages ship.