### PR TITLE
SCP Example for persistent cart/wishlist

### DIFF
--- a/src/pages/graphql/schema/store/queries/store-config.md
+++ b/src/pages/graphql/schema/store/queries/store-config.md
@@ -225,6 +225,8 @@ The following query returns information about the store's customer configuration
 
 ### Query a store's persistent cart and account sharing configuration
 
+<Fragment src="../../includes/saas-only.md"/>
+
 The following query returns the store's persistent shopping cart settings (**Stores** > Settings > **Configuration** > **Customers** > **Persistent Shopping Cart**) and the account sharing scope (**Stores** > Settings > **Configuration** > **Customers** > **Customer Configuration** > **Account Sharing Options** > **Share Customer Accounts**).
 
 The `share_customer_accounts_scope` field returns `0` when customer accounts are shared globally across all stores and `1` when accounts are scoped per website.

--- a/src/pages/graphql/schema/store/queries/store-config.md
+++ b/src/pages/graphql/schema/store/queries/store-config.md
@@ -223,6 +223,40 @@ The following query returns information about the store's customer configuration
 }
 ```
 
+### Query a store's persistent cart and account sharing configuration
+
+The following query returns the store's persistent shopping cart settings (**Stores** > Settings > **Configuration** > **Customers** > **Persistent Shopping Cart**) and the account sharing scope (**Stores** > Settings > **Configuration** > **Customers** > **Customer Configuration** > **Account Sharing Options** > **Share Customer Accounts**).
+
+The `share_customer_accounts_scope` field returns `0` when customer accounts are shared globally across all stores and `1` when accounts are scoped per website.
+
+**Request:**
+
+```graphql
+{
+    storeConfig {
+        persistent_enabled
+        persistent_shopping_cart
+        persistent_options_wishlist
+        share_customer_accounts_scope
+    }
+}
+```
+
+**Response:**
+
+```json
+{
+  "data": {
+    "storeConfig": {
+      "persistent_enabled": true,
+      "persistent_shopping_cart": true,
+      "persistent_options_wishlist": false,
+      "share_customer_accounts_scope": 0
+    }
+  }
+}
+```
+
 ### Query a store's access token expiration configuration
 
 The following query returns the value of the **Stores** > Settings > **Configuration** > **Services** > **OAuth** > **Access Token Expiration** > **Customer Token Lifetime (hours)** field.


### PR DESCRIPTION
## Purpose of this pull request

Documents four new `StoreConfig` fields exposed by the Storefront Compatibility Package for the wishlist drop-in: `persistent_enabled`, `persistent_shopping_cart`, `persistent_options_wishlist`, and `share_customer_accounts_scope`. Adds a `storeConfig` query example covering the persistent shopping cart settings and the customer account sharing scope.

## Affected pages

- https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/#query-a-stores-persistent-cart-and-account-sharing-configuration

### What's New highlights

whatsnew
Added a [storeConfig query example](https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/#query-a-stores-persistent-cart-and-account-sharing-configuration) documenting the new persistent shopping cart and customer account sharing fields (`persistent_enabled`, `persistent_shopping_cart`, `persistent_options_wishlist`, `share_customer_accounts_scope`).
