### PR TITLE
Reference sections

### DIFF
--- a/src/pages/graphql/schema/b2b/company/mutations/assign-child-company.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/assign-child-company.md
@@ -23,9 +23,9 @@ The `assignChildCompany` mutation allows company administrators to assign a chil
 }
 ```
 
-[//]: # (## Reference)
-[//]: # ()
-[//]: # (The [`assignChildCompany`]&#40;/reference/graphql/saas/mutations.md#assignchildcompany&#41; reference provides detailed information about the types and fields defined in this mutation.)
+## Reference
+
+The [`assignChildCompany`](/reference/graphql/saas/mutations.md#assignchildcompany) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/create-address.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/create-address.md
@@ -27,6 +27,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`createCompanyAddress`](/reference/graphql/saas/mutations.md#createcompanyaddress) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 ### Create a company address (type: billing)

--- a/src/pages/graphql/schema/b2b/company/mutations/delete-address.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/delete-address.md
@@ -27,6 +27,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`deleteCompanyAddress`](/reference/graphql/saas/mutations.md#deletecompanyaddress) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 ### Delete a company address

--- a/src/pages/graphql/schema/b2b/company/mutations/set-default-address.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/set-default-address.md
@@ -27,6 +27,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`setDefaultCompanyAddress`](/reference/graphql/saas/mutations.md#setdefaultcompanyaddress) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 ### Set a company address as default (BILLING/SHIPPING)

--- a/src/pages/graphql/schema/b2b/company/mutations/unassign-child-company.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/unassign-child-company.md
@@ -23,9 +23,9 @@ The `unassignChildCompany` mutation allows company administrators to unassign a 
 }
 ```
 
