### PR TITLE
Clearly reference Catalog Service User Guide from the GraphQL schema reference

### DIFF
--- a/src/pages/graphql/schema/catalog-service/index.md
+++ b/src/pages/graphql/schema/catalog-service/index.md
@@ -8,7 +8,7 @@ keywords:
 
 # Catalog Service for Adobe Commerce
 
-The Catalog Service for Adobe Commerce extension contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the [core GraphQL schema](../index.md). This documentation describes the graphQL schema and provides API reference documentation. For information about the architecture, implementation, and use of the Catalog Services, see the [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview). 
+The Catalog Service for Adobe Commerce extension contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the [core GraphQL schema](../index.md). This documentation describes the graphQL schema and provides API reference documentation. For information about the architecture, implementation, and use of the Catalog Services, see the [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview).
 
 The queries in the Catalog Service schema allow Commerce merchants to quickly and fully render product-related content on the storefront, including product detail pages and product list pages.
 
@@ -17,4 +17,3 @@ You can optionally implement [API Mesh for Adobe Developer App Builder](https://
 ## Related topics
 
 - [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview)–Learn about the Catalog Service architecture, implementation, and how to use the service.
-

--- a/src/pages/graphql/schema/catalog-service/index.md
+++ b/src/pages/graphql/schema/catalog-service/index.md
@@ -8,7 +8,7 @@ keywords:
 
 # Catalog Service for Adobe Commerce
 
-The Catalog Service for Adobe Commerce extension contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the [core GraphQL schema](../index.md). This documentation describes the graphQL schema and provides API reference documentation. For information about the architecture, implementation, and use of the Catalog Services, see the [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview).
+The Catalog Service for Adobe Commerce contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the [core GraphQL schema](../index.md). This documentation describes the graphQL schema and provides API reference documentation. For information about the architecture, implementation, and use of the Catalog Services, see the [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview).
 
 The queries in the Catalog Service schema allow Commerce merchants to quickly and fully render product-related content on the storefront, including product detail pages and product list pages.
 

--- a/src/pages/graphql/schema/catalog-service/index.md
+++ b/src/pages/graphql/schema/catalog-service/index.md
@@ -6,14 +6,14 @@ keywords:
   - Services
 ---
 
-# Catalog Service for Adobe Commerce
+# Catalog Service GraphQL Schema for Adobe Commerce
 
-The Catalog Service for Adobe Commerce contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the [core GraphQL schema](../index.md). This documentation describes the graphQL schema and provides API reference documentation. For information about the architecture, implementation, and use of the Catalog Services, see the [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview).
-
-The queries in the Catalog Service schema allow Commerce merchants to quickly and fully render product-related content on the storefront, including product detail pages and product list pages.
+The Catalog Service extension for Adobe Commerce contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the built-in GraphQL functionality provided in Adobe Commerce and Magento Open Source. The queries in this schema allow Commerce merchants to quickly and fully render product-related content on the storefront, including product detail pages and product list pages.
 
 You can optionally implement [API Mesh for Adobe Developer App Builder](https://developer.adobe.com/graphql-mesh-gateway/) to integrate the core and Catalog Service GraphQL schemas with private and third-party APIs, as well as other software interfaces. The mesh can be configured to ensure that calls routed to each endpoint contain the correct authorization information in the headers.
 
-## Related topics
+For instructions on how to install, implement, and use the Catalog Service, see the [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview).
 
-- [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview)–Learn about the Catalog Service architecture, implementation, and how to use the service.
+>[!NOTE]
+>
+>If your Commerce instance uses Live Search or Product Recommendations, the Catalog Service is installed and updated automatically when you onboard or update those services. If you are using Adobe Commerce as a Cloud Service, the latest version of the Catalog Service metapackage is available in your environment. To begin using the service, see [Getting started with the Catalog Service](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/get-started).

--- a/src/pages/graphql/schema/catalog-service/index.md
+++ b/src/pages/graphql/schema/catalog-service/index.md
@@ -8,8 +8,13 @@ keywords:
 
 # Catalog Service for Adobe Commerce
 
-The Catalog Service for Adobe Commerce extension contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the [core GraphQL schema](../index.md). The queries in this schema allow Commerce merchants to quickly and fully render product-related content on the storefront, including product detail pages and product list pages.
+The Catalog Service for Adobe Commerce extension contributes to a services-only GraphQL schema that contains queries that return specialized catalog data that is not available in the [core GraphQL schema](../index.md). This documentation describes the graphQL schema and provides API reference documentation. For information about the architecture, implementation, and use of the Catalog Services, see the [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview). 
+
+The queries in the Catalog Service schema allow Commerce merchants to quickly and fully render product-related content on the storefront, including product detail pages and product list pages.
 
 You can optionally implement [API Mesh for Adobe Developer App Builder](https://developer.adobe.com/graphql-mesh-gateway/) to integrate the core and Catalog Service GraphQL schemas with private and third-party APIs, as well as other software interfaces. The mesh can be configured to ensure that calls routed to each endpoint contain the correct authorization information in the headers.
 
-The [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview) describes the architecture and implementation of this product.
+## Related topics
+
+- [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview)–Learn about the Catalog Service architecture, implementation, and how to use the service.
+

--- a/src/pages/graphql/schema/live-search/index.md
+++ b/src/pages/graphql/schema/live-search/index.md
@@ -1,6 +1,7 @@
 ---
 title: Live Search
-description: Learn how Live Search implements GraphQL.
+description: Explore the Live Search GraphQL schema, learn how to query catalog data through its endpoint, test requests, and troubleshoot common error codes.
+
 keywords:
   - GraphQL
   - Services

--- a/src/pages/graphql/schema/live-search/index.md
+++ b/src/pages/graphql/schema/live-search/index.md
@@ -7,7 +7,7 @@ keywords:
   - Search
 ---
 
-# Live Search
+# Live Search GraphQL Schema Reference
 
 Live Search is a set of standalone packages for Adobe Commerce that replaces the standard search capabilities. It provides GraphQL functionality that is currently separate from the built-in GraphQL functionality provided in Adobe Commerce and Magento Open Source. Live Search GraphQL requires connecting to a different endpoint and specifying a different set of HTTP headers.
 

--- a/src/pages/graphql/schema/live-search/index.md
+++ b/src/pages/graphql/schema/live-search/index.md
@@ -17,7 +17,7 @@ You can connect to the Live Search GraphQL endpoint to test sample queries using
 
 -  Through a standalone version of GraphQL Playground, or any other IDE, such as GraphiQL or Postman. In these applications you must specify the endpoint URL and provide a set of HTTP headers for each call.
 
-For instructions on how to install and implement this product, see [Introduction to Live Search](https://experienceleague.adobe.com/en/docs/commerce/live-search/overview).
+For instructions on how to install, implement, and use the Live Search service, see [Introduction to Live Search](https://experienceleague.adobe.com/en/docs/commerce/live-search/overview).
 
 ## Error Codes
 

--- a/src/pages/graphql/schema/product-recommendations/index.md
+++ b/src/pages/graphql/schema/product-recommendations/index.md
@@ -6,7 +6,7 @@ keywords:
   - Services
 ---
 
-# Product Recommendations
+# Product Recommendations GraphQL Schema Reference
 
 Product Recommendations is a service that suggests products based on the browsing patterns of other shoppers. Product recommendations are surfaced on the storefront as units with labels, such as "Customers who viewed this product also viewed" or "Customers who bought this product also bought". You can create, manage, and deploy recommendations across your store views directly from the Adobe Commerce Admin.
 

--- a/src/pages/graphql/schema/product-recommendations/index.md
+++ b/src/pages/graphql/schema/product-recommendations/index.md
@@ -1,6 +1,6 @@
 ---
 title: Product Recommendations
-description: Learn how Product Recommendations implements GraphQL.
+description: Explore the Product Recommendations GraphQL schema. Learn how to query catalog data through its endpoint, test requests, and troubleshoot common error codes.
 keywords:
   - GraphQL
   - Services
@@ -8,8 +8,8 @@ keywords:
 
 # Product Recommendations GraphQL Schema Reference
 
-Product Recommendations is a service that suggests products based on the browsing patterns of other shoppers. Product recommendations are surfaced on the storefront as units with labels, such as "Customers who viewed this product also viewed" or "Customers who bought this product also bought". You can create, manage, and deploy recommendations across your store views directly from the Adobe Commerce Admin.
+The Product Recommendations service suggests products based on the browsing patterns of other shoppers. Product recommendations are surfaced on the storefront as units with labels, such as "Customers who viewed this product also viewed" or "Customers who bought this product also bought". You can create, manage, and deploy recommendations across your store views directly from the Adobe Commerce Admin. For headless storefronts, use the Product Recommendations GraphQL query to retrieve recommendation blocks for a given SKU and render them in your storefront.
 
 The `recommendations` query returns recommended products based on the provided SKU.
 
-Read more in the [Introduction to Product Recommendations](https://experienceleague.adobe.com/en/docs/commerce/product-recommendations/overview).
+For instructions on how to install, implement, and use the Product Recommendations service, see [Introduction to Product Recommendations](https://experienceleague.adobe.com/en/docs/commerce/product-recommendations/overview).


### PR DESCRIPTION
## Purpose of this pull request

Update the Catalog Service graphQL reference to clearly reference the Catalog Service Guide for information about service architecture, implementation, and usage.

## Affected pages

https://experienceleague.adobe.com/en/docs/commerce/catalog-service/overview