-[//]: # (## Reference)
-[//]: # ()
-[//]: # (The [`unassignChildCompany`]&#40;/reference/graphql/saas/mutations.md#unassignchildcompany&#41; reference provides detailed information about the types and fields defined in this mutation.)
+## Reference
+
+The [`unassignChildCompany`](/reference/graphql/saas/mutations.md#unassignchildcompany) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/company/mutations/update-address.md
+++ b/src/pages/graphql/schema/b2b/company/mutations/update-address.md
@@ -28,6 +28,10 @@ mutation {
 }
 ```
 
+## Reference
+
+The [`updateCompanyAddress`](/reference/graphql/saas/mutations.md#updatecompanyaddress) reference provides detailed information about the types and fields defined in this mutation.
+
 ## Example usage
 
 ### Update a company address

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/import-shared-requisition-list.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/import-shared-requisition-list.md
@@ -23,9 +23,9 @@ The `importSharedRequisitionList` mutation allows recipients within the same com
 }
 ```
 
-[//]: # (## Reference)
-[//]: # ()
-[//]: # (The [`importSharedRequisitionList`]&#40;/reference/graphql/saas/mutations.md#importsharedrequisitionlist&#41; reference provides detailed information about the types and fields defined in this mutation.)
+## Reference
+
+The [`importSharedRequisitionList`](/reference/graphql/saas/mutations.md#importsharedrequisitionlist) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/share-requisition-list-by-email.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/share-requisition-list-by-email.md
@@ -23,9 +23,9 @@ The `shareRequisitionListByEmail` mutation enables B2B customers to share a requ
 }
 ```
 
-[//]: # (## Reference)
-[//]: # ()
-[//]: # (The [`shareRequisitionListByEmail`]&#40;/reference/graphql/saas/mutations.md#sharerequisitionlistbyemail&#41; reference provides detailed information about the types and fields defined in this mutation.)
+## Reference
+
+The [`shareRequisitionListByEmail`](/reference/graphql/saas/mutations.md#sharerequisitionlistbyemail) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/mutations/share-requisition-list-by-token.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/mutations/share-requisition-list-by-token.md
@@ -23,9 +23,9 @@ The `shareRequisitionListByToken` mutation enables B2B customers to share a requ
 }
 ```
 
-[//]: # (## Reference)
-[//]: # ()
-[//]: # (The [`shareRequisitionListByToken`]&#40;/reference/graphql/saas/mutations.md#sharerequisitionlistbytoken&#41; reference provides detailed information about the types and fields defined in this mutation.)
+## Reference
+
+The [`shareRequisitionListByToken`](/reference/graphql/saas/mutations.md#sharerequisitionlistbytoken) reference provides detailed information about the types and fields defined in this mutation.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/b2b/requisition-list/queries/shared-requisition-list.md
+++ b/src/pages/graphql/schema/b2b/requisition-list/queries/shared-requisition-list.md
@@ -23,9 +23,9 @@ The `sharedRequisitionList` query uses a token to retrieve a shared requisition 
 }
 ```
 
-[//]: # (## Reference)
-[//]: # ()
-[//]: # (The [`sharedRequisitionList`]&#40;/reference/graphql/saas/index.md#sharedrequisitionlist&#41; reference provides detailed information about the types and fields defined in this query.)
+## Reference
+
+The [`sharedRequisitionList`](/reference/graphql/saas/index.md#sharedrequisitionlist) reference provides detailed information about the types and fields defined in this query.
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/select-free-gift.md
+++ b/src/pages/graphql/schema/cart/mutations/select-free-gift.md
@@ -20,13 +20,16 @@ After the shopper selects a gift, the mutation adds the product to the cart as a
 
 `mutation: {selectFreeGiftForCart(input: SelectFreeGiftForCartInput!): SelectFreeGiftForCartOutput}`
 
-\<!-- ## Reference
+## Reference
 
+The [`selectFreeGiftForCart`](/reference/graphql/saas/index.md#selectfreegiftforcart) reference provides detailed information about the types and fields defined in this query.
+
+\<!-- Available in PaaS on 2.4.10
 The `selectFreeGiftForCart` reference provides detailed information about the types and fields defined in this mutation.
 
-* [Adobe Commerce as a Cloud Service](/reference/graphql/saas/mutations.md#selectFreeGiftForCart)
+* [Adobe Commerce as a Cloud Service](/reference/graphql/saas/mutations.md#selectfreegiftforcart)
 
-* [On-Premises/Cloud](/reference/graphql/latest/mutations.md#selectFreeGiftForCart) --\>
+* [On-Premises/Cloud](/reference/graphql/latest/mutations.md#selectfreegiftforcart) --\>
 
 ## Example usage
 

--- a/src/pages/graphql/schema/cart/mutations/select-free-gift.md
+++ b/src/pages/graphql/schema/cart/mutations/select-free-gift.md
@@ -22,7 +22,7 @@ After the shopper selects a gift, the mutation adds the product to the cart as a
 
 ## Reference
 
-The [`selectFreeGiftForCart`](/reference/graphql/saas/index.md#selectfreegiftforcart) reference provides detailed information about the types and fields defined in this query.
+The [`selectFreeGiftForCart`](/reference/graphql/saas/index.md#selectfreegiftforcart) reference provides detailed information about the types and fields defined in this mutation.
 
 \<!-- Available in PaaS on 2.4.10
 The `selectFreeGiftForCart` reference provides detailed information about the types and fields defined in this mutation.


### PR DESCRIPTION
## Purpose of this pull request

Adds or uncomments missing `## Reference` sections across several B2B mutations/queries (company address management, requisition list sharing) and the new `selectFreeGiftForCart` mutation, so every schema page links to the SaaS/on-prem type reference.

## Affected pages

- `/graphql/schema/b2b/company/mutations/assign-child-company.md`
- `/graphql/schema/b2b/company/mutations/unassign-child-company.md`
- `/graphql/schema/b2b/company/mutations/create-address.md`
- `/graphql/schema/b2b/company/mutations/update-address.md`
- `/graphql/schema/b2b/company/mutations/delete-address.md`
- `/graphql/schema/b2b/company/mutations/set-default-address.md`
- `/graphql/schema/b2b/requisition-list/mutations/share-requisition-list-by-token.md`
- `/graphql/schema/b2b/requisition-list/mutations/share-requisition-list-by-email.md`
- `/graphql/schema/b2b/requisition-list/mutations/import-shared-requisition-list.md`
- `/graphql/schema/b2b/requisition-list/queries/shared-requisition-list.md`
- `src/pages/graphql/schema/cart/mutations/select-free-gift.md`
