### PR TITLE
update schemas for September release - ACCS

### DIFF
--- a/spectaql/schema_saas.json
+++ b/spectaql/schema_saas.json
@@ -3048,6 +3048,22 @@
             "deprecationReason": null
           },
           {
+            "name": "types",
+            "description": "Array of image types. It can have the following values: image, small_image, thumbnail.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "url",
             "description": "The URL of the product image or video.",
             "args": [],
@@ -3120,6 +3136,22 @@
               "kind": "SCALAR",
               "name": "Int",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "types",
+            "description": "Array of image types. It can have the following values: image, small_image, thumbnail.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4642,6 +4674,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "GiftCartAttributeValue",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "ProductAttributeFile",
             "ofType": null
           }
@@ -4694,6 +4731,105 @@
           {
             "name": "symbol",
             "description": "Currency symbol, for example $.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AvailableFreeGift",
+        "description": "A free-gift cart price rule that has not yet had a gift added because the customer must choose between multiple SKUs and/or product options.",
+        "fields": [
+          {
+            "name": "available_skus",
+            "description": "SKUs configured on the rule that resolved to a salable product.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "gift_qty",
+            "description": "Quantity of the chosen gift product to be added.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "products",
+            "description": "Product details for the configured gift SKUs (parents for configurable/bundle), so the storefront picker can render without an extra round-trip.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "ProductInterface",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rule_id",
+            "description": "Identifier of the cart price rule offering the gift.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rule_label",
+            "description": "Storefront-facing label for this rule (per-store label when set, otherwise description or a default).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -4989,6 +5125,16 @@
             "defaultValue": null
           },
           {
+            "name": "company_address_id",
+            "description": "UID of a company address to use for billing.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "customer_address_id",
             "description": "An ID from the customer's address book that uniquely identifies the address to be used for billing.",
             "type": {
@@ -5136,6 +5282,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "company_address_id",
+            "description": "UID of the company address referenced by this cart address, if any.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
               "ofType": null
             },
             "isDeprecated": false,
@@ -5671,6 +5829,22 @@
             "deprecationReason": "Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration."
           },
           {
+            "name": "is_free_gift",
+            "description": "True if this line item was added by a Free Gift cart price rule.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "is_salable",
             "description": "True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed.",
             "args": [],
@@ -5706,6 +5880,38 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source",
+            "description": "The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors).",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SourceAvailability",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source_errors",
+            "description": "Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "NominatedSourceError",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6496,6 +6702,18 @@
                 "name": "OrderItemOption",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "free_gift_label",
+            "description": "The discount rule label for free gift items. Null if the item is not a free gift.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8388,6 +8606,26 @@
             "deprecationReason": null
           },
           {
+            "name": "available_free_gifts",
+            "description": "Free-gift rules applied to the cart that still need a SKU selection from the customer.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AvailableFreeGift",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "available_gift_wrappings",
             "description": "The list of available gift wrapping options for the cart.",
             "args": [],
@@ -8499,6 +8737,22 @@
               "kind": "OBJECT",
               "name": "GiftWrapping",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "has_available_free_gifts",
+            "description": "True if any applied free-gift rule requires the customer to choose a SKU before placing the order.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8907,9 +9161,13 @@
             "name": "telephone",
             "description": "The telephone number for the billing or shipping address.",
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null
           },
@@ -8956,6 +9214,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "company_address_id",
+            "description": "UID of the company address referenced by this cart address, if any.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
               "ofType": null
             },
             "isDeprecated": false,
@@ -9595,6 +9865,22 @@
             "deprecationReason": "Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration."
           },
           {
+            "name": "is_free_gift",
+            "description": "True if this line item was added by a Free Gift cart price rule.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "is_salable",
             "description": "True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed.",
             "args": [],
@@ -9630,6 +9916,38 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source",
+            "description": "The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors).",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SourceAvailability",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source_errors",
+            "description": "Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "NominatedSourceError",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -11436,6 +11754,22 @@
             "deprecationReason": null
           },
           {
+            "name": "attributes",
+            "description": "A list of merchant-defined attributes designated for the storefront.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CategoryViewAttribute",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "children",
             "description": "The direct child categories for building nested navigation menus.",
             "args": [],
@@ -11535,6 +11869,37 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "attributes",
+            "description": "A list of merchant-defined attributes designated for the storefront.",
+            "args": [
+              {
+                "name": "names",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CategoryViewAttribute",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -11545,6 +11910,45 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CategorySortInput",
+        "description": "The input used for sorting the categories based on an attribute, including the direction order.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "attribute",
+            "description": "The attribute value. For example: 'color', 'size' or 'material'.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "direction",
+            "description": "The sorting direction that can be either ascending or descending. For example: 'ASC' or 'DESC'.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "SortDirectionEnum",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -11915,6 +12319,22 @@
             "deprecationReason": null
           },
           {
+            "name": "attributes",
+            "description": "A list of merchant-defined attributes designated for the storefront.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CategoryViewAttribute",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "description",
             "description": "A detailed description of the category.",
             "args": [],
@@ -12237,6 +12657,73 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "CategoryViewAttribute",
+        "description": "A container for customer-defined attributes that are displayed the storefront.",
+        "fields": [
+          {
+            "name": "name",
+            "description": "Name of an attribute code. For example, `color`, `size` or `material`.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": "Label of the attribute.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataType",
+            "description": "Data type of the attribute. For example 'TEXT', 'INTEGER' etc.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": "Attribute value, arbitrary of type. For example, `red`, `blue` or `green`.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INTERFACE",
         "name": "CategoryViewInterface",
         "description": "Base interface defining essential category fields shared across all category views.",
@@ -12404,6 +12891,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "attributes",
+            "description": "A list of merchant-defined attributes designated for the storefront.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CategoryViewAttribute",
                 "ofType": null
               }
             },
@@ -12676,6 +13179,148 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ClearCartError",
+        "description": "Contains details about errors encountered when a customer clear cart.",
+        "fields": [
+          {
+            "name": "message",
+            "description": "A localized error message",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "A cart-specific error type.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ClearCartErrorType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ClearCartErrorType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "NOT_FOUND",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNAUTHORISED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INACTIVE",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UNDEFINED",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ClearCartInput",
+        "description": "Assigns a specific `cart_id` to the empty cart.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "uid",
+            "description": "The unique ID of a `Cart` object.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ClearCartOutput",
+        "description": "Output of the request to clear the customer cart.",
+        "fields": [
+          {
+            "name": "cart",
+            "description": "The cart after clear cart items.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Cart",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errors",
+            "description": "An array of errors encountered while clearing the cart item",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ClearCartError",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -13074,6 +13719,43 @@
             "deprecationReason": null
           },
           {
+            "name": "addresses",
+            "description": "A paginated list of company addresses assigned to the company.",
+            "args": [
+              {
+                "name": "pageSize",
+                "description": "The maximum number of results to return at once. The default value is 20.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "20"
+              },
+              {
+                "name": "currentPage",
+                "description": "The page of results to return. The default value is 1.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "1"
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CompanyAddresses",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "available_payment_methods",
             "description": "Available payment methods for the company with proper B2B configuration and company-specific filtering.",
             "args": [],
@@ -13113,6 +13795,22 @@
               "kind": "OBJECT",
               "name": "Customer",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "config",
+            "description": "Company address book configuration settings.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CompanyConfig",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -13192,6 +13890,30 @@
                 "name": "CustomAttribute",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "default_billing_address",
+            "description": "The company's default billing address, if set.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CompanyAddress",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "default_shipping_address",
+            "description": "The company's default shipping address, if set.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CompanyAddress",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -13593,6 +14315,818 @@
       },
       {
         "kind": "OBJECT",
+        "name": "CompanyAddress",
+        "description": "",
+        "fields": [
+          {
+            "name": "address_type",
+            "description": "The address type: BILLING or SHIPPING.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CompanyAddressTypeEnum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "city",
+            "description": "The city.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "company",
+            "description": "The company name.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "company_id",
+            "description": "The unique ID of the company that owns the address.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "country_code",
+            "description": "The two-letter country code representing the company's country.",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "CountryCodeEnum",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "custom_attributes",
+            "description": null,
+            "args": [
+              {
+                "name": "attributeCodes",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "AttributeValueInterface",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "extension_attributes",
+            "description": "Extension attributes for the company address.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CustomerAddressAttribute",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fax",
+            "description": "The fax number.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstname",
+            "description": "The first name.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The unique ID for a `CompanyAddress` object.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "is_default",
+            "description": "Indicates whether the address is the default for its type.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastname",
+            "description": "The last name.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "middlename",
+            "description": "The middle name.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nickname",
+            "description": "Optional nickname for the address.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "postcode",
+            "description": "The postal code.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prefix",
+            "description": "The name prefix.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "region",
+            "description": "An object containing the region name, region code, and region ID.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CustomerAddressRegion",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "region_id",
+            "description": "The unique ID for a pre-defined region.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "street",
+            "description": "Street lines of the address.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "suffix",
+            "description": "The name suffix.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "telephone",
+            "description": "The telephone number.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vat_id",
+            "description": "The VAT ID.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CompanyAddresses",
+        "description": "Contains a paginated list of company addresses.",
+        "fields": [
+          {
+            "name": "items",
+            "description": "An array of company addresses.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CompanyAddress",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "page_info",
+            "description": "Pagination metadata.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SearchResultPageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_count",
+            "description": "The number of objects returned.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CompanyAddressInput",
+        "description": "Defines the input schema for creating a company address.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "address_type",
+            "description": "The address type.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CompanyAddressTypeEnum",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "city",
+            "description": "The city.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "company",
+            "description": "The company name.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "country_code",
+            "description": "The two-letter code representing the company's country.",
+            "type": {
+              "kind": "ENUM",
+              "name": "CountryCodeEnum",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "custom_attributes",
+            "description": "Custom attributes assigned to the company address.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "AttributeValueInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "fax",
+            "description": "The fax number.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "firstname",
+            "description": "The first name.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "is_default",
+            "description": "Whether the address is the default for its type.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "lastname",
+            "description": "The last name.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "middlename",
+            "description": "The middle name.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "nickname",
+            "description": "Optional nickname for the address.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "postcode",
+            "description": "The postal code.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "prefix",
+            "description": "The name prefix.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "region",
+            "description": "An object containing the region name, region code, and region ID.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomerAddressRegionInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "street",
+            "description": "Street lines.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "suffix",
+            "description": "The name suffix.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "telephone",
+            "description": "The telephone number.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "vat_id",
+            "description": "The VAT ID.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CompanyAddressTypeEnum",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BILLING",
+            "description": "Billing address.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SHIPPING",
+            "description": "Shipping address.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CompanyAddressUpdateInput",
+        "description": "Defines the input schema for updating a company address. The address type cannot be changed once an address is created.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "city",
+            "description": "The city.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "company",
+            "description": "The company name.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "country_code",
+            "description": "The two-letter code representing the company's country.",
+            "type": {
+              "kind": "ENUM",
+              "name": "CountryCodeEnum",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "custom_attributes",
+            "description": "Custom attributes assigned to the company address.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "AttributeValueInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "fax",
+            "description": "The fax number.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "firstname",
+            "description": "The first name.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "is_default",
+            "description": "Whether the address is the default for its type.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "lastname",
+            "description": "The last name.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "middlename",
+            "description": "The middle name.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "nickname",
+            "description": "Optional nickname for the address.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "postcode",
+            "description": "The postal code.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "prefix",
+            "description": "The name prefix.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "region",
+            "description": "An object containing the region name, region code, and region ID.",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomerAddressRegionInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "street",
+            "description": "Street lines.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "suffix",
+            "description": "The name suffix.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "telephone",
+            "description": "The telephone number.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "vat_id",
+            "description": "The VAT ID.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "CompanyAdmin",
         "description": "Contains details about the company administrator.",
         "fields": [
@@ -13887,6 +15421,49 @@
               "kind": "ENUM",
               "name": "CompanyStatusEnum",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CompanyConfig",
+        "description": "Company address book configuration settings.",
+        "fields": [
+          {
+            "name": "address_book_custom_shipping_address_enabled",
+            "description": "Indicates whether custom shipping address entry is allowed when the company address book is enabled.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "address_book_enabled",
+            "description": "Indicates whether the company address book is enabled.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -16323,6 +17900,22 @@
             "deprecationReason": "This field is deprecated and will be removed."
           },
           {
+            "name": "externalIds",
+            "description": "External Ids",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ExternalId",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "url",
             "description": "Canonical URL of the product.",
             "args": [],
@@ -16383,7 +17976,7 @@
           },
           {
             "name": "categories",
-            "description": "A list of categories in which the product is present.",
+            "description": "A list of categories in which the product is present. Available only for Commerce deployments using Adobe Commerce Optimizer.",
             "args": [
               {
                 "name": "family",
@@ -16761,6 +18354,22 @@
             "deprecationReason": "Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration."
           },
           {
+            "name": "is_free_gift",
+            "description": "True if this line item was added by a Free Gift cart price rule.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "is_salable",
             "description": "True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed.",
             "args": [],
@@ -16796,6 +18405,38 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source",
+            "description": "The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors).",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SourceAvailability",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source_errors",
+            "description": "Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "NominatedSourceError",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -17024,6 +18665,18 @@
                 "name": "OrderItemOption",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "free_gift_label",
+            "description": "The discount rule label for free gift items. Null if the item is not a free gift.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -20894,6 +22547,65 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "CreatePaymentLinkOutput",
+        "description": "Result of createPaymentLink.",
+        "fields": [
+          {
+            "name": "expiresAt",
+            "description": "UTC expiry timestamp of the link.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "payUrl",
+            "description": "The absolute payment link URL.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "token",
+            "description": "The payment link token.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "CreatePaymentOrderInput",
         "description": "Contains payment order details that are used while processing the payment order",
@@ -23907,8 +25619,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": true,
-            "deprecationReason": "`id` is not needed as part of `Customer`, because on the server side, it can be identified based on the customer token used for authentication. There is no need to know customer ID on the client side."
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "is_subscribed",
@@ -26437,6 +28149,16 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "FilterRangeTypeInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "search",
+            "description": "Searches orders by order number, product name, or SKU.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null
@@ -29525,6 +31247,22 @@
             "deprecationReason": "Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration."
           },
           {
+            "name": "is_free_gift",
+            "description": "True if this line item was added by a Free Gift cart price rule.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "is_salable",
             "description": "True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed.",
             "args": [],
@@ -29576,6 +31314,38 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source",
+            "description": "The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors).",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SourceAvailability",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source_errors",
+            "description": "Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "NominatedSourceError",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -30138,6 +31908,18 @@
                 "name": "OrderItemOption",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "free_gift_label",
+            "description": "The discount rule label for free gift items. Null if the item is not a free gift.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -31952,6 +33734,41 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ExternalId",
+        "description": "Represents an external identifier with its origin system",
+        "fields": [
+          {
+            "name": "id",
+            "description": "The external identifier value",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "origin",
+            "description": "The origin system of the external identifier",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "FastlaneConfig",
         "description": "",
         "fields": [
@@ -33228,6 +35045,22 @@
             "deprecationReason": "Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration."
           },
           {
+            "name": "is_free_gift",
+            "description": "True if this line item was added by a Free Gift cart price rule.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "is_salable",
             "description": "True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed.",
             "args": [],
@@ -33275,6 +35108,38 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source",
+            "description": "The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors).",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SourceAvailability",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source_errors",
+            "description": "Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "NominatedSourceError",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -33968,6 +35833,18 @@
                 "name": "OrderItemOption",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "free_gift_label",
+            "description": "The discount rule label for free gift items. Null if the item is not a free gift.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -35336,6 +37213,71 @@
           {
             "kind": "INTERFACE",
             "name": "WishlistItemInterface",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GiftCartAttributeValue",
+        "description": "Gift card custom attribute value containing array data.",
+        "fields": [
+          {
+            "name": "attribute_type",
+            "description": "Attribute type code.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "code",
+            "description": "The attribute code.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "options",
+            "description": "Array of gift card attribute option values.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "AttributeValueInterface",
             "ofType": null
           }
         ],
@@ -39846,11 +41788,11 @@
       {
         "kind": "OBJECT",
         "name": "IsProductAlertSubscriptionResult",
-        "description": "",
+        "description": "Response returned when checking whether a customer is subscribed to a product alert.",
         "fields": [
           {
             "name": "isSubscribed",
-            "description": null,
+            "description": "Indicates whether the customer is currently subscribed to the alert.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -39866,7 +41808,7 @@
           },
           {
             "name": "message",
-            "description": null,
+            "description": "A human-readable message describing the current subscription status.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -40414,6 +42356,22 @@
               "kind": "SCALAR",
               "name": "Int",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "types",
+            "description": "Array of image types. It can have the following values: image, small_image, thumbnail.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -41756,6 +43714,37 @@
             "deprecationReason": null
           },
           {
+            "name": "clearCart",
+            "description": "Remove all items from the specified cart.",
+            "args": [
+              {
+                "name": "input",
+                "description": "An input object that defines cart ID of the shopper.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ClearCartInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ClearCartOutput",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "clearCustomerCart",
             "description": "Remove all items from the specified cart.",
             "args": [
@@ -42105,6 +44094,33 @@
             "deprecationReason": null
           },
           {
+            "name": "createCompanyAddress",
+            "description": "Create a new company address.",
+            "args": [
+              {
+                "name": "input",
+                "description": "An input object that defines the company address to create.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CompanyAddressInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CompanyAddress",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createCompanyRole",
             "description": "Create a new company role.",
             "args": [
@@ -42313,6 +44329,43 @@
             "deprecationReason": null
           },
           {
+            "name": "createPaymentLink",
+            "description": "Mint a Pay By Link payment link against a guest clone of the cart.",
+            "args": [
+              {
+                "name": "cartId",
+                "description": "Masked id of the cart to mint a payment link for.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "recipientEmail",
+                "description": "Optional override for the email the link is sent to; defaults to the cart customer email.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CreatePaymentLinkOutput",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createPaymentOrder",
             "description": "Creates a payment order for further payment processing",
             "args": [
@@ -42465,6 +44518,33 @@
             "type": {
               "kind": "OBJECT",
               "name": "CreateWishlistOutput",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deleteCompanyAddress",
+            "description": "Delete a company address.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The ID of the company address to delete.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "isDeprecated": false,
@@ -44354,6 +46434,33 @@
             "deprecationReason": null
           },
           {
+            "name": "selectFreeGiftForCart",
+            "description": "Defines the product that a shopper has selected as a free gift. This mutations is applicable only if a Free Gift cart price rule has been applied to the cart.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SelectFreeGiftForCartInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SelectFreeGiftForCartOutput",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sendNegotiableQuoteForReview",
             "description": "Send the negotiable quote to the seller for review.",
             "args": [
@@ -44623,6 +46730,33 @@
             "deprecationReason": null
           },
           {
+            "name": "setDefaultCompanyAddress",
+            "description": "Set a company address as the default billing or shipping address for the company.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The ID of the company address to set as default for its type.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CompanyAddress",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "setGiftOptionsOnCart",
             "description": "Set gift options, including gift messages, gift wrapping, gift receipts, and printed cards.",
             "args": [
@@ -44825,6 +46959,33 @@
             "type": {
               "kind": "OBJECT",
               "name": "NegotiableQuoteTemplate",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "setNominatedSourceOnCartItems",
+            "description": "Sets (or clears) the nominated inventory source on one or more cart items. The single canonical write path for nominated_source_code.",
+            "args": [
+              {
+                "name": "input",
+                "description": "The cart and the per-item source nominations to apply or clear.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SetNominatedSourceOnCartItemsInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SetNominatedSourceOnCartItemsOutput",
               "ofType": null
             },
             "isDeprecated": false,
@@ -45230,7 +47391,7 @@
           },
           {
             "name": "unsubscribeProductAlertPrice",
-            "description": "Unsubscribe logged-in customer to price alert for a product.",
+            "description": "Unsubscribe logged-in customer from price alert for a product.",
             "args": [
               {
                 "name": "input",
@@ -45257,7 +47418,7 @@
           },
           {
             "name": "unsubscribeProductAlertPriceAll",
-            "description": "Unsubscribe logged-in customer to price alert for all product.",
+            "description": "Unsubscribe logged-in customer from price alerts for all products.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -45269,7 +47430,7 @@
           },
           {
             "name": "unsubscribeProductAlertStock",
-            "description": "Unsubscribe logged-in customer to stock alert for a product.",
+            "description": "Unsubscribe logged-in customer from stock alert for a product.",
             "args": [
               {
                 "name": "input",
@@ -45296,7 +47457,7 @@
           },
           {
             "name": "unsubscribeProductAlertStockAll",
-            "description": "Unsubscribe logged-in customer to stock alert for all product.",
+            "description": "Unsubscribe logged-in customer from stock alerts for all products.",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -45351,6 +47512,74 @@
             "type": {
               "kind": "OBJECT",
               "name": "UpdateCompanyOutput",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateCompanyAddress",
+            "description": "Update an existing company address.",
+            "args": [
+              {
+                "name": "id",
+                "description": "The ID of the company address to update.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "input",
+                "description": "An input object that defines changes to the company address.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CompanyAddressUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CompanyAddress",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateCompanyConfig",
+            "description": "Update company configuration for the current company context.",
+            "args": [
+              {
+                "name": "input",
+                "description": "An input object that defines company configuration changes.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UpdateCompanyConfigInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "UpdateCompanyConfigOutput",
               "ofType": null
             },
             "isDeprecated": false,
@@ -46674,6 +48903,18 @@
             "deprecationReason": null
           },
           {
+            "name": "company_address_id",
+            "description": "The unique ID of the company address referenced by this negotiable quote address, if any.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "country",
             "description": "The company's country.",
             "args": [],
@@ -46979,6 +49220,18 @@
             "deprecationReason": null
           },
           {
+            "name": "company_address_id",
+            "description": "The unique ID of the company address referenced by this negotiable quote address, if any.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "country",
             "description": "The company's country.",
             "args": [],
@@ -47210,6 +49463,16 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "NegotiableQuoteAddressInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "company_address_id",
+            "description": "The unique ID of a company address to use as the billing address. Requires the company's address book to be enabled.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
               "ofType": null
             },
             "defaultValue": null
@@ -48227,6 +50490,18 @@
             "deprecationReason": null
           },
           {
+            "name": "company_address_id",
+            "description": "The unique ID of the company address referenced by this negotiable quote address, if any.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "country",
             "description": "The company's country.",
             "args": [],
@@ -48470,6 +50745,16 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "NegotiableQuoteAddressInput",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "company_address_id",
+            "description": "The unique ID of a company address to use as the shipping address. Requires the company's address book to be enabled.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
               "ofType": null
             },
             "defaultValue": null
@@ -49803,6 +52088,16 @@
             "defaultValue": null
           },
           {
+            "name": "company_address_id",
+            "description": "The unique ID of a company address to use as the shipping address. Requires the company's address book to be enabled.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "customer_address_uid",
             "description": "An ID from the company user's address book that uniquely identifies the address to be used for shipping.",
             "type": {
@@ -50141,8 +52436,49 @@
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "SKU_SOURCE_CONFLICT",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "NominatedSourceItemInput",
+        "description": "A single cart item's source nomination.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "cart_item_uid",
+            "description": "The unique ID of the cart item to nominate a source for.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "source_code",
+            "description": "The inventory source code to nominate. A null or empty value clears the nomination.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -50526,6 +52862,18 @@
             "deprecationReason": null
           },
           {
+            "name": "company_address_id",
+            "description": "UID of the company address referenced by this order address, if any.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "country_code",
             "description": "The customer's country.",
             "args": [],
@@ -50867,7 +53215,7 @@
           },
           {
             "name": "postcode",
-            "description": "",
+            "description": "Order billing address postcode",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -50941,6 +53289,18 @@
                 "name": "OrderItemOption",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "free_gift_label",
+            "description": "The discount rule label for free gift items. Null if the item is not a free gift.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -51262,6 +53622,18 @@
                 "name": "OrderItemOption",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "free_gift_label",
+            "description": "The discount rule label for free gift items. Null if the item is not a free gift.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -52262,6 +54634,33 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PayByLinkCartOutput",
+        "description": "Result of payByLinkCart.",
+        "fields": [
+          {
+            "name": "masked_cart_id",
+            "description": "Masked id of the guest cart to resume the standard checkout against.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -53823,16 +56222,12 @@
             "description": "An array of place order errors.",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
+              "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PlaceOrderError",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "PlaceOrderError",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -54123,12 +56518,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ProductAlertPriceInput",
-        "description": "",
+        "description": "Input to identify a product by SKU for a price alert subscription.",
         "fields": null,
         "inputFields": [
           {
             "name": "sku",
-            "description": "",
+            "description": "The SKU of the product to subscribe to price alerts for.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -54148,12 +56543,12 @@
       {
         "kind": "INPUT_OBJECT",
         "name": "ProductAlertStockInput",
-        "description": "",
+        "description": "Input to identify a product by SKU for a stock alert subscription.",
         "fields": null,
         "inputFields": [
           {
             "name": "sku",
-            "description": "",
+            "description": "The SKU of the product to subscribe to stock alerts for.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -54173,11 +56568,11 @@
       {
         "kind": "OBJECT",
         "name": "ProductAlertSubscriptionResult",
-        "description": "",
+        "description": "Response returned after a product alert subscribe or unsubscribe mutation.",
         "fields": [
           {
             "name": "message",
-            "description": null,
+            "description": "A human-readable message describing the result of the subscription action.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -54189,7 +56584,7 @@
           },
           {
             "name": "success",
-            "description": null,
+            "description": "Indicates whether the subscription action was successful.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -54452,6 +56847,22 @@
               "kind": "SCALAR",
               "name": "Int",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "types",
+            "description": "Array of image types. It can have the following values: image, small_image, thumbnail.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -55860,6 +58271,22 @@
             "deprecationReason": null
           },
           {
+            "name": "types",
+            "description": "Array of image types. It can have the following values: image, small_image, thumbnail.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "url",
             "description": "The URL of the product image or video.",
             "args": [],
@@ -56169,6 +58596,22 @@
             "deprecationReason": "This field is deprecated and will be removed."
           },
           {
+            "name": "externalIds",
+            "description": "External Ids",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ExternalId",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "url",
             "description": "Canonical URL of the product.",
             "args": [],
@@ -56229,11 +58672,11 @@
           },
           {
             "name": "categories",
-            "description": "A list of categories in which the product is present.",
+            "description": "A list of categories in which the product is present. Available only for Commerce deployments using Adobe Commerce Optimizer.",
             "args": [
               {
                 "name": "family",
-                "description": "The product family to filter the categories by. For example, 'clothing', 'electronics' or 'books'",
+                "description": "The product family to filter the categories by. For example, 'clothing', 'electronics' or 'books'.",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
@@ -60056,7 +62499,7 @@
         "fields": [
           {
             "name": "products",
-            "description": "Search for products that match the specified SKU values. In Adobe Commerce as a Cloud Service, this query replaces the `products` query defined in the Commerce Foundation.",
+            "description": "Search for products that match the specified SKU values. Available only for deployments using the Catalog or Live Search service with Adobe Commerce.",
             "args": [
               {
                 "name": "skus",
@@ -60201,7 +62644,7 @@
           },
           {
             "name": "categories",
-            "description": "Return category views by IDs, with optional role filters and subtree scopes. In Adobe Commerce as a Cloud Service, this query replaces the `categories` query defined in the Commerce Foundation.",
+            "description": "Return category views by IDs, with optional role filters and subtree scopes. Available only for deployments using the Catalog or Live Search service with Adobe Commerce. For Adobe Commerce Optimizer, use the `categoryTree` query instead. See [categoryTree query examples](https://developer.adobe.com/commerce/services/optimizer/merchandising-services/categories-storefront-implementation#categorytree-query-examples).",
             "args": [
               {
                 "name": "ids",
@@ -60259,12 +62702,12 @@
                 "ofType": null
               }
             },
-            "isDeprecated": true,
-            "deprecationReason": "This field is deprecated and will be removed."
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "navigation",
-            "description": "Retrieves the navigation tree for a given product family.",
+            "description": "Retrieves the navigation tree for a given product family. Available only for Commerce deployments using Adobe Commerce Optimizer.",
             "args": [
               {
                 "name": "family",
@@ -60277,6 +62720,16 @@
                     "name": "String",
                     "ofType": null
                   }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "sort",
+                "description": "The sorting criterion used for sorting the result list of categories queries",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CategorySortInput",
+                  "ofType": null
                 },
                 "defaultValue": null
               }
@@ -60295,7 +62748,7 @@
           },
           {
             "name": "categoryTree",
-            "description": "Retrieves category tree nodes, optionally filtered by family, slugs and limited by depth.",
+            "description": "Retrieves category tree nodes, optionally filtered by family, slugs and limited by depth. Available for Commerce deployments using Adobe Commerce Optimizer or Adobe Commerce as a Cloud Service.",
             "args": [
               {
                 "name": "family",
@@ -60350,7 +62803,7 @@
           },
           {
             "name": "searchCategory",
-            "description": "Search for categories by name with optional filtering and pagination. Results are returned in alphabetical order by category name.",
+            "description": "Search for categories by name with optional filtering and pagination. Results are returned in alphabetical order by category name. Available only for Commerce deployments using Adobe Commerce Optimizer.",
             "args": [
               {
                 "name": "searchTerm",
@@ -61497,6 +63950,33 @@
             "deprecationReason": null
           },
           {
+            "name": "payByLinkCart",
+            "description": "Resolve a Pay By Link token to the masked id of the guest cart to resume checkout against.",
+            "args": [
+              {
+                "name": "token",
+                "description": "The Pay By Link token from the emailed link.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PayByLinkCartOutput",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "pickupLocations",
             "description": "The pickup locations query searches for locations that match the search request requirements.",
             "args": [
@@ -61679,6 +64159,77 @@
             "deprecationReason": null
           },
           {
+            "name": "sourceAvailability",
+            "description": "Per-source availability for one or more SKUs, scoped to the storefront-visible sources of the current sales channel's stock. Availability is computed identically to the order-placement guard.",
+            "args": [
+              {
+                "name": "skus",
+                "description": "The product SKUs to report availability for.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "source_codes",
+                "description": "Restrict the report to these inventory sources. Only sources flagged storefront-visible are ever reported; a requested source that is not storefront-visible, or not assigned to the current sales channel's stock, is silently omitted. When omitted, every storefront-visible source assigned to the current sales channel's stock is reported.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "only_in_stock",
+                "description": "When true, omit sources where the SKU is not salable.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SkuSourceAvailability",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "storeConfig",
             "description": "Return details about the store's configuration.",
             "args": [],
@@ -61817,6 +64368,95 @@
                         "ofType": null
                       }
                     }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "currentSku",
+                "description": "SKU of the product currently being viewed on PDP",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "currentProduct",
+                "description": "Current product context from PDP (SKU, price, category, etc.)",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CurrentProductInput",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "userPurchaseHistory",
+                "description": "User purchase history with timestamp",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "PurchaseHistory",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "userViewHistory",
+                "description": "User view history with timestamp",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ViewHistory",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "cartSkus",
+                "description": "SKUs of products in the cart",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Recommendations",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recommendationsByUnits",
+            "description": null,
+            "args": [
+              {
+                "name": "selector",
+                "description": "Selector of preconfigured units",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UnitSelector",
+                    "ofType": null
                   }
                 },
                 "defaultValue": null
@@ -62837,6 +65477,12 @@
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "COMPANY_CREATE",
+            "description": "Create new company account form.",
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -63011,6 +65657,18 @@
           {
             "name": "unitName",
             "description": "Name of the preconfigured unit",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": "Label of the preconfigured unit",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -64312,8 +66970,8 @@
               "name": "RequistionListItems",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Deprecated. Use requisition_list_items instead. Will be removed in a future release."
           },
           {
             "name": "items_count",
@@ -64343,6 +67001,39 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "requisition_list_items",
+            "description": "An array of products added to the requisition list.",
+            "args": [
+              {
+                "name": "currentPage",
+                "description": "The page of results to return. The default value is 1.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "1"
+              },
+              {
+                "name": "pageSize",
+                "description": "The maximum number of results to return. The default value is 1.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "20"
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "RequisitionListItems",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -64537,6 +67228,65 @@
             "ofType": null
           }
         ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RequisitionListItems",
+        "description": "Contains an array of items added to a requisition list.",
+        "fields": [
+          {
+            "name": "items",
+            "description": "An array of items in the requisition list.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "RequisitionListItemInterface",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "page_info",
+            "description": "Pagination metadata.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SearchResultPageInfo",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total_pages",
+            "description": "The number of pages returned.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
       },
       {
         "kind": "INPUT_OBJECT",
@@ -64735,7 +67485,7 @@
       {
         "kind": "OBJECT",
         "name": "RequistionListItems",
-        "description": "Contains an array of items added to a requisition list.",
+        "description": "Deprecated. Use RequisitionListItems via requisition_list_items. Will be removed in a future release.",
         "fields": [
           {
             "name": "items",
@@ -67451,6 +70201,124 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "SelectFreeGiftForCartInput",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "cart_id",
+            "description": "Masked ID of the shopper's cart.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "entered_options",
+            "description": "Custom option values entered by the customer, such as text inputs.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "EnteredOptionInput",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "quantity",
+            "description": "Override the rule's configured gift quantity. Must be a positive integer no greater than the rule's gift_qty. Defaults to the rule's gift_qty.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "rule_id",
+            "description": "Identifier of the free-gift rule the selection is for. Must be currently applied to the cart and pending selection.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "selected_options",
+            "description": "UIDs of selected option values, such as configurable variants or bundle selections.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "sku",
+            "description": "SKU of the gift product to add. Must be one of the rule's configured SKUs.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SelectFreeGiftForCartOutput",
+        "description": "",
+        "fields": [
+          {
+            "name": "cart",
+            "description": "The cart after adding the selected free-gift product.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "SendNegotiableQuoteForReviewInput",
         "description": "Specifies which negotiable quote to send for review.",
         "fields": null,
@@ -68213,6 +71081,96 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SetNominatedSourceOnCartItemsInput",
+        "description": "Input for the setNominatedSourceOnCartItems mutation.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "cart_id",
+            "description": "The masked ID of the cart.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "items",
+            "description": "The per-item source nominations to apply or clear.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NominatedSourceItemInput",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SetNominatedSourceOnCartItemsOutput",
+        "description": "Result of the setNominatedSourceOnCartItems mutation.",
+        "fields": [
+          {
+            "name": "cart",
+            "description": "The updated cart.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rejected_items",
+            "description": "The cart items whose nomination was rejected, each with a reason. Empty when all nominations were applied or cleared.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "RejectedNomination",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -69166,6 +72124,16 @@
             "defaultValue": null
           },
           {
+            "name": "company_address_id",
+            "description": "UID of a company address to use for shipping.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "customer_address_id",
             "description": "An ID from the customer's address book that uniquely identifies the address to be used for shipping.",
             "type": {
@@ -69270,6 +72238,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "company_address_id",
+            "description": "UID of the company address referenced by this cart address, if any.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
               "ofType": null
             },
             "isDeprecated": false,
@@ -69858,6 +72838,22 @@
             "deprecationReason": "Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration."
           },
           {
+            "name": "is_free_gift",
+            "description": "True if this line item was added by a Free Gift cart price rule.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "is_salable",
             "description": "True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed.",
             "args": [],
@@ -69893,6 +72889,38 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source",
+            "description": "The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors).",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SourceAvailability",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source_errors",
+            "description": "Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "NominatedSourceError",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -70866,7 +73894,7 @@
           },
           {
             "name": "externalId",
-            "description": "External Id. For example, `123`, `456` or `789`.",
+            "description": "External Id",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -70875,6 +73903,22 @@
             },
             "isDeprecated": true,
             "deprecationReason": "This field is deprecated and will be removed."
+          },
+          {
+            "name": "externalIds",
+            "description": "External Ids",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ExternalId",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "url",
@@ -70937,7 +73981,7 @@
           },
           {
             "name": "categories",
-            "description": "A list of categories in which the product is present. Categories are used to group products by category. ",
+            "description": "A list of categories in which the product is present. Available only for Commerce deployments using Adobe Commerce Optimizer.",
             "args": [
               {
                 "name": "family",
@@ -71217,6 +74261,53 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "SkuSourceAvailability",
+        "description": "Per-source availability for a single SKU across the sources of the current sales channel's stock.",
+        "fields": [
+          {
+            "name": "sku",
+            "description": "The product SKU the availability applies to.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sources",
+            "description": "Availability at each reported source.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SourceAvailability",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "SmartButtonMethodInput",
         "description": "Smart button payment inputs",
@@ -71471,6 +74562,29 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "SortDirectionEnum",
+        "description": "The available sort options for category queries.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASC",
+            "description": "Sort categories in ascending order.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC",
+            "description": "Sort categories in descending order.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -71917,27 +75031,23 @@
       {
         "kind": "OBJECT",
         "name": "SourceAvailability",
-        "description": "Per-source availability for a SKU.",
+        "description": "Availability of a SKU at a single inventory source.",
         "fields": [
           {
             "name": "available_qty",
-            "description": "Quantity available at the source, net of open source-level reservations.",
+            "description": "Saleable quantity at the source, net of open source-level reservations. The exact value is returned only when it is at or below the merchant's storefront display threshold (cataloginventory/options/stock_threshold_qty); above the threshold it is null and only is_in_stock is meaningful. That threshold defaults to 0, so by default every positive quantity is masked to null and is_in_stock is the authoritative signal.",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
-            "name": "is_salable",
-            "description": "Whether the SKU is salable at the source.",
+            "name": "is_in_stock",
+            "description": "Whether the SKU is salable at the source (available quantity greater than zero).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -72748,13 +75858,9 @@
             "description": "Configuration data from customer/account_information/graphql_share_customer_group",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -73324,6 +76430,54 @@
             "deprecationReason": null
           },
           {
+            "name": "persistent_enabled",
+            "description": "Configuration data from persistent/options/enabled",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "persistent_options_wishlist",
+            "description": "Configuration data from persistent/options/wishlist",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "persistent_shopping_cart",
+            "description": "Configuration data from persistent/options/shopping_cart",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "printed_card_priceV2",
             "description": "The default price of a printed card that accompanies an order.",
             "args": [],
@@ -73331,6 +76485,22 @@
               "kind": "OBJECT",
               "name": "Money",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "product_alert_allow_stock",
+            "description": "Indicates whether back-in-stock (Notify Me) product alerts are enabled. Configuration data from catalog/productalert/allow_stock.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -73592,13 +76762,9 @@
             "description": "Configuration data from customer/magento_customersegment/share_active_segments",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -73608,11 +76774,23 @@
             "description": "Configuration data from promo/graphql/share_applied_cart_rule",
             "args": [],
             "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "share_customer_accounts_scope",
+            "description": "Configuration data from customer/account_share/scope. 0 = Global, 1 = Per Website",
+            "args": [],
+            "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Boolean",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -74885,6 +78063,53 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "UnitSelector",
+        "description": "Provide either rec unit ids or labels to retrieve rec units",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "unitIds",
+            "description": "List unit IDs of preconfigured units",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "labels",
+            "description": "List of labels of the preconfigured unit",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "UpdateCartItemsInput",
         "description": "Modifies the specified items in the cart.",
         "fields": null,
@@ -74963,6 +78188,60 @@
                   "ofType": null
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "UpdateCompanyConfigInput",
+        "description": "Defines the input schema for updating company configuration.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "address_book_enabled",
+            "description": "Indicates whether the company address book is enabled.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "custom_shipping_address_enabled",
+            "description": "Indicates whether custom shipping address entry is allowed when the company address book is enabled.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UpdateCompanyConfigOutput",
+        "description": "Contains the response to the request to update company configuration.",
+        "fields": [
+          {
+            "name": "company",
+            "description": "The updated company.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Company",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -76548,6 +79827,22 @@
             "deprecationReason": "Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration."
           },
           {
+            "name": "is_free_gift",
+            "description": "True if this line item was added by a Free Gift cart price rule.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "is_salable",
             "description": "True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed.",
             "args": [],
@@ -76583,6 +79878,38 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source",
+            "description": "The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors).",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "SourceAvailability",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nominated_source_errors",
+            "description": "Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "NominatedSourceError",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -77688,6 +81015,12 @@
             "deprecationReason": null
           },
           {
+            "name": "REQUIRED_PARAMETER_MISSING",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "NOT_SALABLE",
             "description": "",
             "isDeprecated": false,
@@ -77701,12 +81034,6 @@
           },
           {
             "name": "UNDEFINED",
-            "description": "",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "REQUIRED_PARAMETER_MISSING",
             "description": "",
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/openapi/accs-schema.yaml
+++ b/src/openapi/accs-schema.yaml
@@ -146,6 +146,11 @@ definitions:
         items:
           "$ref": "#/definitions/adobe-assets-integration-data-alt-text-item-interface"
         type: array
+      hidden_store_views:
+        description: Store view codes this asset should be hidden from
+        items:
+          type: string
+        type: array
       position:
         description: Position
         type: integer
@@ -1471,6 +1476,13 @@ definitions:
     type: object
   catalog-data-product-custom-option-extension-interface:
     description: ExtensionInterface class for @see \Magento\Catalog\Api\Data\ProductCustomOptionInterface
+    properties:
+      group:
+        type: string
+      option_uids:
+        items:
+          "$ref": "#/definitions/catalog-product-custom-option-uid-data-option-uid-interface"
+        type: array
     type: object
   catalog-data-product-custom-option-interface:
     description: ''
@@ -2092,6 +2104,31 @@ definitions:
     - orders
     - limit
     type: object
+  catalog-product-custom-option-uid-data-option-uid-interface:
+    description: 'A single add-to-cart UID entry for a customizable option. For selectable
+      options (drop_down/radio/checkbox/multiple) there is one entry per value, and
+      option_type_id identifies which value the uid belongs to. For entered options
+      (field/area/file/date/date_time/time) there is a single entry whose uid applies
+      to the option itself; option_type_id is null on the object and, because the
+      REST output processor omits null values, is absent from the serialized response
+      rather than present as null. The sibling "group" extension attribute on the
+      option classifies it as one of four groups: "select" (drop_down/radio/checkbox/multiple),
+      "text" (field/area), "file" (file), or "date" (date/date_time/time). It is the
+      selectable-vs-entered discriminator: "select" means option_uids holds one entry
+      per value, each carrying that value''s option_type_id (correlate a value to
+      its uid by matching option_type_id), while "text"/"file"/"date" mean option_uids
+      holds a single option-level entry.'
+    properties:
+      option_type_id:
+        description: Value id this uid belongs to; present only for selectable options
+          and absent for entered options.
+        type: integer
+      uid:
+        description: Base64 add-to-cart uid.
+        type: string
+    required:
+    - uid
+    type: object
   checkout-agreements-data-agreement-extension-interface:
     description: ExtensionInterface class for @see \Magento\CheckoutAgreements\Api\Data\AgreementInterface
     type: object
@@ -2203,6 +2240,17 @@ definitions:
     required:
     - address
     type: object
+  commerce-backend-uix-data-admin-ui-sdk-config-result-interface:
+    description: Response DTO returned by the Admin UI SDK configuration update endpoint
+      (PUT /V1/adminuisdk/config). Carries a single boolean reflecting whether the
+      Admin UI SDK is enabled after the configuration change has been persisted.
+    properties:
+      enabled:
+        description: True when the Admin UI SDK is enabled after the update
+        type: boolean
+    required:
+    - enabled
+    type: object
   commerce-backend-uix-data-app-management-validation-result-interface:
     description: App Management User Validation Result Interface
     properties:
@@ -2280,6 +2328,21 @@ definitions:
     - error_message
     - request_timestamp
     type: object
+  commerce-backend-uix-data-permission-check-result-interface:
+    description: Response DTO returned by the Admin UI SDK permission check endpoint
+      (POST /V1/adminuisdk/permission/check). Carries a single boolean indicating
+      whether the authenticated admin user holds the requested ACL resource. A false
+      value means either the resource is not registered through any SDK extension
+      point or the user's role does not grant it — callers must not distinguish between
+      the two cases.
+    properties:
+      allowed:
+        description: True when the current user is authorized for the requested ACL
+          resource.
+        type: boolean
+    required:
+    - allowed
+    type: object
   commerce-backend-uix-data-selected-extension-data-interface:
     description: Defines the selected extensions table data model
     properties:
@@ -2303,6 +2366,111 @@ definitions:
         type: boolean
     required:
     - installed
+    type: object
+  company-address-storefront-compatibility-data-company-address-extension-interface:
+    description: Extension attributes for company address.
+    type: object
+  company-address-storefront-compatibility-data-company-address-interface:
+    description: Company address data interface.
+    properties:
+      city:
+        description: City.
+        type: string
+      company:
+        description: Company name.
+        type: string
+      company_address_id:
+        description: Company address ID.
+        type: integer
+      company_id:
+        description: Company ID.
+        type: integer
+      country_id:
+        description: Country ID.
+        type: string
+      custom_attributes:
+        description: Custom attributes values.
+        items:
+          "$ref": "#/definitions/framework-attribute-interface"
+        type: array
+      extension_attributes:
+        "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-extension-interface"
+      fax:
+        description: Fax.
+        type: string
+      firstname:
+        description: First name.
+        type: string
+      increment_id:
+        description: Increment ID.
+        type: string
+      lastname:
+        description: Last name.
+        type: string
+      middlename:
+        description: Middle name.
+        type: string
+      nickname:
+        description: Nickname.
+        type: string
+      postcode:
+        description: Postcode.
+        type: string
+      prefix:
+        description: Prefix.
+        type: string
+      region:
+        "$ref": "#/definitions/customer-data-region-interface"
+      region_id:
+        description: Region ID.
+        type: integer
+      street:
+        description: Street lines.
+        items:
+          type: string
+        type: array
+      suffix:
+        description: Suffix.
+        type: string
+      telephone:
+        description: Telephone.
+        type: string
+      type:
+        description: Address type.
+        type: integer
+      vat_id:
+        description: VAT ID.
+        type: string
+      vat_is_valid:
+        description: VAT validity flag.
+        type: integer
+      vat_request_date:
+        description: VAT request date.
+        type: string
+      vat_request_id:
+        description: VAT request ID.
+        type: string
+      vat_request_success:
+        description: VAT request success flag.
+        type: integer
+    type: object
+  company-address-storefront-compatibility-data-company-address-search-results-interface:
+    description: ''
+    properties:
+      items:
+        description: Company addresses list.
+        items:
+          "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-interface"
+        type: array
+      search_criteria:
+        "$ref": "#/definitions/framework-search-criteria-interface"
+      total_count:
+        description: Total count.
+        type: integer
+    required:
+    - items
+    - search_criteria
+    - total_count
     type: object
   company-credit-data-credit-balance-options-interface:
     description: Credit balance data transfer object interface.
@@ -2542,6 +2710,10 @@ definitions:
         type: string
       available_shipping_methods:
         type: string
+      is_company_address_book_enabled:
+        type: boolean
+      is_custom_shipping_address_allowed:
+        type: boolean
       is_purchase_order_enabled:
         type: boolean
       quote_config:
@@ -2690,7 +2862,7 @@ definitions:
         type: integer
     type: object
   company-data-permission-interface:
-    description: Permission interface.
+    description: Permission management
     properties:
       id:
         description: Id.
@@ -2755,7 +2927,7 @@ definitions:
     description: ExtensionInterface class for @see \Magento\Company\Api\Data\TeamInterface
     type: object
   company-data-team-interface:
-    description: Team interface
+    description: Team custom attributes management
     properties:
       custom_attributes:
         description: Custom attributes values.
@@ -3157,6 +3329,10 @@ definitions:
   customer-data-customer-extension-interface:
     description: ExtensionInterface class for @see \Magento\Customer\Api\Data\CustomerInterface
     properties:
+      all_company_attributes:
+        items:
+          "$ref": "#/definitions/company-data-company-customer-interface"
+        type: array
       assistance_allowed:
         type: integer
       company_attributes:
@@ -4428,6 +4604,8 @@ definitions:
       parser
     properties:
       carrier_links:
+        description: Carrier links for the source as an array of SourceCarrierLinkInterface
+          objects or null.
         items:
           "$ref": "#/definitions/inventory-api-data-source-carrier-link-interface"
         type: array
@@ -4552,6 +4730,8 @@ definitions:
       ExtensionInterface class for @see \Magento\InventoryApi\Api\Data\StockInterface'
     properties:
       sales_channels:
+        description: Stock extension attributes like sales channels for a stock entity
+          as an array of SalesChannelInterface.
         items:
           "$ref": "#/definitions/inventory-sales-api-data-sales-channel-interface"
         type: array
@@ -4634,8 +4814,10 @@ definitions:
     description: Specifies item and quantity for partial inventory transfer.
     properties:
       qty:
+        description: The quantity of the partial inventory transfer item.
         type: number
       sku:
+        description: The SKU of the partial inventory transfer item.
         type: string
     required:
     - sku
@@ -4714,7 +4896,8 @@ definitions:
     type: object
   inventory-low-quantity-notification-api-data-source-item-configuration-interface:
     description: Represents a Source Item Configuration object Used fully qualified
-      namespaces in annotations for proper work of WebApi request parser
+      namespaces in annotations for proper work of WebApi request parser phpcs:disable
+      Generic.Files.LineLength.TooLong
     properties:
       extension_attributes:
         "$ref": "#/definitions/inventory-low-quantity-notification-api-data-source-item-configuration-extension-interface"
@@ -4785,10 +4968,14 @@ definitions:
     description: ''
     properties:
       code:
+        description: The error code related to product salability, returning it as
+          a string value.
         type: string
       extension_attributes:
         "$ref": "#/definitions/inventory-sales-api-data-product-salability-error-extension-interface"
       message:
+        description: The error message related to product salability, returning it
+          as a string value.
         type: string
     required:
     - code
@@ -4801,12 +4988,14 @@ definitions:
     description: Represents result of service Magento\InventorySalesApi\Api\IsProductSalableForRequestedQtyInterface::execute
     properties:
       errors:
+        description: A list of errors related to product salability.
         items:
           "$ref": "#/definitions/inventory-sales-api-data-product-salability-error-interface"
         type: array
       extension_attributes:
         "$ref": "#/definitions/inventory-sales-api-data-product-salable-result-extension-interface"
       salable:
+        description: If the product is salable based on its availability and conditions.
         type: boolean
     required:
     - salable
@@ -4902,12 +5091,15 @@ definitions:
     description: Data Interface representing particular Source Selection Algorithm
     properties:
       code:
+        description: The code of the Source Selection Algorithm as a string.
         type: string
       description:
+        description: The description of the Source Selection Algorithm as a string.
         type: string
       extension_attributes:
         "$ref": "#/definitions/inventory-source-selection-api-data-source-selection-algorithm-extension-interface"
       title:
+        description: The title of the Source Selection Algorithm as a string.
         type: string
     required:
     - code
@@ -4949,8 +5141,11 @@ definitions:
       extension_attributes:
         "$ref": "#/definitions/inventory-source-selection-api-data-source-selection-result-extension-interface"
       shippable:
+        description: If the source selection result is eligible for shipping.
         type: boolean
       source_selection_items:
+        description: The list of source selection items representing how product quantities
+          are deducted from sources.
         items:
           "$ref": "#/definitions/inventory-source-selection-api-data-source-selection-item-interface"
         type: array
@@ -5751,6 +5946,8 @@ definitions:
   quote-data-address-extension-interface:
     description: ExtensionInterface class for @see \Magento\Quote\Api\Data\AddressInterface
     properties:
+      company_address_id:
+        type: integer
       discounts:
         items:
           "$ref": "#/definitions/sales-rule-data-rule-discount-interface"
@@ -9528,6 +9725,9 @@ definitions:
     type: object
   sales-rule-data-condition-extension-interface:
     description: ExtensionInterface class for @see \Magento\SalesRule\Api\Data\ConditionInterface
+    properties:
+      attribute_scope:
+        type: string
     type: object
   sales-rule-data-condition-interface:
     description: Interface ConditionInterface
@@ -9716,6 +9916,12 @@ definitions:
   sales-rule-data-rule-extension-interface:
     description: ExtensionInterface class for @see \Magento\SalesRule\Api\Data\RuleInterface
     properties:
+      gift_discount_type:
+        type: string
+      gift_qty:
+        type: integer
+      gift_sku:
+        type: string
       reward_points_delta:
         type: integer
     type: object
@@ -10076,6 +10282,85 @@ definitions:
     - code
     - name
     - default_group_id
+    type: object
+  system-config-rest-data-system-config-item-interface:
+    description: System configuration item (path + value + scope) for API
+    properties:
+      path:
+        description: Path (e.g. general/locale/code)
+        type: string
+      scope:
+        description: 'Type: default, website, store'
+        type: string
+      scope_code:
+        description: Code (website code or store code); null for default scope
+        type: string
+      value:
+        description: Value (scalar or array for multi-value fields)
+        type: string
+    required:
+    - path
+    - value
+    - scope
+    type: object
+  system-config-rest-data-system-config-search-results-interface:
+    description: Search results for a system configuration GET request
+    properties:
+      items:
+        description: Items matching the search criteria
+        items:
+          "$ref": "#/definitions/system-config-rest-data-system-config-item-interface"
+        type: array
+      search_criteria:
+        "$ref": "#/definitions/framework-search-criteria-interface"
+      total_count:
+        description: Total count.
+        type: integer
+    required:
+    - items
+    - search_criteria
+    - total_count
+    type: object
+  system-config-rest-data-system-config-update-error-interface:
+    description: A configuration item from a PUT request that was not persisted, with
+      the reason why
+    properties:
+      message:
+        description: Reason the item was not persisted (never includes the submitted
+          value)
+        type: string
+      path:
+        description: Path that was rejected
+        type: string
+      scope:
+        description: 'Type the item was submitted at: default, website, store'
+        type: string
+      scope_code:
+        description: Code the item was submitted at; null for default scope
+        type: string
+    required:
+    - path
+    - scope
+    - message
+    type: object
+  system-config-rest-data-system-config-update-result-interface:
+    description: 'Outcome of a system configuration PUT request: every submitted item
+      is accounted for in either items (persisted) or errors (rejected, with a reason)
+      — never both, never neither'
+    properties:
+      errors:
+        description: That were rejected, with the reason for each
+        items:
+          "$ref": "#/definitions/system-config-rest-data-system-config-update-error-interface"
+        type: array
+      items:
+        description: That were successfully persisted
+        items:
+          "$ref": "#/definitions/system-config-rest-data-system-config-item-interface"
+        type: array
+    required:
+    - items
+    - errors
     type: object
   tax-data-applied-tax-rate-extension-interface:
     description: ExtensionInterface class for @see \Magento\Tax\Api\Data\AppliedTaxRateInterface
@@ -10528,7 +10813,7 @@ definitions:
 host: https://<server>.api.commerce.adobe.com/<tenant-id>
 info:
   title: Adobe Commerce as a Cloud Service
-  version: July 2026
+  version: September 2026
   description:
     "$ref": intro/accs-intro.md
 paths:
@@ -10610,6 +10895,45 @@ paths:
       tags:
       - adminuisdk/appmanagement/validate
       summary: adminuisdk/appmanagement/validate
+  "/V1/adminuisdk/config":
+    put:
+      consumes:
+      - application/json
+      - application/xml
+      description: Enables or disables the Admin UI SDK and returns the resulting
+        state
+      operationId: PutV1AdminuisdkConfig
+      parameters:
+      - in: body
+        name: PutV1AdminuisdkConfigBody
+        schema:
+          properties:
+            enableAdminUiSdk:
+              type: boolean
+          required:
+          - enableAdminUiSdk
+          type: object
+          xml:
+            name: request
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/commerce-backend-uix-data-admin-ui-sdk-config-result-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - adminuisdk/config
+      summary: adminuisdk/config
   "/V1/adminuisdk/extension":
     post:
       consumes:
@@ -10773,6 +11097,49 @@ paths:
       tags:
       - adminuisdk/orderviewbutton/{request_id}
       summary: adminuisdk/orderviewbutton/{request_id}
+  "/V1/adminuisdk/permission/check":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: Checks if the user has permissions for Admin UI SDK ACL resource
+        registered by an extension point
+      operationId: PostV1AdminuisdkPermissionCheck
+      parameters:
+      - in: body
+        name: PostV1AdminuisdkPermissionCheckBody
+        schema:
+          properties:
+            resource:
+              type: string
+          required:
+          - resource
+          type: object
+          xml:
+            name: request
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/commerce-backend-uix-data-permission-check-result-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - adminuisdk/permission/check
+      summary: adminuisdk/permission/check
   "/V1/adobe_io_events/check_configuration":
     get:
       consumes:
@@ -11044,6 +11411,151 @@ paths:
       tags:
       - adobestock/search
       summary: adobestock/search
+  "/V1/attributeMetadata/companyAddress":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Get all attribute metadata.
+      operationId: GetV1AttributeMetadataCompanyAddress
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            items:
+              "$ref": "#/definitions/customer-data-attribute-metadata-interface"
+            type: array
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - attributeMetadata/companyAddress
+      summary: attributeMetadata/companyAddress
+  "/V1/attributeMetadata/companyAddress/attribute/{attributeCode}":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Retrieve attribute metadata.
+      operationId: GetV1AttributeMetadataCompanyAddressAttributeAttributeCode
+      parameters:
+      - in: path
+        name: attributeCode
+        required: true
+        type: string
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/customer-data-attribute-metadata-interface"
+        '400':
+          description: 400 Bad Request
+          schema:
+            "$ref": "#/definitions/error-response"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - attributeMetadata/companyAddress/attribute/{attributeCode}
+      summary: attributeMetadata/companyAddress/attribute/{attributeCode}
+  "/V1/attributeMetadata/companyAddress/custom":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Get custom attributes metadata for the given data interface.
+      operationId: GetV1AttributeMetadataCompanyAddressCustom
+      parameters:
+      - in: query
+        name: dataInterfaceName
+        required: false
+        type: string
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            items:
+              "$ref": "#/definitions/customer-data-attribute-metadata-interface"
+            type: array
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - attributeMetadata/companyAddress/custom
+      summary: attributeMetadata/companyAddress/custom
+  "/V1/attributeMetadata/companyAddress/form/{formCode}":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Retrieve all attributes filtered by form code
+      operationId: GetV1AttributeMetadataCompanyAddressFormFormCode
+      parameters:
+      - in: path
+        name: formCode
+        required: true
+        type: string
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            items:
+              "$ref": "#/definitions/customer-data-attribute-metadata-interface"
+            type: array
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - attributeMetadata/companyAddress/form/{formCode}
+      summary: attributeMetadata/companyAddress/form/{formCode}
   "/V1/attributeMetadata/customer":
     get:
       consumes:
@@ -12173,6 +12685,68 @@ paths:
       tags:
       - carts/{cartId}
       summary: carts/{cartId}
+  "/V1/carts/{cartId}/balance/apply":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: Apply store credit
+      operationId: PostV1CartsCartIdBalanceApply
+      parameters:
+      - in: path
+        name: cartId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            type: boolean
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - carts/{cartId}/balance/apply
+      summary: carts/{cartId}/balance/apply
+  "/V1/carts/{cartId}/balance/unapply":
+    delete:
+      consumes:
+      - application/json
+      - application/xml
+      description: Remove store credit from cart
+      operationId: DeleteV1CartsCartIdBalanceUnapply
+      parameters:
+      - in: path
+        name: cartId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            type: boolean
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - carts/{cartId}/balance/unapply
+      summary: carts/{cartId}/balance/unapply
   "/V1/carts/{cartId}/billing-address":
     get:
       consumes:
@@ -13906,6 +14480,225 @@ paths:
       tags:
       - categories/{id}
       summary: categories/{id}
+  "/V1/companies/{companyId}/billingAddress":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Retrieve the default billing company address for a company.
+      operationId: GetV1CompaniesCompanyIdBillingAddress
+      parameters:
+      - in: path
+        name: companyId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - companies/{companyId}/billingAddress
+      summary: companies/{companyId}/billingAddress
+  "/V1/companies/{companyId}/shippingAddress":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Retrieve the default shipping company address for a company.
+      operationId: GetV1CompaniesCompanyIdShippingAddress
+      parameters:
+      - in: path
+        name: companyId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - companies/{companyId}/shippingAddress
+      summary: companies/{companyId}/shippingAddress
+  "/V1/company-address/{addressId}":
+    delete:
+      consumes:
+      - application/json
+      - application/xml
+      description: Delete company address by ID.
+      operationId: DeleteV1CompanyaddressAddressId
+      parameters:
+      - in: path
+        name: addressId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            type: boolean
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - company-address/{addressId}
+      summary: company-address/{addressId}
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Retrieve company address by ID.
+      operationId: GetV1CompanyaddressAddressId
+      parameters:
+      - in: path
+        name: addressId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - company-address/{addressId}
+      summary: company-address/{addressId}
+    put:
+      consumes:
+      - application/json
+      - application/xml
+      description: Update an existing company address.
+      operationId: PutV1CompanyaddressAddressId
+      parameters:
+      - in: path
+        name: addressId
+        required: true
+        type: integer
+      - in: body
+        name: PutV1CompanyaddressAddressIdBody
+        schema:
+          properties:
+            companyAddress:
+              "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-interface"
+          required:
+          - companyAddress
+          type: object
+          xml:
+            name: request
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - company-address/{addressId}
+      summary: company-address/{addressId}
+  "/V1/company-addresses/{addressId}/default":
+    put:
+      consumes:
+      - application/json
+      - application/xml
+      description: Set a company address as the default for its address type.
+      operationId: PutV1CompanyaddressesAddressIdDefault
+      parameters:
+      - in: path
+        name: addressId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - company-addresses/{addressId}/default
+      summary: company-addresses/{addressId}/default
   "/V1/company/":
     get:
       consumes:
@@ -14514,6 +15307,115 @@ paths:
       tags:
       - company/{companyId}
       summary: company/{companyId}
+  "/V1/company/{companyId}/address":
+    post:
+      consumes:
+      - application/json
+      - application/xml
+      description: Create a company address for the given company.
+      operationId: PostV1CompanyCompanyIdAddress
+      parameters:
+      - in: path
+        name: companyId
+        required: true
+        type: integer
+      - in: body
+        name: PostV1CompanyCompanyIdAddressBody
+        schema:
+          properties:
+            companyAddress:
+              "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-interface"
+          required:
+          - companyAddress
+          type: object
+          xml:
+            name: request
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - company/{companyId}/address
+      summary: company/{companyId}/address
+  "/V1/company/{companyId}/addresses":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: Retrieve company addresses for the given company.
+      operationId: GetV1CompanyCompanyIdAddresses
+      parameters:
+      - in: path
+        name: companyId
+        required: true
+        type: integer
+      - description: Field
+        in: query
+        name: searchCriteria[filterGroups][0][filters][0][field]
+        type: string
+      - description: Value
+        in: query
+        name: searchCriteria[filterGroups][0][filters][0][value]
+        type: string
+      - description: Condition type
+        in: query
+        name: searchCriteria[filterGroups][0][filters][0][conditionType]
+        type: string
+      - description: Sorting field.
+        in: query
+        name: searchCriteria[sortOrders][0][field]
+        type: string
+      - description: Sorting direction.
+        in: query
+        name: searchCriteria[sortOrders][0][direction]
+        type: string
+      - description: Page size.
+        in: query
+        name: searchCriteria[pageSize]
+        type: integer
+      - description: Current page.
+        in: query
+        name: searchCriteria[currentPage]
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/company-address-storefront-compatibility-data-company-address-search-results-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - company/{companyId}/addresses
+      summary: company/{companyId}/addresses
   "/V1/company/{parentId}/relations":
     post:
       consumes:
@@ -16177,9 +17079,10 @@ paths:
       - application/xml
       description: Create a custom email template. Server-assigned fields (template_id,
         added_at, modified_at) and the strict-mode flag (is_legacy = 0) are set by
-        the service; any value supplied for them is ignored. The template_code must
-        be unique. Returns the persisted template, including its server-assigned template_id
-        (usable as-is with POST /V1/custom-email/send).
+        the service; any value supplied for them is ignored — create always assigns
+        a fresh template_id (use updateById to modify an existing template). The template_code
+        must be unique. Returns the persisted template, including its server-assigned
+        template_id (usable as-is with POST /V1/custom-email/send).
       operationId: PostV1CustomemailTemplates
       parameters:
       - in: body
@@ -16217,6 +17120,44 @@ paths:
       - custom-email/templates
       summary: custom-email/templates
   "/V1/custom-email/templates/{templateId}":
+    delete:
+      consumes:
+      - application/json
+      - application/xml
+      description: Delete a custom email template by id. A template that is currently
+        referenced by store configuration (e.g. assigned as a Sales email) cannot
+        be deleted; the attempt is rejected as a 409 Conflict, mirroring the Admin
+        behaviour. The template_id is matched against the current tenant's database
+        only.
+      operationId: DeleteV1CustomemailTemplatesTemplateId
+      parameters:
+      - in: path
+        name: templateId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            type: boolean
+        '400':
+          description: 400 Bad Request
+          schema:
+            "$ref": "#/definitions/error-response"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - custom-email/templates/{templateId}
+      summary: custom-email/templates/{templateId}
     get:
       consumes:
       - application/json
@@ -16229,6 +17170,56 @@ paths:
         name: templateId
         required: true
         type: integer
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/custom-email-template-data-email-template-detail-interface"
+        '400':
+          description: 400 Bad Request
+          schema:
+            "$ref": "#/definitions/error-response"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - custom-email/templates/{templateId}
+      summary: custom-email/templates/{templateId}
+    put:
+      consumes:
+      - application/json
+      - application/xml
+      description: 'Update an existing custom email template by id. Partial (PATCH-like)
+        update: only the fields present in the request are changed; omitted fields
+        keep their stored value. template_code is mutable but must remain unique across
+        templates. The strict-mode flag (is_legacy = 0) is enforced. The templateId
+        is matched against the current tenant''s database only, so a foreign id yields
+        a 404 (no cross-tenant update). Returns the updated template.'
+      operationId: PutV1CustomemailTemplatesTemplateId
+      parameters:
+      - in: path
+        name: templateId
+        required: true
+        type: integer
+      - in: body
+        name: PutV1CustomemailTemplatesTemplateIdBody
+        schema:
+          properties:
+            template:
+              "$ref": "#/definitions/custom-email-template-data-email-template-detail-interface"
+          required:
+          - template
+          type: object
+          xml:
+            name: request
       produces:
       - application/json
       - application/xml
@@ -16814,6 +17805,10 @@ paths:
           description: 200 Success.
           schema:
             "$ref": "#/definitions/customer-data-address-interface"
+        '400':
+          description: 400 Bad Request
+          schema:
+            "$ref": "#/definitions/error-response"
         '401':
           description: 401 Unauthorized
           schema:
@@ -19616,7 +20611,8 @@ paths:
       consumes:
       - application/json
       - application/xml
-      description: ''
+      description: Save an array of SourceItemConfigurationInterface objects passed
+        as parameter.
       operationId: PostV1InventoryLowquantitynotification
       parameters:
       - in: body
@@ -19863,7 +20859,8 @@ paths:
       consumes:
       - application/json
       - application/xml
-      description: ''
+      description: Returns a list of registered Source Selection Algorithm (SSA) data
+        interfaces available in the system.
       operationId: GetV1InventorySourceselectionalgorithmlist
       produces:
       - application/json
@@ -19891,7 +20888,8 @@ paths:
       consumes:
       - application/json
       - application/xml
-      description: ''
+      description: Executes the source selection service using the provided inventory
+        request and algorithm code.
       operationId: PostV1InventorySourceselectionalgorithmresult
       parameters:
       - in: body
@@ -25356,6 +26354,10 @@ paths:
               type: array
             assetId:
               type: string
+            hiddenStoreViews:
+              items:
+                type: string
+              type: array
             position:
               type: integer
             roles:
@@ -29469,6 +30471,134 @@ paths:
       tags:
       - store/websites
       summary: store/websites
+  "/V1/system/config":
+    get:
+      consumes:
+      - application/json
+      - application/xml
+      description: 'Get system configuration values matching the given search criteria
+        Standard Magento search: $searchCriteria''s pageSize/currentPage drive real
+        offset/limit pagination (0/unset pageSize preserves the legacy behavior of
+        returning up to 500 paths with no paging); a "path" filter (single "eq" value
+        or comma-separated "in" list) restricts the result to those specific paths
+        instead of every allowed/visible one, in which case pageSize/ currentPage
+        are ignored since the caller already controls the exact set requested — the
+        returned pageSize/currentPage/totalCount then all reflect that single page.
+        The result''s echoed-back searchCriteria reflects the pageSize/currentPage
+        actually applied.'
+      operationId: GetV1SystemConfig
+      parameters:
+      - description: Field
+        in: query
+        name: searchCriteria[filterGroups][0][filters][0][field]
+        type: string
+      - description: Value
+        in: query
+        name: searchCriteria[filterGroups][0][filters][0][value]
+        type: string
+      - description: Condition type
+        in: query
+        name: searchCriteria[filterGroups][0][filters][0][conditionType]
+        type: string
+      - description: Sorting field.
+        in: query
+        name: searchCriteria[sortOrders][0][field]
+        type: string
+      - description: Sorting direction.
+        in: query
+        name: searchCriteria[sortOrders][0][direction]
+        type: string
+      - description: Page size.
+        in: query
+        name: searchCriteria[pageSize]
+        type: integer
+      - description: Current page.
+        in: query
+        name: searchCriteria[currentPage]
+        type: integer
+      - description: 'Scope type: default, website, store'
+        in: query
+        name: scope
+        required: false
+        type: string
+      - description: Website code or store code; null for default scope
+        in: query
+        name: scopeCode
+        required: false
+        type: string
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/system-config-rest-data-system-config-search-results-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        '500':
+          description: Internal Server error
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - system/config
+      summary: system/config
+    put:
+      consumes:
+      - application/json
+      - application/xml
+      description: 'Update system configuration with multiple options at once Every
+        submitted item is accounted for in the returned result — either persisted
+        (SystemConfigUpdateResultInterface::getItems()) or rejected with a reason
+        (SystemConfigUpdateResultInterface::getErrors()): a restricted path, a path
+        not found in system.xml/not visible for the given scope/not allowed by ACL,
+        an invalid scope code, or a value rejected by a declarative field rule. Saving
+        behavior otherwise matches admin UI save. Persisting one (section, scope)
+        group is independent of another — one group failing to save does not prevent
+        an unrelated group in the same request from being saved. This never throws
+        for a per-item validation problem; an exception here means a genuinely unexpected
+        failure (e.g. a database error).'
+      operationId: PutV1SystemConfig
+      parameters:
+      - in: body
+        name: PutV1SystemConfigBody
+        schema:
+          properties:
+            items:
+              description: Configuration items to save
+              items:
+                "$ref": "#/definitions/system-config-rest-data-system-config-item-interface"
+              type: array
+          required:
+          - items
+          type: object
+          xml:
+            name: request
+      produces:
+      - application/json
+      - application/xml
+      responses:
+        '200':
+          description: 200 Success.
+          schema:
+            "$ref": "#/definitions/system-config-rest-data-system-config-update-result-interface"
+        '401':
+          description: 401 Unauthorized
+          schema:
+            "$ref": "#/definitions/error-response"
+        default:
+          description: Unexpected error
+          schema:
+            "$ref": "#/definitions/error-response"
+      tags:
+      - system/config
+      summary: system/config
   "/V1/taxClasses":
     post:
       consumes:
@@ -30767,15 +31897,21 @@ swagger: '2.0'
 tags:
 - name: addresses/{addressId}
 - name: adminuisdk/appmanagement/validate
+- name: adminuisdk/config
 - name: adminuisdk/extension
 - name: adminuisdk/extension/{workspace_name}/{extension_name}
 - name: adminuisdk/massaction/{request_id}
 - name: adminuisdk/orderviewbutton/{request_id}
+- name: adminuisdk/permission/check
 - name: adobe_io_events/check_configuration
 - name: adobestock/asset/{id}
 - name: adobestock/asset/list
 - name: adobestock/asset/search
 - name: adobestock/search
+- name: attributeMetadata/companyAddress
+- name: attributeMetadata/companyAddress/attribute/{attributeCode}
+- name: attributeMetadata/companyAddress/custom
+- name: attributeMetadata/companyAddress/form/{formCode}
 - name: attributeMetadata/customer
 - name: attributeMetadata/customer/attribute/{attributeCode}
 - name: attributeMetadata/customer/custom
@@ -30799,6 +31935,8 @@ tags:
 - name: bundle-products/options/types
 - name: carts/
 - name: carts/{cartId}
+- name: carts/{cartId}/balance/apply
+- name: carts/{cartId}/balance/unapply
 - name: carts/{cartId}/billing-address
 - name: carts/{cartId}/coupons
 - name: carts/{cartId}/coupons/{couponCode}
@@ -30834,8 +31972,14 @@ tags:
 - name: categories/attributes/{attributeCode}
 - name: categories/attributes/{attributeCode}/options
 - name: categories/list
+- name: companies/{companyId}/billingAddress
+- name: companies/{companyId}/shippingAddress
+- name: company-address/{addressId}
+- name: company-addresses/{addressId}/default
 - name: company/
 - name: company/{companyId}
+- name: company/{companyId}/address
+- name: company/{companyId}/addresses
 - name: company/{parentId}/relations
 - name: company/{parentId}/relations/{companyId}
 - name: company/assignRoles
@@ -31132,6 +32276,7 @@ tags:
 - name: store/storeGroups
 - name: store/storeViews
 - name: store/websites
+- name: system/config
 - name: taxClasses
 - name: taxClasses/{classId}
 - name: taxClasses/{taxClassId}
@@ -31158,10 +32303,12 @@ x-tagGroups:
 - name: adminuisdk
   tags:
   - adminuisdk/appmanagement/validate
+  - adminuisdk/config
   - adminuisdk/extension
   - adminuisdk/extension/{workspace_name}/{extension_name}
   - adminuisdk/massaction/{request_id}
   - adminuisdk/orderviewbutton/{request_id}
+  - adminuisdk/permission/check
 - name: adobe_io_events
   tags:
   - adobe_io_events/check_configuration
@@ -31173,6 +32320,10 @@ x-tagGroups:
   - adobestock/search
 - name: attributeMetadata
   tags:
+  - attributeMetadata/companyAddress
+  - attributeMetadata/companyAddress/attribute/{attributeCode}
+  - attributeMetadata/companyAddress/custom
+  - attributeMetadata/companyAddress/form/{formCode}
   - attributeMetadata/customer
   - attributeMetadata/customer/attribute/{attributeCode}
   - attributeMetadata/customer/custom
@@ -31205,6 +32356,8 @@ x-tagGroups:
   - carts/licence/list
   - carts/search
   - carts/{cartId}
+  - carts/{cartId}/balance/apply
+  - carts/{cartId}/balance/unapply
   - carts/{cartId}/billing-address
   - carts/{cartId}/coupons
   - carts/{cartId}/coupons/deleteByCodes
@@ -31239,6 +32392,16 @@ x-tagGroups:
   - categories/{categoryId}/products
   - categories/{categoryId}/products/{sku}
   - categories/{id}
+- name: companies
+  tags:
+  - companies/{companyId}/billingAddress
+  - companies/{companyId}/shippingAddress
+- name: company address
+  tags:
+  - company-address/{addressId}
+- name: company addresses
+  tags:
+  - company-addresses/{addressId}/default
 - name: company
   tags:
   - company/
@@ -31250,6 +32413,8 @@ x-tagGroups:
   - company/role/{roleId}/users
   - company/setCustomAttributes
   - company/{companyId}
+  - company/{companyId}/address
+  - company/{companyId}/addresses
   - company/{parentId}/relations
   - company/{parentId}/relations/{companyId}
 - name: companyCredits
@@ -31625,6 +32790,9 @@ x-tagGroups:
   - store/storeGroups
   - store/storeViews
   - store/websites
+- name: system
+  tags:
+  - system/config
 - name: taxClasses
   tags:
   - taxClasses

--- a/src/pages/includes/autogenerated/graphql-api-saas-mutations.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-mutations.md
@@ -119,26 +119,26 @@ mutation acceptNegotiableQuoteTemplate($input: AcceptNegotiableQuoteTemplateInpu
       "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
-      "is_min_max_qty_used": true,
-      "is_virtual": true,
+      "is_min_max_qty_used": false,
+      "is_virtual": false,
       "items": [CartItemInterface],
       "max_order_commitment": 987,
       "min_order_commitment": 987,
-      "name": "abc123",
+      "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
         NegotiableQuoteReferenceDocumentLink
       ],
-      "sales_rep_name": "abc123",
+      "sales_rep_name": "xyz789",
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
-      "status": "xyz789",
-      "template_id": 4,
-      "total_quantity": 123.45,
+      "status": "abc123",
+      "template_id": "4",
+      "total_quantity": 987.65,
       "uid": "4",
-      "updated_at": "xyz789"
+      "updated_at": "abc123"
     }
   }
 }
@@ -227,7 +227,7 @@ mutation addGiftRegistryRegistrants(
 
 ```json
 {
-  "giftRegistryUid": 4,
+  "giftRegistryUid": "4",
   "registrants": [AddGiftRegistryRegistrantInput]
 }
 ```
@@ -286,7 +286,7 @@ mutation addProductsToCart(
 
 ```json
 {
-  "cartId": "abc123",
+  "cartId": "xyz789",
   "cartItems": [CartItemInput]
 }
 ```
@@ -350,7 +350,7 @@ mutation addProductsToCompareList($input: AddProductsToCompareListInput) {
   "data": {
     "addProductsToCompareList": {
       "attributes": [ComparableAttribute],
-      "item_count": 987,
+      "item_count": 123,
       "items": [ComparableItem],
       "uid": 4
     }
@@ -663,8 +663,8 @@ mutation addRequisitionListItemsToCart(
 
 ```json
 {
-  "requisitionListUid": "4",
-  "requisitionListItemUids": [4]
+  "requisitionListUid": 4,
+  "requisitionListItemUids": ["4"]
 }
 ```
 
@@ -678,7 +678,7 @@ mutation addRequisitionListItemsToCart(
         AddRequisitionListItemToCartUserError
       ],
       "cart": Cart,
-      "status": false
+      "status": true
     }
   }
 }
@@ -816,7 +816,7 @@ mutation addWishlistItemsToCart(
 ##### Variables
 
 ```json
-{"wishlistId": 4, "wishlistItemIds": [4]}
+{"wishlistId": 4, "wishlistItemIds": ["4"]}
 ```
 
 ##### Response
@@ -828,7 +828,7 @@ mutation addWishlistItemsToCart(
       "add_wishlist_items_to_cart_user_errors": [
         WishlistCartUserInputError
       ],
-      "status": true,
+      "status": false,
       "wishlist": Wishlist
     }
   }
@@ -1163,7 +1163,7 @@ mutation assignCompareListToCustomer($uid: ID!) {
 ##### Variables
 
 ```json
-{"uid": "4"}
+{"uid": 4}
 ```
 
 ##### Response
@@ -1173,7 +1173,7 @@ mutation assignCompareListToCustomer($uid: ID!) {
   "data": {
     "assignCompareListToCustomer": {
       "compare_list": CompareList,
-      "result": false
+      "result": true
     }
   }
 }
@@ -1212,6 +1212,9 @@ mutation assignCustomerToGuestCart($cart_id: String!) {
     applied_store_credit {
       ...AppliedStoreCreditFragment
     }
+    available_free_gifts {
+      ...AvailableFreeGiftFragment
+    }
     available_gift_wrappings {
       ...GiftWrappingFragment
     }
@@ -1232,6 +1235,7 @@ mutation assignCustomerToGuestCart($cart_id: String!) {
     gift_wrapping {
       ...GiftWrappingFragment
     }
+    has_available_free_gifts
     id
     is_virtual
     itemsV2 {
@@ -1258,7 +1262,7 @@ mutation assignCustomerToGuestCart($cart_id: String!) {
 ##### Variables
 
 ```json
-{"cart_id": "abc123"}
+{"cart_id": "xyz789"}
 ```
 
 ##### Response
@@ -1271,25 +1275,27 @@ mutation assignCustomerToGuestCart($cart_id: String!) {
       "applied_gift_cards": [AppliedGiftCard],
       "applied_reward_points": RewardPointsAmount,
       "applied_store_credit": AppliedStoreCredit,
+      "available_free_gifts": [AvailableFreeGift],
       "available_gift_wrappings": [GiftWrapping],
       "available_payment_methods": [
         AvailablePaymentMethod
       ],
       "billing_address": BillingCartAddress,
       "custom_attributes": [CustomAttribute],
-      "email": "abc123",
+      "email": "xyz789",
       "gift_message": GiftMessage,
-      "gift_receipt_included": true,
+      "gift_receipt_included": false,
       "gift_wrapping": GiftWrapping,
+      "has_available_free_gifts": true,
       "id": "4",
-      "is_virtual": false,
+      "is_virtual": true,
       "itemsV2": CartItems,
       "prices": CartPrices,
-      "printed_card_included": false,
+      "printed_card_included": true,
       "rules": [CartRuleStorefront],
       "selected_payment_method": SelectedPaymentMethod,
       "shipping_addresses": [ShippingCartAddress],
-      "total_quantity": 987.65
+      "total_quantity": 123.45
     }
   }
 }
@@ -1378,12 +1384,12 @@ mutation cancelNegotiableQuoteTemplate($input: CancelNegotiableQuoteTemplateInpu
       "expiration_date": "abc123",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
-      "is_min_max_qty_used": false,
-      "is_virtual": true,
+      "is_min_max_qty_used": true,
+      "is_virtual": false,
       "items": [CartItemInterface],
-      "max_order_commitment": 987,
+      "max_order_commitment": 123,
       "min_order_commitment": 987,
-      "name": "abc123",
+      "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
@@ -1641,8 +1647,8 @@ mutation changeCustomerPassword(
 
 ```json
 {
-  "currentPassword": "xyz789",
-  "newPassword": "abc123"
+  "currentPassword": "abc123",
+  "newPassword": "xyz789"
 }
 ```
 
@@ -1655,27 +1661,27 @@ mutation changeCustomerPassword(
       "addresses": [CustomerAddress],
       "addressesV2": CustomerAddresses,
       "admin_assistance_actions": AdminAssistanceActions,
-      "allow_remote_shopping_assistance": false,
+      "allow_remote_shopping_assistance": true,
       "companies": UserCompaniesOutput,
       "company_hierarchy": [CompanyHierarchy],
       "compare_list": CompareList,
       "confirmation_status": "ACCOUNT_CONFIRMED",
       "created_at": "abc123",
       "custom_attributes": [AttributeValueInterface],
-      "date_of_birth": "xyz789",
+      "date_of_birth": "abc123",
       "default_billing": "xyz789",
-      "default_shipping": "xyz789",
-      "email": "xyz789",
+      "default_shipping": "abc123",
+      "email": "abc123",
       "firstname": "xyz789",
-      "gender": 123,
+      "gender": 987,
       "gift_registries": [GiftRegistry],
       "gift_registry": GiftRegistry,
       "group": CustomerGroupStorefront,
-      "id": "4",
+      "id": 4,
       "is_subscribed": false,
       "job_title": "xyz789",
       "lastname": "xyz789",
-      "middlename": "xyz789",
+      "middlename": "abc123",
       "orders": CustomerOrders,
       "prefix": "abc123",
       "purchase_order": PurchaseOrder,
@@ -1683,7 +1689,7 @@ mutation changeCustomerPassword(
       "purchase_order_approval_rule_metadata": PurchaseOrderApprovalRuleMetadata,
       "purchase_order_approval_rules": PurchaseOrderApprovalRules,
       "purchase_orders": PurchaseOrders,
-      "purchase_orders_enabled": false,
+      "purchase_orders_enabled": true,
       "quote_enabled": true,
       "requisition_lists": RequisitionLists,
       "return": Return,
@@ -1693,13 +1699,63 @@ mutation changeCustomerPassword(
       "segments": [CustomerSegmentStorefront],
       "status": "ACTIVE",
       "store_credit": CustomerStoreCredit,
-      "structure_id": 4,
-      "suffix": "xyz789",
-      "taxvat": "xyz789",
+      "structure_id": "4",
+      "suffix": "abc123",
+      "taxvat": "abc123",
       "team": CompanyTeam,
       "telephone": "abc123",
       "wishlist_v2": Wishlist,
       "wishlists": [Wishlist]
+    }
+  }
+}
+```
+
+<HorizontalLine />
+
+### clearCart
+
+Remove all items from the specified cart.
+
+**Response:** [`ClearCartOutput!`](/reference/graphql/saas/types-c-e.md#clearcartoutput)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `input` - [`ClearCartInput!`](/reference/graphql/saas/types-c-e.md#clearcartinput) | An input object that defines cart ID of the shopper. |
+
+#### Example
+
+##### Query
+
+```graphql
+mutation clearCart($input: ClearCartInput!) {
+  clearCart(input: $input) {
+    cart {
+      ...CartFragment
+    }
+    errors {
+      ...ClearCartErrorFragment
+    }
+  }
+}
+```
+
+##### Variables
+
+```json
+{"input": ClearCartInput}
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "clearCart": {
+      "cart": Cart,
+      "errors": [ClearCartError]
     }
   }
 }
@@ -1745,7 +1801,7 @@ mutation clearCustomerCart($cartUid: String!) {
 ```json
 {
   "data": {
-    "clearCustomerCart": {"cart": Cart, "status": false}
+    "clearCustomerCart": {"cart": Cart, "status": true}
   }
 }
 ```
@@ -2086,7 +2142,7 @@ mutation contactUs($input: ContactUsInput!) {
 ##### Response
 
 ```json
-{"data": {"contactUs": {"status": true}}}
+{"data": {"contactUs": {"status": false}}}
 ```
 
 <HorizontalLine />
@@ -2132,7 +2188,7 @@ mutation copyItemsBetweenRequisitionLists(
 ```json
 {
   "sourceRequisitionListUid": 4,
-  "destinationRequisitionListUid": 4,
+  "destinationRequisitionListUid": "4",
   "requisitionListItem": CopyItemsBetweenRequisitionListsInput
 }
 ```
@@ -2197,8 +2253,8 @@ mutation copyProductsBetweenWishlists(
 
 ```json
 {
-  "sourceWishlistUid": 4,
-  "destinationWishlistUid": 4,
+  "sourceWishlistUid": "4",
+  "destinationWishlistUid": "4",
   "wishlistItems": [WishlistItemCopyInput]
 }
 ```
@@ -2255,6 +2311,98 @@ mutation createCompany($input: CompanyCreateInput!) {
 
 ```json
 {"data": {"createCompany": {"company": Company}}}
+```
+
+<HorizontalLine />
+
+### createCompanyAddress
+
+Create a new company address.
+
+**Response:** [`CompanyAddress`](/reference/graphql/saas/types-c-e.md#companyaddress)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `input` - [`CompanyAddressInput!`](/reference/graphql/saas/types-c-e.md#companyaddressinput) | An input object that defines the company address to create. |
+
+#### Example
+
+##### Query
+
+```graphql
+mutation createCompanyAddress($input: CompanyAddressInput!) {
+  createCompanyAddress(input: $input) {
+    address_type
+    city
+    company
+    company_id
+    country_code
+    custom_attributes {
+      ...AttributeValueInterfaceFragment
+    }
+    extension_attributes {
+      ...CustomerAddressAttributeFragment
+    }
+    fax
+    firstname
+    id
+    is_default
+    lastname
+    middlename
+    nickname
+    postcode
+    prefix
+    region {
+      ...CustomerAddressRegionFragment
+    }
+    region_id
+    street
+    suffix
+    telephone
+    vat_id
+  }
+}
+```
+
+##### Variables
+
+```json
+{"input": CompanyAddressInput}
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "createCompanyAddress": {
+      "address_type": "BILLING",
+      "city": "xyz789",
+      "company": "xyz789",
+      "company_id": 4,
+      "country_code": "AF",
+      "custom_attributes": [AttributeValueInterface],
+      "extension_attributes": [CustomerAddressAttribute],
+      "fax": "xyz789",
+      "firstname": "abc123",
+      "id": 4,
+      "is_default": false,
+      "lastname": "xyz789",
+      "middlename": "abc123",
+      "nickname": "xyz789",
+      "postcode": "abc123",
+      "prefix": "xyz789",
+      "region": CustomerAddressRegion,
+      "region_id": 123,
+      "street": ["xyz789"],
+      "suffix": "abc123",
+      "telephone": "xyz789",
+      "vat_id": "abc123"
+    }
+  }
+}
 ```
 
 <HorizontalLine />
@@ -2425,7 +2573,7 @@ mutation createCompareList($input: CreateCompareListInput) {
       "attributes": [ComparableAttribute],
       "item_count": 987,
       "items": [ComparableItem],
-      "uid": 4
+      "uid": "4"
     }
   }
 }
@@ -2495,27 +2643,27 @@ mutation createCustomerAddress($input: CustomerAddressInput!) {
 {
   "data": {
     "createCustomerAddress": {
-      "city": "xyz789",
-      "company": "xyz789",
+      "city": "abc123",
+      "company": "abc123",
       "country_code": "AF",
       "custom_attributesV2": [AttributeValueInterface],
-      "default_billing": false,
-      "default_shipping": false,
+      "default_billing": true,
+      "default_shipping": true,
       "extension_attributes": [CustomerAddressAttribute],
-      "fax": "xyz789",
-      "firstname": "abc123",
+      "fax": "abc123",
+      "firstname": "xyz789",
       "id": 123,
       "lastname": "xyz789",
-      "middlename": "abc123",
-      "postcode": "xyz789",
-      "prefix": "abc123",
+      "middlename": "xyz789",
+      "postcode": "abc123",
+      "prefix": "xyz789",
       "region": CustomerAddressRegion,
       "region_id": 123,
       "street": ["abc123"],
       "suffix": "abc123",
-      "telephone": "xyz789",
-      "uid": 4,
-      "vat_id": "xyz789"
+      "telephone": "abc123",
+      "uid": "4",
+      "vat_id": "abc123"
     }
   }
 }
@@ -2647,6 +2795,64 @@ mutation createGuestCart($input: CreateGuestCartInput) {
 
 <HorizontalLine />
 
+### createPaymentLink
+
+Mint a Pay By Link payment link against a guest clone of the cart.
+
+**Response:** [`CreatePaymentLinkOutput`](/reference/graphql/saas/types-c-e.md#createpaymentlinkoutput)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `cartId` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | Masked id of the cart to mint a payment link for. |
+| `recipientEmail` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Optional override for the email the link is sent to; defaults to the cart customer email. |
+
+#### Example
+
+##### Query
+
+```graphql
+mutation createPaymentLink(
+  $cartId: String!,
+  $recipientEmail: String
+) {
+  createPaymentLink(
+    cartId: $cartId,
+    recipientEmail: $recipientEmail
+  ) {
+    expiresAt
+    payUrl
+    token
+  }
+}
+```
+
+##### Variables
+
+```json
+{
+  "cartId": "abc123",
+  "recipientEmail": "abc123"
+}
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "createPaymentLink": {
+      "expiresAt": "xyz789",
+      "payUrl": "abc123",
+      "token": "abc123"
+    }
+  }
+}
+```
+
+<HorizontalLine />
+
 ### createPaymentOrder
 
 Creates a payment order for further payment processing
@@ -2690,7 +2896,7 @@ mutation createPaymentOrder($input: CreatePaymentOrderInput!) {
       "amount": 987.65,
       "currency_code": "xyz789",
       "id": "abc123",
-      "mp_order_id": "abc123",
+      "mp_order_id": "xyz789",
       "status": "xyz789"
     }
   }
@@ -2753,13 +2959,13 @@ mutation createPurchaseOrderApprovalRule($input: PurchaseOrderApprovalRuleInput!
       "applies_to_roles": [CompanyRole],
       "approver_roles": [CompanyRole],
       "condition": PurchaseOrderApprovalRuleConditionInterface,
-      "created_at": "abc123",
+      "created_at": "xyz789",
       "created_by": "abc123",
       "description": "xyz789",
       "name": "xyz789",
       "status": "ENABLED",
       "uid": 4,
-      "updated_at": "xyz789"
+      "updated_at": "abc123"
     }
   }
 }
@@ -2945,6 +3151,42 @@ mutation createWishlist($input: CreateWishlistInput!) {
 
 <HorizontalLine />
 
+### deleteCompanyAddress
+
+Delete a company address.
+
+**Response:** [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The ID of the company address to delete. |
+
+#### Example
+
+##### Query
+
+```graphql
+mutation deleteCompanyAddress($id: ID!) {
+  deleteCompanyAddress(id: $id)
+}
+```
+
+##### Variables
+
+```json
+{"id": "4"}
+```
+
+##### Response
+
+```json
+{"data": {"deleteCompanyAddress": false}}
+```
+
+<HorizontalLine />
+
 ### deleteCompanyRole
 
 Delete the specified company role.
@@ -2972,7 +3214,7 @@ mutation deleteCompanyRole($id: ID!) {
 ##### Variables
 
 ```json
-{"id": "4"}
+{"id": 4}
 ```
 
 ##### Response
@@ -3054,7 +3296,7 @@ mutation deleteCompanyUserV2($id: ID!) {
 ##### Response
 
 ```json
-{"data": {"deleteCompanyUserV2": {"success": true}}}
+{"data": {"deleteCompanyUserV2": {"success": false}}}
 ```
 
 <HorizontalLine />
@@ -3086,13 +3328,13 @@ mutation deleteCompareList($uid: ID!) {
 ##### Variables
 
 ```json
-{"uid": 4}
+{"uid": "4"}
 ```
 
 ##### Response
 
 ```json
-{"data": {"deleteCompareList": {"result": false}}}
+{"data": {"deleteCompareList": {"result": true}}}
 ```
 
 <HorizontalLine />
@@ -3150,13 +3392,13 @@ mutation deleteCustomerAddress($id: Int!) {
 ##### Variables
 
 ```json
-{"id": 987}
+{"id": 123}
 ```
 
 ##### Response
 
 ```json
-{"data": {"deleteCustomerAddress": false}}
+{"data": {"deleteCustomerAddress": true}}
 ```
 
 <HorizontalLine />
@@ -3332,7 +3574,7 @@ mutation deletePaymentToken($public_hash: String!) {
   "data": {
     "deletePaymentToken": {
       "customerPaymentTokens": CustomerPaymentTokens,
-      "result": true
+      "result": false
     }
   }
 }
@@ -3470,10 +3712,7 @@ mutation deleteRequisitionListItems(
 ##### Variables
 
 ```json
-{
-  "requisitionListUid": 4,
-  "requisitionListItemUids": ["4"]
-}
+{"requisitionListUid": 4, "requisitionListItemUids": [4]}
 ```
 
 ##### Response
@@ -3520,7 +3759,7 @@ mutation deleteWishlist($wishlistId: ID!) {
 ##### Variables
 
 ```json
-{"wishlistId": "4"}
+{"wishlistId": 4}
 ```
 
 ##### Response
@@ -3642,8 +3881,8 @@ mutation estimateShippingMethods($input: EstimateTotalsInput!) {
         "carrier_code": "xyz789",
         "carrier_title": "xyz789",
         "error_message": "abc123",
-        "method_code": "abc123",
-        "method_title": "abc123",
+        "method_code": "xyz789",
+        "method_title": "xyz789",
         "price_excl_tax": Money,
         "price_incl_tax": Money
       }
@@ -3734,7 +3973,7 @@ mutation exchangeExternalCustomerToken($input: ExchangeExternalCustomerTokenInpu
   "data": {
     "exchangeExternalCustomerToken": {
       "customer": Customer,
-      "token": "xyz789"
+      "token": "abc123"
     }
   }
 }
@@ -3778,7 +4017,7 @@ mutation exchangeOtpForCustomerToken(
 ```json
 {
   "email": "xyz789",
-  "otp": "abc123"
+  "otp": "xyz789"
 }
 ```
 
@@ -3832,8 +4071,8 @@ mutation finishUpload($input: finishUploadInput!) {
 {
   "data": {
     "finishUpload": {
-      "key": "abc123",
-      "message": "abc123",
+      "key": "xyz789",
+      "message": "xyz789",
       "success": true
     }
   }
@@ -3877,7 +4116,7 @@ mutation generateCustomerToken(
 
 ```json
 {
-  "email": "abc123",
+  "email": "xyz789",
   "password": "abc123"
 }
 ```
@@ -3932,7 +4171,7 @@ mutation generateCustomerTokenAsAdmin($input: GenerateCustomerTokenAsAdminInput!
 {
   "data": {
     "generateCustomerTokenAsAdmin": {
-      "customer_token": "abc123"
+      "customer_token": "xyz789"
     }
   }
 }
@@ -3973,13 +4212,7 @@ mutation generateNegotiableQuoteFromTemplate($input: GenerateNegotiableQuoteFrom
 ##### Response
 
 ```json
-{
-  "data": {
-    "generateNegotiableQuoteFromTemplate": {
-      "negotiable_quote_uid": "4"
-    }
-  }
-}
+{"data": {"generateNegotiableQuoteFromTemplate": {"negotiable_quote_uid": 4}}}
 ```
 
 <HorizontalLine />
@@ -4016,7 +4249,7 @@ mutation importSharedRequisitionList($token: String!) {
 ##### Variables
 
 ```json
-{"token": "abc123"}
+{"token": "xyz789"}
 ```
 
 ##### Response
@@ -4070,7 +4303,7 @@ mutation initiateUpload($input: initiateUploadInput!) {
 {
   "data": {
     "initiateUpload": {
-      "expires_at": "xyz789",
+      "expires_at": "abc123",
       "key": "xyz789",
       "upload_url": "xyz789"
     }
@@ -4118,6 +4351,9 @@ mutation mergeCarts(
     applied_store_credit {
       ...AppliedStoreCreditFragment
     }
+    available_free_gifts {
+      ...AvailableFreeGiftFragment
+    }
     available_gift_wrappings {
       ...GiftWrappingFragment
     }
@@ -4138,6 +4374,7 @@ mutation mergeCarts(
     gift_wrapping {
       ...GiftWrappingFragment
     }
+    has_available_free_gifts
     id
     is_virtual
     itemsV2 {
@@ -4165,7 +4402,7 @@ mutation mergeCarts(
 
 ```json
 {
-  "source_cart_id": "xyz789",
+  "source_cart_id": "abc123",
   "destination_cart_id": "xyz789"
 }
 ```
@@ -4180,18 +4417,20 @@ mutation mergeCarts(
       "applied_gift_cards": [AppliedGiftCard],
       "applied_reward_points": RewardPointsAmount,
       "applied_store_credit": AppliedStoreCredit,
+      "available_free_gifts": [AvailableFreeGift],
       "available_gift_wrappings": [GiftWrapping],
       "available_payment_methods": [
         AvailablePaymentMethod
       ],
       "billing_address": BillingCartAddress,
       "custom_attributes": [CustomAttribute],
-      "email": "xyz789",
+      "email": "abc123",
       "gift_message": GiftMessage,
-      "gift_receipt_included": true,
+      "gift_receipt_included": false,
       "gift_wrapping": GiftWrapping,
+      "has_available_free_gifts": false,
       "id": 4,
-      "is_virtual": true,
+      "is_virtual": false,
       "itemsV2": CartItems,
       "prices": CartPrices,
       "printed_card_included": false,
@@ -4311,8 +4550,8 @@ mutation moveItemsBetweenRequisitionLists(
 
 ```json
 {
-  "sourceRequisitionListUid": 4,
-  "destinationRequisitionListUid": "4",
+  "sourceRequisitionListUid": "4",
+  "destinationRequisitionListUid": 4,
   "requisitionListItem": MoveItemsBetweenRequisitionListsInput
 }
 ```
@@ -4425,7 +4664,7 @@ mutation moveProductsBetweenWishlists(
 ```json
 {
   "sourceWishlistUid": "4",
-  "destinationWishlistUid": "4",
+  "destinationWishlistUid": 4,
   "wishlistItems": [WishlistItemMoveInput]
 }
 ```
@@ -4524,29 +4763,29 @@ mutation openNegotiableQuoteTemplate($input: OpenNegotiableQuoteTemplateInput!) 
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
       "created_at": "xyz789",
-      "expiration_date": "abc123",
+      "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
       "is_min_max_qty_used": false,
-      "is_virtual": false,
+      "is_virtual": true,
       "items": [CartItemInterface],
-      "max_order_commitment": 987,
-      "min_order_commitment": 123,
-      "name": "abc123",
+      "max_order_commitment": 123,
+      "min_order_commitment": 987,
+      "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
         NegotiableQuoteReferenceDocumentLink
       ],
-      "sales_rep_name": "abc123",
+      "sales_rep_name": "xyz789",
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
       "status": "abc123",
-      "template_id": "4",
+      "template_id": 4,
       "total_quantity": 987.65,
       "uid": 4,
-      "updated_at": "abc123"
+      "updated_at": "xyz789"
     }
   }
 }
@@ -4829,7 +5068,7 @@ mutation redeemGiftCardBalanceAsStoreCredit($input: GiftCardAccountInput!) {
   "data": {
     "redeemGiftCardBalanceAsStoreCredit": {
       "balance": Money,
-      "code": "xyz789",
+      "code": "abc123",
       "expiration_date": "xyz789"
     }
   }
@@ -5035,7 +5274,7 @@ mutation removeGiftRegistry($giftRegistryUid: ID!) {
 ##### Variables
 
 ```json
-{"giftRegistryUid": 4}
+{"giftRegistryUid": "4"}
 ```
 
 ##### Response
@@ -5138,10 +5377,7 @@ mutation removeGiftRegistryRegistrants(
 ##### Variables
 
 ```json
-{
-  "giftRegistryUid": 4,
-  "registrantsUid": ["4"]
-}
+{"giftRegistryUid": 4, "registrantsUid": [4]}
 ```
 
 ##### Response
@@ -5328,23 +5564,23 @@ mutation removeNegotiableQuoteTemplateItems($input: RemoveNegotiableQuoteTemplat
       "is_min_max_qty_used": true,
       "is_virtual": false,
       "items": [CartItemInterface],
-      "max_order_commitment": 123,
-      "min_order_commitment": 123,
-      "name": "abc123",
+      "max_order_commitment": 987,
+      "min_order_commitment": 987,
+      "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
         NegotiableQuoteReferenceDocumentLink
       ],
-      "sales_rep_name": "abc123",
+      "sales_rep_name": "xyz789",
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
-      "status": "abc123",
+      "status": "xyz789",
       "template_id": 4,
       "total_quantity": 123.45,
       "uid": 4,
-      "updated_at": "xyz789"
+      "updated_at": "abc123"
     }
   }
 }
@@ -5396,9 +5632,9 @@ mutation removeProductsFromCompareList($input: RemoveProductsFromCompareListInpu
   "data": {
     "removeProductsFromCompareList": {
       "attributes": [ComparableAttribute],
-      "item_count": 123,
+      "item_count": 987,
       "items": [ComparableItem],
-      "uid": 4
+      "uid": "4"
     }
   }
 }
@@ -5445,10 +5681,7 @@ mutation removeProductsFromWishlist(
 ##### Variables
 
 ```json
-{
-  "wishlistId": "4",
-  "wishlistItemsIds": ["4"]
-}
+{"wishlistId": 4, "wishlistItemsIds": ["4"]}
 ```
 
 ##### Response
@@ -5535,7 +5768,7 @@ mutation removeRewardPointsFromCart($cartId: ID!) {
 ##### Variables
 
 ```json
-{"cartId": "4"}
+{"cartId": 4}
 ```
 
 ##### Response
@@ -5662,7 +5895,7 @@ mutation reorderItems($orderNumber: String!) {
 ##### Variables
 
 ```json
-{"orderNumber": "xyz789"}
+{"orderNumber": "abc123"}
 ```
 
 ##### Response
@@ -5722,7 +5955,7 @@ mutation requestGuestOrderCancel($input: GuestOrderCancelInput!) {
 {
   "data": {
     "requestGuestOrderCancel": {
-      "error": "abc123",
+      "error": "xyz789",
       "errorV2": CancelOrderError,
       "order": CustomerOrder
     }
@@ -5901,30 +6134,30 @@ mutation requestNegotiableQuoteTemplateFromQuote($input: RequestNegotiableQuoteT
     "requestNegotiableQuoteTemplateFromQuote": {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
-      "created_at": "abc123",
+      "created_at": "xyz789",
       "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
-      "is_min_max_qty_used": true,
+      "is_min_max_qty_used": false,
       "is_virtual": true,
       "items": [CartItemInterface],
-      "max_order_commitment": 123,
-      "min_order_commitment": 987,
-      "name": "xyz789",
+      "max_order_commitment": 987,
+      "min_order_commitment": 123,
+      "name": "abc123",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
         NegotiableQuoteReferenceDocumentLink
       ],
-      "sales_rep_name": "abc123",
+      "sales_rep_name": "xyz789",
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
-      "status": "xyz789",
+      "status": "abc123",
       "template_id": 4,
       "total_quantity": 987.65,
-      "uid": "4",
-      "updated_at": "abc123"
+      "uid": 4,
+      "updated_at": "xyz789"
     }
   }
 }
@@ -5963,7 +6196,7 @@ mutation requestPasswordResetEmail($email: String!) {
 ##### Response
 
 ```json
-{"data": {"requestPasswordResetEmail": true}}
+{"data": {"requestPasswordResetEmail": false}}
 ```
 
 <HorizontalLine />
@@ -6043,13 +6276,13 @@ mutation resendConfirmationEmail($email: String!) {
 ##### Variables
 
 ```json
-{"email": "abc123"}
+{"email": "xyz789"}
 ```
 
 ##### Response
 
 ```json
-{"data": {"resendConfirmationEmail": true}}
+{"data": {"resendConfirmationEmail": false}}
 ```
 
 <HorizontalLine />
@@ -6090,16 +6323,16 @@ mutation resetPassword(
 
 ```json
 {
-  "email": "xyz789",
+  "email": "abc123",
   "resetPasswordToken": "abc123",
-  "newPassword": "abc123"
+  "newPassword": "xyz789"
 }
 ```
 
 ##### Response
 
 ```json
-{"data": {"resetPassword": true}}
+{"data": {"resetPassword": false}}
 ```
 
 <HorizontalLine />
@@ -6126,6 +6359,46 @@ mutation revokeCustomerToken {
 
 ```json
 {"data": {"revokeCustomerToken": {"result": true}}}
+```
+
+<HorizontalLine />
+
+### selectFreeGiftForCart
+
+Defines the product that a shopper has selected as a free gift. This mutations is applicable only if a Free Gift cart price rule has been applied to the cart.
+
+**Response:** [`SelectFreeGiftForCartOutput`](/reference/graphql/saas/types-q-s.md#selectfreegiftforcartoutput)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `input` - [`SelectFreeGiftForCartInput!`](/reference/graphql/saas/types-q-s.md#selectfreegiftforcartinput) |  |
+
+#### Example
+
+##### Query
+
+```graphql
+mutation selectFreeGiftForCart($input: SelectFreeGiftForCartInput!) {
+  selectFreeGiftForCart(input: $input) {
+    cart {
+      ...CartFragment
+    }
+  }
+}
+```
+
+##### Variables
+
+```json
+{"input": SelectFreeGiftForCartInput}
+```
+
+##### Response
+
+```json
+{"data": {"selectFreeGiftForCart": {"cart": Cart}}}
 ```
 
 <HorizontalLine />
@@ -6253,7 +6526,7 @@ mutation setCartAsInactive($cartId: String!) {
 {
   "data": {
     "setCartAsInactive": {
-      "error": "xyz789",
+      "error": "abc123",
       "success": false
     }
   }
@@ -6611,6 +6884,98 @@ mutation setCustomAttributesOnNegotiableQuote($input: SetCustomAttributesOnNegot
   "data": {
     "setCustomAttributesOnNegotiableQuote": {
       "quote": NegotiableQuote
+    }
+  }
+}
+```
+
+<HorizontalLine />
+
+### setDefaultCompanyAddress
+
+Set a company address as the default billing or shipping address for the company.
+
+**Response:** [`CompanyAddress`](/reference/graphql/saas/types-c-e.md#companyaddress)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The ID of the company address to set as default for its type. |
+
+#### Example
+
+##### Query
+
+```graphql
+mutation setDefaultCompanyAddress($id: ID!) {
+  setDefaultCompanyAddress(id: $id) {
+    address_type
+    city
+    company
+    company_id
+    country_code
+    custom_attributes {
+      ...AttributeValueInterfaceFragment
+    }
+    extension_attributes {
+      ...CustomerAddressAttributeFragment
+    }
+    fax
+    firstname
+    id
+    is_default
+    lastname
+    middlename
+    nickname
+    postcode
+    prefix
+    region {
+      ...CustomerAddressRegionFragment
+    }
+    region_id
+    street
+    suffix
+    telephone
+    vat_id
+  }
+}
+```
+
+##### Variables
+
+```json
+{"id": 4}
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "setDefaultCompanyAddress": {
+      "address_type": "BILLING",
+      "city": "abc123",
+      "company": "abc123",
+      "company_id": "4",
+      "country_code": "AF",
+      "custom_attributes": [AttributeValueInterface],
+      "extension_attributes": [CustomerAddressAttribute],
+      "fax": "xyz789",
+      "firstname": "xyz789",
+      "id": 4,
+      "is_default": true,
+      "lastname": "xyz789",
+      "middlename": "abc123",
+      "nickname": "xyz789",
+      "postcode": "abc123",
+      "prefix": "abc123",
+      "region": CustomerAddressRegion,
+      "region_id": 123,
+      "street": ["xyz789"],
+      "suffix": "abc123",
+      "telephone": "xyz789",
+      "vat_id": "abc123"
     }
   }
 }
@@ -6999,14 +7364,14 @@ mutation setNegotiableQuoteTemplateShippingAddress($input: SetNegotiableQuoteTem
     "setNegotiableQuoteTemplateShippingAddress": {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
-      "created_at": "xyz789",
-      "expiration_date": "xyz789",
+      "created_at": "abc123",
+      "expiration_date": "abc123",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
       "is_min_max_qty_used": false,
-      "is_virtual": false,
+      "is_virtual": true,
       "items": [CartItemInterface],
-      "max_order_commitment": 123,
+      "max_order_commitment": 987,
       "min_order_commitment": 123,
       "name": "xyz789",
       "notifications": [QuoteTemplateNotificationMessage],
@@ -7021,8 +7386,58 @@ mutation setNegotiableQuoteTemplateShippingAddress($input: SetNegotiableQuoteTem
       "status": "xyz789",
       "template_id": 4,
       "total_quantity": 123.45,
-      "uid": 4,
+      "uid": "4",
       "updated_at": "abc123"
+    }
+  }
+}
+```
+
+<HorizontalLine />
+
+### setNominatedSourceOnCartItems
+
+Sets (or clears) the nominated inventory source on one or more cart items. The single canonical write path for nominated_source_code.
+
+**Response:** [`SetNominatedSourceOnCartItemsOutput`](/reference/graphql/saas/types-q-s.md#setnominatedsourceoncartitemsoutput)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `input` - [`SetNominatedSourceOnCartItemsInput!`](/reference/graphql/saas/types-q-s.md#setnominatedsourceoncartitemsinput) | The cart and the per-item source nominations to apply or clear. |
+
+#### Example
+
+##### Query
+
+```graphql
+mutation setNominatedSourceOnCartItems($input: SetNominatedSourceOnCartItemsInput!) {
+  setNominatedSourceOnCartItems(input: $input) {
+    cart {
+      ...CartFragment
+    }
+    rejected_items {
+      ...RejectedNominationFragment
+    }
+  }
+}
+```
+
+##### Variables
+
+```json
+{"input": SetNominatedSourceOnCartItemsInput}
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "setNominatedSourceOnCartItems": {
+      "cart": Cart,
+      "rejected_items": [RejectedNomination]
     }
   }
 }
@@ -7147,12 +7562,12 @@ mutation setQuoteTemplateExpirationDate($input: QuoteTemplateExpirationDateInput
     "setQuoteTemplateExpirationDate": {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
-      "created_at": "abc123",
+      "created_at": "xyz789",
       "expiration_date": "abc123",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
       "is_min_max_qty_used": true,
-      "is_virtual": false,
+      "is_virtual": true,
       "items": [CartItemInterface],
       "max_order_commitment": 987,
       "min_order_commitment": 987,
@@ -7162,15 +7577,15 @@ mutation setQuoteTemplateExpirationDate($input: QuoteTemplateExpirationDateInput
       "reference_document_links": [
         NegotiableQuoteReferenceDocumentLink
       ],
-      "sales_rep_name": "xyz789",
+      "sales_rep_name": "abc123",
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
       "status": "abc123",
       "template_id": 4,
-      "total_quantity": 987.65,
+      "total_quantity": 123.45,
       "uid": 4,
-      "updated_at": "xyz789"
+      "updated_at": "abc123"
     }
   }
 }
@@ -7256,14 +7671,14 @@ mutation setQuoteTemplateLineItemNote($input: QuoteTemplateLineItemNoteInput!) {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
       "created_at": "xyz789",
-      "expiration_date": "abc123",
+      "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
       "is_min_max_qty_used": false,
-      "is_virtual": false,
+      "is_virtual": true,
       "items": [CartItemInterface],
-      "max_order_commitment": 987,
-      "min_order_commitment": 123,
+      "max_order_commitment": 123,
+      "min_order_commitment": 987,
       "name": "abc123",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
@@ -7274,10 +7689,10 @@ mutation setQuoteTemplateLineItemNote($input: QuoteTemplateLineItemNoteInput!) {
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
-      "status": "abc123",
+      "status": "xyz789",
       "template_id": "4",
-      "total_quantity": 123.45,
-      "uid": "4",
+      "total_quantity": 987.65,
+      "uid": 4,
       "updated_at": "xyz789"
     }
   }
@@ -7404,7 +7819,7 @@ mutation shareGiftRegistry(
 
 ```json
 {
-  "giftRegistryUid": "4",
+  "giftRegistryUid": 4,
   "sender": ShareGiftRegistrySenderInput,
   "invitees": [ShareGiftRegistryInviteeInput]
 }
@@ -7413,7 +7828,7 @@ mutation shareGiftRegistry(
 ##### Response
 
 ```json
-{"data": {"shareGiftRegistry": {"is_shared": false}}}
+{"data": {"shareGiftRegistry": {"is_shared": true}}}
 ```
 
 <HorizontalLine />
@@ -7493,7 +7908,7 @@ mutation shareRequisitionListByToken($requisitionListUid: ID!) {
 ##### Variables
 
 ```json
-{"requisitionListUid": 4}
+{"requisitionListUid": "4"}
 ```
 
 ##### Response
@@ -7502,7 +7917,7 @@ mutation shareRequisitionListByToken($requisitionListUid: ID!) {
 {
   "data": {
     "shareRequisitionListByToken": {
-      "token": "abc123"
+      "token": "xyz789"
     }
   }
 }
@@ -7587,30 +8002,30 @@ mutation submitNegotiableQuoteTemplateForReview($input: SubmitNegotiableQuoteTem
     "submitNegotiableQuoteTemplateForReview": {
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
-      "created_at": "xyz789",
+      "created_at": "abc123",
       "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "historyV2": [NegotiableQuoteTemplateHistoryEntry],
       "is_min_max_qty_used": false,
       "is_virtual": true,
       "items": [CartItemInterface],
-      "max_order_commitment": 123,
-      "min_order_commitment": 987,
+      "max_order_commitment": 987,
+      "min_order_commitment": 123,
       "name": "abc123",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
         NegotiableQuoteReferenceDocumentLink
       ],
-      "sales_rep_name": "abc123",
+      "sales_rep_name": "xyz789",
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
-      "status": "abc123",
+      "status": "xyz789",
       "template_id": 4,
       "total_quantity": 987.65,
       "uid": 4,
-      "updated_at": "abc123"
+      "updated_at": "xyz789"
     }
   }
 }
@@ -7694,7 +8109,7 @@ mutation subscribeProductAlertPrice($input: ProductAlertPriceInput!) {
   "data": {
     "subscribeProductAlertPrice": {
       "message": "abc123",
-      "success": true
+      "success": false
     }
   }
 }
@@ -7740,7 +8155,7 @@ mutation subscribeProductAlertStock($input: ProductAlertStockInput!) {
   "data": {
     "subscribeProductAlertStock": {
       "message": "abc123",
-      "success": false
+      "success": true
     }
   }
 }
@@ -7779,7 +8194,7 @@ mutation syncPaymentOrder($input: SyncPaymentOrderInput) {
 ##### Response
 
 ```json
-{"data": {"syncPaymentOrder": false}}
+{"data": {"syncPaymentOrder": true}}
 ```
 
 <HorizontalLine />
@@ -7832,7 +8247,7 @@ mutation unassignChildCompany($input: UnassignChildCompanyInput!) {
 
 ### unsubscribeProductAlertPrice
 
-Unsubscribe logged-in customer to price alert for a product.
+Unsubscribe logged-in customer from price alert for a product.
 
 **Response:** [`ProductAlertSubscriptionResult`](/reference/graphql/saas/types-k-p.md#productalertsubscriptionresult)
 
@@ -7867,7 +8282,7 @@ mutation unsubscribeProductAlertPrice($input: ProductAlertPriceInput!) {
 {
   "data": {
     "unsubscribeProductAlertPrice": {
-      "message": "xyz789",
+      "message": "abc123",
       "success": true
     }
   }
@@ -7878,7 +8293,7 @@ mutation unsubscribeProductAlertPrice($input: ProductAlertPriceInput!) {
 
 ### unsubscribeProductAlertPriceAll
 
-Unsubscribe logged-in customer to price alert for all product.
+Unsubscribe logged-in customer from price alerts for all products.
 
 **Response:** [`ProductAlertSubscriptionResult`](/reference/graphql/saas/types-k-p.md#productalertsubscriptionresult)
 
@@ -7902,7 +8317,7 @@ mutation unsubscribeProductAlertPriceAll {
   "data": {
     "unsubscribeProductAlertPriceAll": {
       "message": "abc123",
-      "success": true
+      "success": false
     }
   }
 }
@@ -7912,7 +8327,7 @@ mutation unsubscribeProductAlertPriceAll {
 
 ### unsubscribeProductAlertStock
 
-Unsubscribe logged-in customer to stock alert for a product.
+Unsubscribe logged-in customer from stock alert for a product.
 
 **Response:** [`ProductAlertSubscriptionResult`](/reference/graphql/saas/types-k-p.md#productalertsubscriptionresult)
 
@@ -7947,7 +8362,7 @@ mutation unsubscribeProductAlertStock($input: ProductAlertStockInput!) {
 {
   "data": {
     "unsubscribeProductAlertStock": {
-      "message": "xyz789",
+      "message": "abc123",
       "success": true
     }
   }
@@ -7958,7 +8373,7 @@ mutation unsubscribeProductAlertStock($input: ProductAlertStockInput!) {
 
 ### unsubscribeProductAlertStockAll
 
-Unsubscribe logged-in customer to stock alert for all product.
+Unsubscribe logged-in customer from stock alerts for all products.
 
 **Response:** [`ProductAlertSubscriptionResult`](/reference/graphql/saas/types-k-p.md#productalertsubscriptionresult)
 
@@ -8076,6 +8491,145 @@ mutation updateCompany($input: CompanyUpdateInput!) {
 
 ```json
 {"data": {"updateCompany": {"company": Company}}}
+```
+
+<HorizontalLine />
+
+### updateCompanyAddress
+
+Update an existing company address.
+
+**Response:** [`CompanyAddress`](/reference/graphql/saas/types-c-e.md#companyaddress)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The ID of the company address to update. |
+| `input` - [`CompanyAddressUpdateInput!`](/reference/graphql/saas/types-c-e.md#companyaddressupdateinput) | An input object that defines changes to the company address. |
+
+#### Example
+
+##### Query
+
+```graphql
+mutation updateCompanyAddress(
+  $id: ID!,
+  $input: CompanyAddressUpdateInput!
+) {
+  updateCompanyAddress(
+    id: $id,
+    input: $input
+  ) {
+    address_type
+    city
+    company
+    company_id
+    country_code
+    custom_attributes {
+      ...AttributeValueInterfaceFragment
+    }
+    extension_attributes {
+      ...CustomerAddressAttributeFragment
+    }
+    fax
+    firstname
+    id
+    is_default
+    lastname
+    middlename
+    nickname
+    postcode
+    prefix
+    region {
+      ...CustomerAddressRegionFragment
+    }
+    region_id
+    street
+    suffix
+    telephone
+    vat_id
+  }
+}
+```
+
+##### Variables
+
+```json
+{"id": 4, "input": CompanyAddressUpdateInput}
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "updateCompanyAddress": {
+      "address_type": "BILLING",
+      "city": "xyz789",
+      "company": "xyz789",
+      "company_id": "4",
+      "country_code": "AF",
+      "custom_attributes": [AttributeValueInterface],
+      "extension_attributes": [CustomerAddressAttribute],
+      "fax": "abc123",
+      "firstname": "xyz789",
+      "id": 4,
+      "is_default": true,
+      "lastname": "xyz789",
+      "middlename": "xyz789",
+      "nickname": "xyz789",
+      "postcode": "abc123",
+      "prefix": "xyz789",
+      "region": CustomerAddressRegion,
+      "region_id": 987,
+      "street": ["xyz789"],
+      "suffix": "xyz789",
+      "telephone": "abc123",
+      "vat_id": "xyz789"
+    }
+  }
+}
+```
+
+<HorizontalLine />
+
+### updateCompanyConfig
+
+Update company configuration for the current company context.
+
+**Response:** [`UpdateCompanyConfigOutput`](/reference/graphql/saas/types-t-z.md#updatecompanyconfigoutput)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `input` - [`UpdateCompanyConfigInput!`](/reference/graphql/saas/types-t-z.md#updatecompanyconfiginput) | An input object that defines company configuration changes. |
+
+#### Example
+
+##### Query
+
+```graphql
+mutation updateCompanyConfig($input: UpdateCompanyConfigInput!) {
+  updateCompanyConfig(input: $input) {
+    company {
+      ...CompanyFragment
+    }
+  }
+}
+```
+
+##### Variables
+
+```json
+{"input": UpdateCompanyConfigInput}
+```
+
+##### Response
+
+```json
+{"data": {"updateCompanyConfig": {"company": Company}}}
 ```
 
 <HorizontalLine />
@@ -8313,27 +8867,27 @@ mutation updateCustomerAddress(
 {
   "data": {
     "updateCustomerAddress": {
-      "city": "abc123",
-      "company": "xyz789",
+      "city": "xyz789",
+      "company": "abc123",
       "country_code": "AF",
       "custom_attributesV2": [AttributeValueInterface],
-      "default_billing": false,
-      "default_shipping": false,
+      "default_billing": true,
+      "default_shipping": true,
       "extension_attributes": [CustomerAddressAttribute],
-      "fax": "abc123",
-      "firstname": "xyz789",
-      "id": 987,
-      "lastname": "abc123",
-      "middlename": "xyz789",
-      "postcode": "abc123",
+      "fax": "xyz789",
+      "firstname": "abc123",
+      "id": 123,
+      "lastname": "xyz789",
+      "middlename": "abc123",
+      "postcode": "xyz789",
       "prefix": "xyz789",
       "region": CustomerAddressRegion,
       "region_id": 123,
-      "street": ["abc123"],
+      "street": ["xyz789"],
       "suffix": "xyz789",
-      "telephone": "xyz789",
+      "telephone": "abc123",
       "uid": 4,
-      "vat_id": "abc123"
+      "vat_id": "xyz789"
     }
   }
 }
@@ -8401,10 +8955,7 @@ mutation updateCustomerAddressV2(
 ##### Variables
 
 ```json
-{
-  "uid": "4",
-  "input": CustomerAddressInput
-}
+{"uid": 4, "input": CustomerAddressInput}
 ```
 
 ##### Response
@@ -8414,26 +8965,26 @@ mutation updateCustomerAddressV2(
   "data": {
     "updateCustomerAddressV2": {
       "city": "xyz789",
-      "company": "abc123",
+      "company": "xyz789",
       "country_code": "AF",
       "custom_attributesV2": [AttributeValueInterface],
-      "default_billing": true,
-      "default_shipping": false,
+      "default_billing": false,
+      "default_shipping": true,
       "extension_attributes": [CustomerAddressAttribute],
-      "fax": "abc123",
+      "fax": "xyz789",
       "firstname": "xyz789",
       "id": 987,
-      "lastname": "abc123",
+      "lastname": "xyz789",
       "middlename": "xyz789",
-      "postcode": "xyz789",
-      "prefix": "xyz789",
+      "postcode": "abc123",
+      "prefix": "abc123",
       "region": CustomerAddressRegion,
-      "region_id": 123,
-      "street": ["abc123"],
-      "suffix": "xyz789",
-      "telephone": "xyz789",
+      "region_id": 987,
+      "street": ["xyz789"],
+      "suffix": "abc123",
+      "telephone": "abc123",
       "uid": 4,
-      "vat_id": "xyz789"
+      "vat_id": "abc123"
     }
   }
 }
@@ -8479,7 +9030,7 @@ mutation updateCustomerEmail(
 ```json
 {
   "email": "abc123",
-  "password": "abc123"
+  "password": "xyz789"
 }
 ```
 
@@ -8568,7 +9119,7 @@ mutation updateGiftRegistry(
 
 ```json
 {
-  "giftRegistryUid": 4,
+  "giftRegistryUid": "4",
   "giftRegistry": UpdateGiftRegistryInput
 }
 ```
@@ -8904,12 +9455,12 @@ mutation updatePurchaseOrderApprovalRule($input: UpdatePurchaseOrderApprovalRule
       "approver_roles": [CompanyRole],
       "condition": PurchaseOrderApprovalRuleConditionInterface,
       "created_at": "xyz789",
-      "created_by": "xyz789",
-      "description": "xyz789",
-      "name": "abc123",
+      "created_by": "abc123",
+      "description": "abc123",
+      "name": "xyz789",
       "status": "ENABLED",
-      "uid": "4",
-      "updated_at": "abc123"
+      "uid": 4,
+      "updated_at": "xyz789"
     }
   }
 }
@@ -8954,7 +9505,7 @@ mutation updateRequisitionList(
 
 ```json
 {
-  "requisitionListUid": 4,
+  "requisitionListUid": "4",
   "input": UpdateRequisitionListInput
 }
 ```
@@ -9010,7 +9561,7 @@ mutation updateRequisitionListItems(
 
 ```json
 {
-  "requisitionListUid": 4,
+  "requisitionListUid": "4",
   "requisitionListItems": [
     UpdateRequisitionListItemsInput
   ]
@@ -9071,8 +9622,8 @@ mutation updateWishlist(
 
 ```json
 {
-  "wishlistId": 4,
-  "name": "xyz789",
+  "wishlistId": "4",
+  "name": "abc123",
   "visibility": "PUBLIC"
 }
 ```
@@ -9083,8 +9634,8 @@ mutation updateWishlist(
 {
   "data": {
     "updateWishlist": {
-      "name": "abc123",
-      "uid": 4,
+      "name": "xyz789",
+      "uid": "4",
       "visibility": "PUBLIC"
     }
   }

--- a/src/pages/includes/autogenerated/graphql-api-saas-queries.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-queries.md
@@ -281,9 +281,13 @@ query availableStores($useCurrentGroup: Boolean) {
     orders_invoices_credit_memos_display_shipping_amount
     orders_invoices_credit_memos_display_subtotal
     orders_invoices_credit_memos_display_zero_tax
+    persistent_enabled
+    persistent_options_wishlist
+    persistent_shopping_cart
     printed_card_priceV2 {
       ...MoneyFragment
     }
+    product_alert_allow_stock
     product_fixed_product_tax_display_setting
     product_url_suffix
     quickorder_active
@@ -305,6 +309,7 @@ query availableStores($useCurrentGroup: Boolean) {
     secure_base_url
     share_active_segments
     share_applied_cart_rule
+    share_customer_accounts_scope
     shopping_assistance_checkbox_title
     shopping_assistance_checkbox_tooltip
     shopping_assistance_enabled
@@ -340,7 +345,7 @@ query availableStores($useCurrentGroup: Boolean) {
 ##### Variables
 
 ```json
-{"useCurrentGroup": false}
+{"useCurrentGroup": true}
 ```
 
 ##### Response
@@ -351,152 +356,157 @@ query availableStores($useCurrentGroup: Boolean) {
     "availableStores": [
       {
         "allow_company_registration": true,
-        "allow_gift_receipt": "xyz789",
-        "allow_gift_wrapping_on_order": "xyz789",
-        "allow_gift_wrapping_on_order_items": "xyz789",
+        "allow_gift_receipt": "abc123",
+        "allow_gift_wrapping_on_order": "abc123",
+        "allow_gift_wrapping_on_order_items": "abc123",
         "allow_items": "xyz789",
-        "allow_order": "abc123",
-        "allow_printed_card": "xyz789",
+        "allow_order": "xyz789",
+        "allow_printed_card": "abc123",
         "autocomplete_on_storefront": true,
         "base_currency_code": "abc123",
-        "base_link_url": "xyz789",
+        "base_link_url": "abc123",
         "base_media_url": "xyz789",
-        "base_static_url": "abc123",
+        "base_static_url": "xyz789",
         "base_url": "abc123",
-        "cart_expires_in_days": 987,
-        "cart_gift_wrapping": "abc123",
-        "cart_merge_preference": "abc123",
+        "cart_expires_in_days": 123,
+        "cart_gift_wrapping": "xyz789",
+        "cart_merge_preference": "xyz789",
         "cart_printed_card": "abc123",
-        "cart_summary_display_quantity": 987,
-        "catalog_default_sort_by": "abc123",
+        "cart_summary_display_quantity": 123,
+        "catalog_default_sort_by": "xyz789",
         "category_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
         "category_url_suffix": "xyz789",
-        "check_money_order_enable_for_specific_countries": true,
+        "check_money_order_enable_for_specific_countries": false,
         "check_money_order_enabled": true,
-        "check_money_order_make_check_payable_to": "xyz789",
+        "check_money_order_make_check_payable_to": "abc123",
         "check_money_order_max_order_total": "xyz789",
-        "check_money_order_min_order_total": "xyz789",
+        "check_money_order_min_order_total": "abc123",
         "check_money_order_new_order_status": "xyz789",
-        "check_money_order_payment_from_specific_countries": "xyz789",
-        "check_money_order_send_check_to": "abc123",
+        "check_money_order_payment_from_specific_countries": "abc123",
+        "check_money_order_send_check_to": "xyz789",
         "check_money_order_sort_order": 987,
-        "check_money_order_title": "xyz789",
-        "company_credit_enabled": false,
-        "company_enabled": true,
+        "check_money_order_title": "abc123",
+        "company_credit_enabled": true,
+        "company_enabled": false,
         "configurable_product_image": "ITSELF",
         "configurable_thumbnail_source": "xyz789",
         "contact_enabled": true,
-        "countries_with_required_region": "xyz789",
+        "countries_with_required_region": "abc123",
         "create_account_confirmation": true,
         "customer_access_token_lifetime": 987.65,
         "default_country": "abc123",
-        "default_display_currency_code": "xyz789",
+        "default_display_currency_code": "abc123",
         "display_product_prices_in_catalog": 987,
         "display_shipping_prices": 987,
         "display_state_if_optional": true,
-        "enable_multiple_wishlists": "xyz789",
+        "enable_multiple_wishlists": "abc123",
         "fixed_product_taxes_apply_tax_to_fpt": false,
         "fixed_product_taxes_display_prices_in_emails": 123,
         "fixed_product_taxes_display_prices_in_product_lists": 987,
         "fixed_product_taxes_display_prices_in_sales_modules": 987,
-        "fixed_product_taxes_display_prices_on_product_view_page": 987,
+        "fixed_product_taxes_display_prices_on_product_view_page": 123,
         "fixed_product_taxes_enable": true,
         "fixed_product_taxes_include_fpt_in_subtotal": true,
-        "graphql_share_customer_group": true,
+        "graphql_share_customer_group": false,
         "grid_per_page": 123,
-        "grid_per_page_values": "abc123",
+        "grid_per_page_values": "xyz789",
         "grouped_product_image": "ITSELF",
         "is_checkout_agreements_enabled": false,
         "is_default_store": true,
         "is_default_store_group": false,
         "is_guest_checkout_enabled": false,
-        "is_negotiable_quote_active": true,
+        "is_negotiable_quote_active": false,
         "is_one_page_checkout_enabled": false,
-        "is_requisition_list_active": "abc123",
-        "list_mode": "xyz789",
-        "list_per_page": 123,
-        "list_per_page_values": "xyz789",
+        "is_requisition_list_active": "xyz789",
+        "list_mode": "abc123",
+        "list_per_page": 987,
+        "list_per_page_values": "abc123",
         "locale": "xyz789",
-        "magento_reward_general_is_enabled": "xyz789",
-        "magento_reward_general_is_enabled_on_front": "abc123",
-        "magento_reward_general_min_points_balance": "abc123",
+        "magento_reward_general_is_enabled": "abc123",
+        "magento_reward_general_is_enabled_on_front": "xyz789",
+        "magento_reward_general_min_points_balance": "xyz789",
         "magento_reward_general_publish_history": "xyz789",
         "magento_reward_points_invitation_customer": "abc123",
         "magento_reward_points_invitation_customer_limit": "abc123",
-        "magento_reward_points_invitation_order": "xyz789",
+        "magento_reward_points_invitation_order": "abc123",
         "magento_reward_points_invitation_order_limit": "abc123",
-        "magento_reward_points_newsletter": "xyz789",
-        "magento_reward_points_order": "abc123",
+        "magento_reward_points_newsletter": "abc123",
+        "magento_reward_points_order": "xyz789",
         "magento_reward_points_register": "xyz789",
-        "magento_reward_points_review": "abc123",
+        "magento_reward_points_review": "xyz789",
         "magento_reward_points_review_limit": "xyz789",
-        "magento_wishlist_general_is_enabled": "xyz789",
-        "max_items_in_order_summary": 123,
+        "magento_wishlist_general_is_enabled": "abc123",
+        "max_items_in_order_summary": 987,
         "maximum_number_of_wishlists": "abc123",
         "minicart_display": true,
-        "minicart_max_items": 123,
-        "minimum_password_length": "abc123",
+        "minicart_max_items": 987,
+        "minimum_password_length": "xyz789",
         "newsletter_enabled": false,
         "optional_zip_countries": "abc123",
         "order_cancellation_enabled": false,
         "order_cancellation_reasons": [
           CancellationReason
         ],
-        "orders_invoices_credit_memos_display_full_summary": true,
-        "orders_invoices_credit_memos_display_grandtotal": false,
+        "orders_invoices_credit_memos_display_full_summary": false,
+        "orders_invoices_credit_memos_display_grandtotal": true,
         "orders_invoices_credit_memos_display_price": 987,
-        "orders_invoices_credit_memos_display_shipping_amount": 123,
-        "orders_invoices_credit_memos_display_subtotal": 987,
-        "orders_invoices_credit_memos_display_zero_tax": false,
+        "orders_invoices_credit_memos_display_shipping_amount": 987,
+        "orders_invoices_credit_memos_display_subtotal": 123,
+        "orders_invoices_credit_memos_display_zero_tax": true,
+        "persistent_enabled": true,
+        "persistent_options_wishlist": false,
+        "persistent_shopping_cart": true,
         "printed_card_priceV2": Money,
+        "product_alert_allow_stock": false,
         "product_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
         "product_url_suffix": "abc123",
         "quickorder_active": false,
         "quote_minimum_amount": 123.45,
-        "quote_minimum_amount_message": "xyz789",
+        "quote_minimum_amount_message": "abc123",
         "required_character_classes_number": "abc123",
-        "requisition_list_share_link_validity_days": 123,
-        "requisition_list_share_max_recipients": 987,
+        "requisition_list_share_link_validity_days": 987,
+        "requisition_list_share_max_recipients": 123,
         "requisition_list_share_storefront_path": "xyz789",
         "requisition_list_sharing_enabled": false,
-        "returns_enabled": "abc123",
-        "root_category_uid": "4",
+        "returns_enabled": "xyz789",
+        "root_category_uid": 4,
         "sales_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
-        "sales_gift_wrapping": "xyz789",
+        "sales_gift_wrapping": "abc123",
         "sales_printed_card": "abc123",
-        "secure_base_link_url": "xyz789",
-        "secure_base_media_url": "xyz789",
+        "secure_base_link_url": "abc123",
+        "secure_base_media_url": "abc123",
         "secure_base_static_url": "abc123",
-        "secure_base_url": "abc123",
+        "secure_base_url": "xyz789",
         "share_active_segments": false,
-        "share_applied_cart_rule": false,
-        "shopping_assistance_checkbox_title": "abc123",
+        "share_applied_cart_rule": true,
+        "share_customer_accounts_scope": 123,
+        "shopping_assistance_checkbox_title": "xyz789",
         "shopping_assistance_checkbox_tooltip": "abc123",
-        "shopping_assistance_enabled": false,
-        "shopping_cart_display_full_summary": false,
+        "shopping_assistance_enabled": true,
+        "shopping_cart_display_full_summary": true,
         "shopping_cart_display_grand_total": false,
-        "shopping_cart_display_price": 123,
-        "shopping_cart_display_shipping": 123,
-        "shopping_cart_display_subtotal": 123,
+        "shopping_cart_display_price": 987,
+        "shopping_cart_display_shipping": 987,
+        "shopping_cart_display_subtotal": 987,
         "shopping_cart_display_tax_gift_wrapping": "DISPLAY_EXCLUDING_TAX",
         "shopping_cart_display_zero_tax": true,
-        "store_code": 4,
+        "store_code": "4",
         "store_group_code": "4",
-        "store_group_name": "abc123",
+        "store_group_name": "xyz789",
         "store_name": "abc123",
-        "store_sort_order": 987,
-        "timezone": "abc123",
-        "title_separator": "abc123",
+        "store_sort_order": 123,
+        "timezone": "xyz789",
+        "title_separator": "xyz789",
         "use_store_in_url": true,
         "website_code": "4",
-        "website_name": "abc123",
-        "weight_unit": "abc123",
-        "zero_subtotal_enable_for_specific_countries": false,
+        "website_name": "xyz789",
+        "weight_unit": "xyz789",
+        "zero_subtotal_enable_for_specific_countries": true,
         "zero_subtotal_enabled": false,
         "zero_subtotal_new_order_status": "abc123",
         "zero_subtotal_payment_action": "xyz789",
         "zero_subtotal_payment_from_specific_countries": "xyz789",
-        "zero_subtotal_sort_order": 123,
+        "zero_subtotal_sort_order": 987,
         "zero_subtotal_title": "xyz789"
       }
     ]
@@ -537,6 +547,9 @@ query cart($cart_id: String!) {
     applied_store_credit {
       ...AppliedStoreCreditFragment
     }
+    available_free_gifts {
+      ...AvailableFreeGiftFragment
+    }
     available_gift_wrappings {
       ...GiftWrappingFragment
     }
@@ -557,6 +570,7 @@ query cart($cart_id: String!) {
     gift_wrapping {
       ...GiftWrappingFragment
     }
+    has_available_free_gifts
     id
     is_virtual
     itemsV2 {
@@ -583,7 +597,7 @@ query cart($cart_id: String!) {
 ##### Variables
 
 ```json
-{"cart_id": "abc123"}
+{"cart_id": "xyz789"}
 ```
 
 ##### Response
@@ -596,21 +610,23 @@ query cart($cart_id: String!) {
       "applied_gift_cards": [AppliedGiftCard],
       "applied_reward_points": RewardPointsAmount,
       "applied_store_credit": AppliedStoreCredit,
+      "available_free_gifts": [AvailableFreeGift],
       "available_gift_wrappings": [GiftWrapping],
       "available_payment_methods": [
         AvailablePaymentMethod
       ],
       "billing_address": BillingCartAddress,
       "custom_attributes": [CustomAttribute],
-      "email": "xyz789",
+      "email": "abc123",
       "gift_message": GiftMessage,
-      "gift_receipt_included": false,
+      "gift_receipt_included": true,
       "gift_wrapping": GiftWrapping,
+      "has_available_free_gifts": true,
       "id": "4",
-      "is_virtual": false,
+      "is_virtual": true,
       "itemsV2": CartItems,
       "prices": CartPrices,
-      "printed_card_included": false,
+      "printed_card_included": true,
       "rules": [CartRuleStorefront],
       "selected_payment_method": SelectedPaymentMethod,
       "shipping_addresses": [ShippingCartAddress],
@@ -624,11 +640,7 @@ query cart($cart_id: String!) {
 
 ### categories
 
-*Deprecated*
-
-This field is deprecated and will be removed.
-
-Return category views by IDs, with optional role filters and subtree scopes. In Adobe Commerce as a Cloud Service, this query replaces the `categories` query defined in the Commerce Foundation.
+Return category views by IDs, with optional role filters and subtree scopes. Available only for deployments using the Catalog or Live Search service with Adobe Commerce. For Adobe Commerce Optimizer, use the `categoryTree` query instead. See [categoryTree query examples](https://developer.adobe.com/commerce/services/optimizer/merchandising-services/categories-storefront-implementation#categorytree-query-examples).
 
 **Response:** [`[CategoryView]`](/reference/graphql/saas/types-c-e.md#categoryview)
 
@@ -690,18 +702,18 @@ query categories(
   "data": {
     "categories": [
       {
-        "availableSortBy": ["abc123"],
+        "availableSortBy": ["xyz789"],
         "children": ["xyz789"],
-        "defaultSortBy": "abc123",
+        "defaultSortBy": "xyz789",
         "id": 4,
         "level": 987,
-        "name": "abc123",
-        "parentId": "abc123",
+        "name": "xyz789",
+        "parentId": "xyz789",
         "position": 987,
-        "path": "abc123",
+        "path": "xyz789",
         "roles": ["abc123"],
         "urlKey": "xyz789",
-        "urlPath": "abc123",
+        "urlPath": "xyz789",
         "count": 987,
         "title": "xyz789"
       }
@@ -743,11 +755,11 @@ query checkoutAgreements {
   "data": {
     "checkoutAgreements": [
       {
-        "agreement_id": 123,
+        "agreement_id": 987,
         "checkbox_text": "xyz789",
         "content": "abc123",
-        "content_height": "xyz789",
-        "is_html": false,
+        "content_height": "abc123",
+        "is_html": true,
         "mode": "AUTO",
         "name": "abc123"
       }
@@ -806,6 +818,9 @@ query company {
     acl_resources {
       ...CompanyAclResourceFragment
     }
+    addresses {
+      ...CompanyAddressesFragment
+    }
     available_payment_methods {
       ...AvailablePaymentMethodFragment
     }
@@ -815,6 +830,9 @@ query company {
     company_admin {
       ...CustomerFragment
     }
+    config {
+      ...CompanyConfigFragment
+    }
     credit {
       ...CompanyCreditFragment
     }
@@ -823,6 +841,12 @@ query company {
     }
     custom_attributes {
       ...CustomAttributeFragment
+    }
+    default_billing_address {
+      ...CompanyAddressFragment
+    }
+    default_shipping_address {
+      ...CompanyAddressFragment
     }
     email
     id
@@ -867,6 +891,7 @@ query company {
   "data": {
     "company": {
       "acl_resources": [CompanyAclResource],
+      "addresses": CompanyAddresses,
       "available_payment_methods": [
         AvailablePaymentMethod
       ],
@@ -874,15 +899,18 @@ query company {
         CompanyAvailableShippingMethod
       ],
       "company_admin": Customer,
+      "config": CompanyConfig,
       "credit": CompanyCredit,
       "credit_history": CompanyCreditHistory,
       "custom_attributes": [CustomAttribute],
+      "default_billing_address": CompanyAddress,
+      "default_shipping_address": CompanyAddress,
       "email": "abc123",
-      "id": "4",
+      "id": 4,
       "legal_address": CompanyLegalAddress,
-      "legal_name": "xyz789",
-      "name": "abc123",
-      "payment_methods": ["abc123"],
+      "legal_name": "abc123",
+      "name": "xyz789",
+      "payment_methods": ["xyz789"],
       "reseller_id": "abc123",
       "role": CompanyRole,
       "roles": CompanyRoles,
@@ -946,7 +974,7 @@ query compareList($uid: ID!) {
       "attributes": [ComparableAttribute],
       "item_count": 987,
       "items": [ComparableItem],
-      "uid": 4
+      "uid": "4"
     }
   }
 }
@@ -988,9 +1016,9 @@ query countries {
       {
         "available_regions": [Region],
         "full_name_english": "abc123",
-        "full_name_locale": "xyz789",
-        "id": "abc123",
-        "three_letter_abbreviation": "abc123",
+        "full_name_locale": "abc123",
+        "id": "xyz789",
+        "three_letter_abbreviation": "xyz789",
         "two_letter_abbreviation": "abc123"
       }
     ]
@@ -1045,8 +1073,8 @@ query country($id: String) {
     "country": {
       "available_regions": [Region],
       "full_name_english": "abc123",
-      "full_name_locale": "xyz789",
-      "id": "xyz789",
+      "full_name_locale": "abc123",
+      "id": "abc123",
       "three_letter_abbreviation": "xyz789",
       "two_letter_abbreviation": "abc123"
     }
@@ -1088,12 +1116,12 @@ query currency {
   "data": {
     "currency": {
       "available_currency_codes": [
-        "abc123"
+        "xyz789"
       ],
-      "base_currency_code": "xyz789",
-      "base_currency_symbol": "xyz789",
-      "default_display_currency_code": "abc123",
-      "default_display_currency_symbol": "abc123",
+      "base_currency_code": "abc123",
+      "base_currency_symbol": "abc123",
+      "default_display_currency_code": "xyz789",
+      "default_display_currency_symbol": "xyz789",
       "exchange_rates": [ExchangeRate]
     }
   }
@@ -1287,20 +1315,20 @@ query customer {
       "custom_attributes": [AttributeValueInterface],
       "date_of_birth": "abc123",
       "default_billing": "xyz789",
-      "default_shipping": "xyz789",
+      "default_shipping": "abc123",
       "email": "xyz789",
-      "firstname": "xyz789",
+      "firstname": "abc123",
       "gender": 123,
       "gift_registries": [GiftRegistry],
       "gift_registry": GiftRegistry,
       "group": CustomerGroupStorefront,
       "id": "4",
       "is_subscribed": false,
-      "job_title": "xyz789",
-      "lastname": "abc123",
-      "middlename": "xyz789",
+      "job_title": "abc123",
+      "lastname": "xyz789",
+      "middlename": "abc123",
       "orders": CustomerOrders,
-      "prefix": "xyz789",
+      "prefix": "abc123",
       "purchase_order": PurchaseOrder,
       "purchase_order_approval_rule": PurchaseOrderApprovalRule,
       "purchase_order_approval_rule_metadata": PurchaseOrderApprovalRuleMetadata,
@@ -1316,11 +1344,11 @@ query customer {
       "segments": [CustomerSegmentStorefront],
       "status": "ACTIVE",
       "store_credit": CustomerStoreCredit,
-      "structure_id": "4",
-      "suffix": "xyz789",
-      "taxvat": "xyz789",
+      "structure_id": 4,
+      "suffix": "abc123",
+      "taxvat": "abc123",
       "team": CompanyTeam,
-      "telephone": "abc123",
+      "telephone": "xyz789",
       "wishlist_v2": Wishlist,
       "wishlists": [Wishlist]
     }
@@ -1355,6 +1383,9 @@ query customerCart {
     applied_store_credit {
       ...AppliedStoreCreditFragment
     }
+    available_free_gifts {
+      ...AvailableFreeGiftFragment
+    }
     available_gift_wrappings {
       ...GiftWrappingFragment
     }
@@ -1375,6 +1406,7 @@ query customerCart {
     gift_wrapping {
       ...GiftWrappingFragment
     }
+    has_available_free_gifts
     id
     is_virtual
     itemsV2 {
@@ -1408,6 +1440,7 @@ query customerCart {
       "applied_gift_cards": [AppliedGiftCard],
       "applied_reward_points": RewardPointsAmount,
       "applied_store_credit": AppliedStoreCredit,
+      "available_free_gifts": [AvailableFreeGift],
       "available_gift_wrappings": [GiftWrapping],
       "available_payment_methods": [
         AvailablePaymentMethod
@@ -1416,9 +1449,10 @@ query customerCart {
       "custom_attributes": [CustomAttribute],
       "email": "xyz789",
       "gift_message": GiftMessage,
-      "gift_receipt_included": true,
+      "gift_receipt_included": false,
       "gift_wrapping": GiftWrapping,
-      "id": 4,
+      "has_available_free_gifts": true,
+      "id": "4",
       "is_virtual": false,
       "itemsV2": CartItems,
       "prices": CartPrices,
@@ -1426,7 +1460,7 @@ query customerCart {
       "rules": [CartRuleStorefront],
       "selected_payment_method": SelectedPaymentMethod,
       "shipping_addresses": [ShippingCartAddress],
-      "total_quantity": 987.65
+      "total_quantity": 123.45
     }
   }
 }
@@ -1489,7 +1523,7 @@ query customerGroup {
 ##### Response
 
 ```json
-{"data": {"customerGroup": {"uid": 4}}}
+{"data": {"customerGroup": {"uid": "4"}}}
 ```
 
 <HorizontalLine />
@@ -1553,7 +1587,7 @@ query customerSegments($cartId: String!) {
 ##### Variables
 
 ```json
-{"cartId": "abc123"}
+{"cartId": "xyz789"}
 ```
 
 ##### Response
@@ -1681,10 +1715,10 @@ query getPaymentOrder(
 {
   "data": {
     "getPaymentOrder": {
-      "id": "abc123",
-      "mp_order_id": "xyz789",
+      "id": "xyz789",
+      "mp_order_id": "abc123",
       "payment_source_details": PaymentSourceDetails,
-      "status": "xyz789"
+      "status": "abc123"
     }
   }
 }
@@ -1811,8 +1845,8 @@ query giftCardAccount($input: GiftCardAccountInput!) {
   "data": {
     "giftCardAccount": {
       "balance": Money,
-      "code": "abc123",
-      "expiration_date": "abc123"
+      "code": "xyz789",
+      "expiration_date": "xyz789"
     }
   }
 }
@@ -1884,7 +1918,7 @@ query giftRegistry($giftRegistryUid: ID!) {
       "event_name": "abc123",
       "items": [GiftRegistryItemInterface],
       "message": "xyz789",
-      "owner_name": "abc123",
+      "owner_name": "xyz789",
       "privacy_settings": "PRIVATE",
       "registrants": [GiftRegistryRegistrant],
       "shipping_address": CustomerAddress,
@@ -1941,11 +1975,11 @@ query giftRegistryEmailSearch($email: String!) {
     "giftRegistryEmailSearch": [
       {
         "event_date": "abc123",
-        "event_title": "xyz789",
-        "gift_registry_uid": 4,
+        "event_title": "abc123",
+        "gift_registry_uid": "4",
         "location": "abc123",
-        "name": "xyz789",
-        "type": "abc123"
+        "name": "abc123",
+        "type": "xyz789"
       }
     ]
   }
@@ -1996,12 +2030,12 @@ query giftRegistryIdSearch($giftRegistryUid: ID!) {
   "data": {
     "giftRegistryIdSearch": [
       {
-        "event_date": "xyz789",
+        "event_date": "abc123",
         "event_title": "xyz789",
         "gift_registry_uid": 4,
-        "location": "xyz789",
+        "location": "abc123",
         "name": "xyz789",
-        "type": "abc123"
+        "type": "xyz789"
       }
     ]
   }
@@ -2053,8 +2087,8 @@ query giftRegistryTypeSearch(
 
 ```json
 {
-  "firstName": "abc123",
-  "lastName": "xyz789",
+  "firstName": "xyz789",
+  "lastName": "abc123",
   "giftRegistryTypeUid": 4
 }
 ```
@@ -2066,12 +2100,12 @@ query giftRegistryTypeSearch(
   "data": {
     "giftRegistryTypeSearch": [
       {
-        "event_date": "abc123",
+        "event_date": "xyz789",
         "event_title": "xyz789",
-        "gift_registry_uid": 4,
+        "gift_registry_uid": "4",
         "location": "xyz789",
-        "name": "abc123",
-        "type": "abc123"
+        "name": "xyz789",
+        "type": "xyz789"
       }
     ]
   }
@@ -2225,23 +2259,23 @@ query guestOrder($input: GuestOrderInformationInput!) {
 {
   "data": {
     "guestOrder": {
-      "admin_assisted_order": 987,
+      "admin_assisted_order": 123,
       "applied_coupons": [AppliedCoupon],
       "applied_gift_cards": [ApplyGiftCardToOrder],
       "available_actions": ["REORDER"],
       "billing_address": OrderAddress,
-      "carrier": "xyz789",
+      "carrier": "abc123",
       "comments": [SalesCommentItem],
       "credit_memos": [CreditMemo],
       "custom_attributes": [CustomAttribute],
       "customer_info": OrderCustomerInfo,
       "email": "abc123",
       "gift_message": GiftMessage,
-      "gift_receipt_included": false,
+      "gift_receipt_included": true,
       "gift_wrapping": GiftWrapping,
       "id": "4",
       "invoices": [Invoice],
-      "is_virtual": false,
+      "is_virtual": true,
       "items": [OrderItemInterface],
       "items_eligible_for_return": [OrderItemInterface],
       "negotiable_quote": NegotiableQuote,
@@ -2249,12 +2283,12 @@ query guestOrder($input: GuestOrderInformationInput!) {
       "order_date": "abc123",
       "order_status_change_date": "abc123",
       "payment_methods": [OrderPaymentMethod],
-      "printed_card_included": true,
+      "printed_card_included": false,
       "returns": Returns,
       "shipments": [OrderShipment],
       "shipping_address": OrderAddress,
-      "shipping_method": "abc123",
-      "status": "abc123",
+      "shipping_method": "xyz789",
+      "status": "xyz789",
       "token": "xyz789",
       "total": OrderTotal
     }
@@ -2379,25 +2413,25 @@ query guestOrderByToken($input: OrderTokenInput!) {
       "customer_info": OrderCustomerInfo,
       "email": "abc123",
       "gift_message": GiftMessage,
-      "gift_receipt_included": false,
+      "gift_receipt_included": true,
       "gift_wrapping": GiftWrapping,
-      "id": "4",
+      "id": 4,
       "invoices": [Invoice],
-      "is_virtual": true,
+      "is_virtual": false,
       "items": [OrderItemInterface],
       "items_eligible_for_return": [OrderItemInterface],
       "negotiable_quote": NegotiableQuote,
-      "number": "xyz789",
-      "order_date": "abc123",
+      "number": "abc123",
+      "order_date": "xyz789",
       "order_status_change_date": "xyz789",
       "payment_methods": [OrderPaymentMethod],
       "printed_card_included": true,
       "returns": Returns,
       "shipments": [OrderShipment],
       "shipping_address": OrderAddress,
-      "shipping_method": "abc123",
-      "status": "xyz789",
-      "token": "xyz789",
+      "shipping_method": "xyz789",
+      "status": "abc123",
+      "token": "abc123",
       "total": OrderTotal
     }
   }
@@ -2439,7 +2473,7 @@ query isCompanyAdminEmailAvailable($email: String!) {
 ##### Response
 
 ```json
-{"data": {"isCompanyAdminEmailAvailable": {"is_email_available": true}}}
+{"data": {"isCompanyAdminEmailAvailable": {"is_email_available": false}}}
 ```
 
 <HorizontalLine />
@@ -2477,7 +2511,7 @@ query isCompanyEmailAvailable($email: String!) {
 ##### Response
 
 ```json
-{"data": {"isCompanyEmailAvailable": {"is_email_available": true}}}
+{"data": {"isCompanyEmailAvailable": {"is_email_available": false}}}
 ```
 
 <HorizontalLine />
@@ -2515,7 +2549,7 @@ query isCompanyRoleNameAvailable($name: String!) {
 ##### Response
 
 ```json
-{"data": {"isCompanyRoleNameAvailable": {"is_role_name_available": true}}}
+{"data": {"isCompanyRoleNameAvailable": {"is_role_name_available": false}}}
 ```
 
 <HorizontalLine />
@@ -2547,13 +2581,13 @@ query isCompanyUserEmailAvailable($email: String!) {
 ##### Variables
 
 ```json
-{"email": "xyz789"}
+{"email": "abc123"}
 ```
 
 ##### Response
 
 ```json
-{"data": {"isCompanyUserEmailAvailable": {"is_email_available": true}}}
+{"data": {"isCompanyUserEmailAvailable": {"is_email_available": false}}}
 ```
 
 <HorizontalLine />
@@ -2633,7 +2667,7 @@ query isSubscribedProductAlertPrice($input: ProductAlertPriceInput!) {
 {
   "data": {
     "isSubscribedProductAlertPrice": {
-      "isSubscribed": false,
+      "isSubscribed": true,
       "message": "abc123"
     }
   }
@@ -2680,7 +2714,7 @@ query isSubscribedProductAlertStock($input: ProductAlertStockInput!) {
   "data": {
     "isSubscribedProductAlertStock": {
       "isSubscribed": true,
-      "message": "xyz789"
+      "message": "abc123"
     }
   }
 }
@@ -2759,7 +2793,7 @@ query negotiableQuote($uid: ID!) {
 ##### Variables
 
 ```json
-{"uid": 4}
+{"uid": "4"}
 ```
 
 ##### Response
@@ -2774,27 +2808,27 @@ query negotiableQuote($uid: ID!) {
       "billing_address": NegotiableQuoteBillingAddress,
       "buyer": NegotiableQuoteUser,
       "comments": [NegotiableQuoteComment],
-      "created_at": "xyz789",
+      "created_at": "abc123",
       "custom_attributes": [CustomAttribute],
       "email": "abc123",
-      "expiration_date": "abc123",
+      "expiration_date": "xyz789",
       "history": [NegotiableQuoteHistoryEntry],
       "is_virtual": false,
       "items": [CartItemInterface],
       "name": "abc123",
       "order": CustomerOrder,
       "prices": CartPrices,
-      "sales_rep_name": "xyz789",
+      "sales_rep_name": "abc123",
       "selected_payment_method": SelectedPaymentMethod,
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
       "status": "SUBMITTED",
-      "template_id": "4",
+      "template_id": 4,
       "template_name": "abc123",
       "total_quantity": 123.45,
       "uid": 4,
-      "updated_at": "abc123"
+      "updated_at": "xyz789"
     }
   }
 }
@@ -2886,9 +2920,9 @@ query negotiableQuoteTemplate($templateId: ID!) {
       "is_min_max_qty_used": false,
       "is_virtual": true,
       "items": [CartItemInterface],
-      "max_order_commitment": 987,
+      "max_order_commitment": 123,
       "min_order_commitment": 987,
-      "name": "xyz789",
+      "name": "abc123",
       "notifications": [QuoteTemplateNotificationMessage],
       "prices": CartPrices,
       "reference_document_links": [
@@ -2898,10 +2932,10 @@ query negotiableQuoteTemplate($templateId: ID!) {
       "shipping_addresses": [
         NegotiableQuoteShippingAddress
       ],
-      "status": "abc123",
-      "template_id": "4",
-      "total_quantity": 987.65,
-      "uid": "4",
+      "status": "xyz789",
+      "template_id": 4,
+      "total_quantity": 123.45,
+      "uid": 4,
       "updated_at": "xyz789"
     }
   }
@@ -2976,7 +3010,7 @@ query negotiableQuoteTemplates(
       "items": [NegotiableQuoteTemplateGridItem],
       "page_info": SearchResultPageInfo,
       "sort_fields": SortFields,
-      "total_count": 123
+      "total_count": 987
     }
   }
 }
@@ -3058,6 +3092,50 @@ query negotiableQuotes(
 
 <HorizontalLine />
 
+### payByLinkCart
+
+Resolve a Pay By Link token to the masked id of the guest cart to resume checkout against.
+
+**Response:** [`PayByLinkCartOutput`](/reference/graphql/saas/types-k-p.md#paybylinkcartoutput)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `token` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The Pay By Link token from the emailed link. |
+
+#### Example
+
+##### Query
+
+```graphql
+query payByLinkCart($token: String!) {
+  payByLinkCart(token: $token) {
+    masked_cart_id
+  }
+}
+```
+
+##### Variables
+
+```json
+{"token": "abc123"}
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "payByLinkCart": {
+      "masked_cart_id": "abc123"
+    }
+  }
+}
+```
+
+<HorizontalLine />
+
 ### pickupLocations
 
 The pickup locations query searches for locations that match the search request requirements.
@@ -3128,7 +3206,7 @@ query pickupLocations(
     "pickupLocations": {
       "items": [PickupLocation],
       "page_info": SearchResultPageInfo,
-      "total_count": 123
+      "total_count": 987
     }
   }
 }
@@ -3201,7 +3279,7 @@ query productSearch(
   "current_page": 1,
   "filter": [SearchClauseInput],
   "page_size": 20,
-  "phrase": "abc123",
+  "phrase": "xyz789",
   "sort": [ProductSearchSortInput]
 }
 ```
@@ -3216,7 +3294,7 @@ query productSearch(
       "items": [ProductSearchItem],
       "page_info": SearchResultPageInfo,
       "related_terms": ["abc123"],
-      "suggestions": ["abc123"],
+      "suggestions": ["xyz789"],
       "total_count": 987,
       "warnings": [ProductSearchWarning]
     }
@@ -3228,7 +3306,7 @@ query productSearch(
 
 ### products
 
-Search for products that match the specified SKU values. In Adobe Commerce as a Cloud Service, this query replaces the `products` query defined in the Commerce Foundation.
+Search for products that match the specified SKU values. Available only for deployments using the Catalog or Live Search service with Adobe Commerce.
 
 **Response:** [`[ProductView]`](/reference/graphql/saas/types-k-p.md#productview)
 
@@ -3270,6 +3348,9 @@ query products($skus: [String]) {
     }
     sku
     externalId
+    externalIds {
+      ...ExternalIdFragment
+    }
     url
     urlKey
     links {
@@ -3295,27 +3376,28 @@ query products($skus: [String]) {
     "products": [
       {
         "addToCartAllowed": false,
-        "inStock": true,
-        "lowStock": false,
+        "inStock": false,
+        "lowStock": true,
         "attributes": [ProductViewAttribute],
-        "description": "abc123",
+        "description": "xyz789",
         "id": 4,
         "images": [ProductViewImage],
         "videos": [ProductViewVideo],
         "lastModifiedAt": "2007-12-03T10:15:30Z",
-        "metaDescription": "abc123",
+        "metaDescription": "xyz789",
         "metaKeyword": "abc123",
         "metaTitle": "abc123",
-        "name": "abc123",
+        "name": "xyz789",
         "shortDescription": "xyz789",
         "inputOptions": [ProductViewInputOption],
-        "sku": "xyz789",
+        "sku": "abc123",
         "externalId": "abc123",
-        "url": "abc123",
-        "urlKey": "xyz789",
+        "externalIds": [ExternalId],
+        "url": "xyz789",
+        "urlKey": "abc123",
         "links": [ProductViewLink],
         "queryType": "xyz789",
-        "visibility": "xyz789"
+        "visibility": "abc123"
       }
     ]
   }
@@ -3413,7 +3495,7 @@ query recaptchaFormConfigs($formTypes: [ReCaptchaFormEnum!]!) {
       {
         "configurations": ReCaptchaConfiguration,
         "form_type": "PLACE_ORDER",
-        "is_enabled": true
+        "is_enabled": false
       }
     ]
   }
@@ -3456,11 +3538,11 @@ query recaptchaV3Config {
       "badge_position": "abc123",
       "failure_message": "xyz789",
       "forms": ["PLACE_ORDER"],
-      "is_enabled": true,
+      "is_enabled": false,
       "language_code": "abc123",
       "minimum_score": 123.45,
       "theme": "abc123",
-      "website_key": "xyz789"
+      "website_key": "abc123"
     }
   }
 }
@@ -3542,6 +3624,78 @@ query recommendations(
   "data": {
     "recommendations": {
       "results": [RecommendationUnit],
+      "totalResults": 123
+    }
+  }
+}
+```
+
+<HorizontalLine />
+
+### recommendationsByUnits
+
+**Response:** [`Recommendations`](/reference/graphql/saas/types-q-s.md#recommendations)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `selector` - [`UnitSelector!`](/reference/graphql/saas/types-t-z.md#unitselector) | Selector of preconfigured units |
+| `currentSku` - [`String`](/reference/graphql/saas/types-q-s.md#string) | SKU of the product currently being viewed on PDP |
+| `currentProduct` - [`CurrentProductInput`](/reference/graphql/saas/types-c-e.md#currentproductinput) | Current product context from PDP (SKU, price, category, etc.) |
+| `userPurchaseHistory` - [`[PurchaseHistory]`](/reference/graphql/saas/types-k-p.md#purchasehistory) | User purchase history with timestamp |
+| `userViewHistory` - [`[ViewHistory]`](/reference/graphql/saas/types-t-z.md#viewhistory) | User view history with timestamp |
+| `cartSkus` - [`[String]`](/reference/graphql/saas/types-q-s.md#string) | SKUs of products in the cart |
+
+#### Example
+
+##### Query
+
+```graphql
+query recommendationsByUnits(
+  $selector: UnitSelector!,
+  $currentSku: String,
+  $currentProduct: CurrentProductInput,
+  $userPurchaseHistory: [PurchaseHistory],
+  $userViewHistory: [ViewHistory],
+  $cartSkus: [String]
+) {
+  recommendationsByUnits(
+    selector: $selector,
+    currentSku: $currentSku,
+    currentProduct: $currentProduct,
+    userPurchaseHistory: $userPurchaseHistory,
+    userViewHistory: $userViewHistory,
+    cartSkus: $cartSkus
+  ) {
+    results {
+      ...RecommendationUnitFragment
+    }
+    totalResults
+  }
+}
+```
+
+##### Variables
+
+```json
+{
+  "selector": UnitSelector,
+  "currentSku": "xyz789",
+  "currentProduct": CurrentProductInput,
+  "userPurchaseHistory": [PurchaseHistory],
+  "userViewHistory": [ViewHistory],
+  "cartSkus": ["abc123"]
+}
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "recommendationsByUnits": {
+      "results": [RecommendationUnit],
       "totalResults": 987
     }
   }
@@ -3601,6 +3755,9 @@ query refineProduct(
     }
     sku
     externalId
+    externalIds {
+      ...ExternalIdFragment
+    }
     url
     urlKey
     links {
@@ -3616,7 +3773,7 @@ query refineProduct(
 
 ```json
 {
-  "optionIds": ["xyz789"],
+  "optionIds": ["abc123"],
   "sku": "abc123"
 }
 ```
@@ -3627,27 +3784,28 @@ query refineProduct(
 {
   "data": {
     "refineProduct": {
-      "addToCartAllowed": false,
-      "inStock": true,
-      "lowStock": false,
+      "addToCartAllowed": true,
+      "inStock": false,
+      "lowStock": true,
       "attributes": [ProductViewAttribute],
       "description": "abc123",
-      "id": 4,
+      "id": "4",
       "images": [ProductViewImage],
       "videos": [ProductViewVideo],
       "lastModifiedAt": "2007-12-03T10:15:30Z",
       "metaDescription": "xyz789",
       "metaKeyword": "abc123",
-      "metaTitle": "abc123",
+      "metaTitle": "xyz789",
       "name": "abc123",
-      "shortDescription": "abc123",
+      "shortDescription": "xyz789",
       "inputOptions": [ProductViewInputOption],
-      "sku": "abc123",
-      "externalId": "abc123",
-      "url": "abc123",
+      "sku": "xyz789",
+      "externalId": "xyz789",
+      "externalIds": [ExternalId],
+      "url": "xyz789",
       "urlKey": "abc123",
       "links": [ProductViewLink],
-      "queryType": "xyz789",
+      "queryType": "abc123",
       "visibility": "xyz789"
     }
   }
@@ -3686,7 +3844,7 @@ query sharedRequisitionList($token: String!) {
 ##### Variables
 
 ```json
-{"token": "abc123"}
+{"token": "xyz789"}
 ```
 
 ##### Response
@@ -3698,6 +3856,70 @@ query sharedRequisitionList($token: String!) {
       "requisition_list": RequisitionList,
       "sender_name": "xyz789"
     }
+  }
+}
+```
+
+<HorizontalLine />
+
+### sourceAvailability
+
+Per-source availability for one or more SKUs, scoped to the storefront-visible sources of the current sales channel's stock. Availability is computed identically to the order-placement guard.
+
+**Response:** [`[SkuSourceAvailability]!`](/reference/graphql/saas/types-q-s.md#skusourceavailability)
+
+#### Arguments
+
+| Name | Description |
+|------|-------------|
+| `skus` - [`[String!]!`](/reference/graphql/saas/types-q-s.md#string) | The product SKUs to report availability for. |
+| `source_codes` - [`[String!]`](/reference/graphql/saas/types-q-s.md#string) | Restrict the report to these inventory sources. Only sources flagged storefront-visible are ever reported; a requested source that is not storefront-visible, or not assigned to the current sales channel's stock, is silently omitted. When omitted, every storefront-visible source assigned to the current sales channel's stock is reported. |
+| `only_in_stock` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | When true, omit sources where the SKU is not salable. |
+
+#### Example
+
+##### Query
+
+```graphql
+query sourceAvailability(
+  $skus: [String!]!,
+  $source_codes: [String!],
+  $only_in_stock: Boolean
+) {
+  sourceAvailability(
+    skus: $skus,
+    source_codes: $source_codes,
+    only_in_stock: $only_in_stock
+  ) {
+    sku
+    sources {
+      ...SourceAvailabilityFragment
+    }
+  }
+}
+```
+
+##### Variables
+
+```json
+{
+  "skus": ["xyz789"],
+  "source_codes": ["abc123"],
+  "only_in_stock": false
+}
+```
+
+##### Response
+
+```json
+{
+  "data": {
+    "sourceAvailability": [
+      {
+        "sku": "abc123",
+        "sources": [SourceAvailability]
+      }
+    ]
   }
 }
 ```
@@ -3815,9 +4037,13 @@ query storeConfig {
     orders_invoices_credit_memos_display_shipping_amount
     orders_invoices_credit_memos_display_subtotal
     orders_invoices_credit_memos_display_zero_tax
+    persistent_enabled
+    persistent_options_wishlist
+    persistent_shopping_cart
     printed_card_priceV2 {
       ...MoneyFragment
     }
+    product_alert_allow_stock
     product_fixed_product_tax_display_setting
     product_url_suffix
     quickorder_active
@@ -3839,6 +4065,7 @@ query storeConfig {
     secure_base_url
     share_active_segments
     share_applied_cart_rule
+    share_customer_accounts_scope
     shopping_assistance_checkbox_title
     shopping_assistance_checkbox_tooltip
     shopping_assistance_enabled
@@ -3880,92 +4107,92 @@ query storeConfig {
       "allow_company_registration": false,
       "allow_gift_receipt": "abc123",
       "allow_gift_wrapping_on_order": "xyz789",
-      "allow_gift_wrapping_on_order_items": "xyz789",
+      "allow_gift_wrapping_on_order_items": "abc123",
       "allow_items": "abc123",
-      "allow_order": "abc123",
+      "allow_order": "xyz789",
       "allow_printed_card": "xyz789",
       "autocomplete_on_storefront": true,
-      "base_currency_code": "xyz789",
-      "base_link_url": "xyz789",
+      "base_currency_code": "abc123",
+      "base_link_url": "abc123",
       "base_media_url": "abc123",
-      "base_static_url": "abc123",
+      "base_static_url": "xyz789",
       "base_url": "abc123",
       "cart_expires_in_days": 123,
-      "cart_gift_wrapping": "xyz789",
-      "cart_merge_preference": "abc123",
-      "cart_printed_card": "abc123",
-      "cart_summary_display_quantity": 987,
+      "cart_gift_wrapping": "abc123",
+      "cart_merge_preference": "xyz789",
+      "cart_printed_card": "xyz789",
+      "cart_summary_display_quantity": 123,
       "catalog_default_sort_by": "xyz789",
       "category_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
-      "category_url_suffix": "abc123",
+      "category_url_suffix": "xyz789",
       "check_money_order_enable_for_specific_countries": false,
       "check_money_order_enabled": true,
       "check_money_order_make_check_payable_to": "xyz789",
-      "check_money_order_max_order_total": "xyz789",
+      "check_money_order_max_order_total": "abc123",
       "check_money_order_min_order_total": "abc123",
       "check_money_order_new_order_status": "xyz789",
       "check_money_order_payment_from_specific_countries": "abc123",
       "check_money_order_send_check_to": "abc123",
       "check_money_order_sort_order": 987,
-      "check_money_order_title": "abc123",
-      "company_credit_enabled": true,
-      "company_enabled": true,
+      "check_money_order_title": "xyz789",
+      "company_credit_enabled": false,
+      "company_enabled": false,
       "configurable_product_image": "ITSELF",
       "configurable_thumbnail_source": "xyz789",
       "contact_enabled": false,
       "countries_with_required_region": "abc123",
-      "create_account_confirmation": true,
-      "customer_access_token_lifetime": 987.65,
-      "default_country": "xyz789",
-      "default_display_currency_code": "xyz789",
+      "create_account_confirmation": false,
+      "customer_access_token_lifetime": 123.45,
+      "default_country": "abc123",
+      "default_display_currency_code": "abc123",
       "display_product_prices_in_catalog": 123,
-      "display_shipping_prices": 987,
+      "display_shipping_prices": 123,
       "display_state_if_optional": false,
       "enable_multiple_wishlists": "xyz789",
       "fixed_product_taxes_apply_tax_to_fpt": true,
       "fixed_product_taxes_display_prices_in_emails": 987,
-      "fixed_product_taxes_display_prices_in_product_lists": 987,
+      "fixed_product_taxes_display_prices_in_product_lists": 123,
       "fixed_product_taxes_display_prices_in_sales_modules": 123,
-      "fixed_product_taxes_display_prices_on_product_view_page": 987,
-      "fixed_product_taxes_enable": false,
+      "fixed_product_taxes_display_prices_on_product_view_page": 123,
+      "fixed_product_taxes_enable": true,
       "fixed_product_taxes_include_fpt_in_subtotal": false,
       "graphql_share_customer_group": true,
-      "grid_per_page": 123,
-      "grid_per_page_values": "abc123",
+      "grid_per_page": 987,
+      "grid_per_page_values": "xyz789",
       "grouped_product_image": "ITSELF",
-      "is_checkout_agreements_enabled": true,
+      "is_checkout_agreements_enabled": false,
       "is_default_store": false,
-      "is_default_store_group": true,
-      "is_guest_checkout_enabled": false,
+      "is_default_store_group": false,
+      "is_guest_checkout_enabled": true,
       "is_negotiable_quote_active": false,
-      "is_one_page_checkout_enabled": true,
+      "is_one_page_checkout_enabled": false,
       "is_requisition_list_active": "xyz789",
       "list_mode": "xyz789",
       "list_per_page": 123,
-      "list_per_page_values": "xyz789",
+      "list_per_page_values": "abc123",
       "locale": "xyz789",
       "magento_reward_general_is_enabled": "abc123",
       "magento_reward_general_is_enabled_on_front": "abc123",
-      "magento_reward_general_min_points_balance": "abc123",
-      "magento_reward_general_publish_history": "xyz789",
+      "magento_reward_general_min_points_balance": "xyz789",
+      "magento_reward_general_publish_history": "abc123",
       "magento_reward_points_invitation_customer": "xyz789",
-      "magento_reward_points_invitation_customer_limit": "abc123",
-      "magento_reward_points_invitation_order": "abc123",
-      "magento_reward_points_invitation_order_limit": "abc123",
+      "magento_reward_points_invitation_customer_limit": "xyz789",
+      "magento_reward_points_invitation_order": "xyz789",
+      "magento_reward_points_invitation_order_limit": "xyz789",
       "magento_reward_points_newsletter": "xyz789",
-      "magento_reward_points_order": "abc123",
-      "magento_reward_points_register": "xyz789",
+      "magento_reward_points_order": "xyz789",
+      "magento_reward_points_register": "abc123",
       "magento_reward_points_review": "xyz789",
       "magento_reward_points_review_limit": "xyz789",
-      "magento_wishlist_general_is_enabled": "xyz789",
+      "magento_wishlist_general_is_enabled": "abc123",
       "max_items_in_order_summary": 987,
       "maximum_number_of_wishlists": "abc123",
-      "minicart_display": true,
+      "minicart_display": false,
       "minicart_max_items": 987,
       "minimum_password_length": "xyz789",
-      "newsletter_enabled": true,
+      "newsletter_enabled": false,
       "optional_zip_countries": "abc123",
-      "order_cancellation_enabled": true,
+      "order_cancellation_enabled": false,
       "order_cancellation_reasons": [CancellationReason],
       "orders_invoices_credit_memos_display_full_summary": false,
       "orders_invoices_credit_memos_display_grandtotal": false,
@@ -3973,56 +4200,61 @@ query storeConfig {
       "orders_invoices_credit_memos_display_shipping_amount": 123,
       "orders_invoices_credit_memos_display_subtotal": 123,
       "orders_invoices_credit_memos_display_zero_tax": true,
+      "persistent_enabled": false,
+      "persistent_options_wishlist": true,
+      "persistent_shopping_cart": true,
       "printed_card_priceV2": Money,
+      "product_alert_allow_stock": false,
       "product_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
       "product_url_suffix": "abc123",
-      "quickorder_active": false,
+      "quickorder_active": true,
       "quote_minimum_amount": 987.65,
       "quote_minimum_amount_message": "abc123",
       "required_character_classes_number": "abc123",
       "requisition_list_share_link_validity_days": 987,
       "requisition_list_share_max_recipients": 987,
       "requisition_list_share_storefront_path": "abc123",
-      "requisition_list_sharing_enabled": true,
-      "returns_enabled": "xyz789",
+      "requisition_list_sharing_enabled": false,
+      "returns_enabled": "abc123",
       "root_category_uid": "4",
       "sales_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
       "sales_gift_wrapping": "xyz789",
-      "sales_printed_card": "xyz789",
-      "secure_base_link_url": "abc123",
-      "secure_base_media_url": "abc123",
-      "secure_base_static_url": "abc123",
+      "sales_printed_card": "abc123",
+      "secure_base_link_url": "xyz789",
+      "secure_base_media_url": "xyz789",
+      "secure_base_static_url": "xyz789",
       "secure_base_url": "abc123",
-      "share_active_segments": false,
+      "share_active_segments": true,
       "share_applied_cart_rule": false,
+      "share_customer_accounts_scope": 123,
       "shopping_assistance_checkbox_title": "xyz789",
-      "shopping_assistance_checkbox_tooltip": "abc123",
+      "shopping_assistance_checkbox_tooltip": "xyz789",
       "shopping_assistance_enabled": false,
-      "shopping_cart_display_full_summary": true,
-      "shopping_cart_display_grand_total": true,
-      "shopping_cart_display_price": 987,
+      "shopping_cart_display_full_summary": false,
+      "shopping_cart_display_grand_total": false,
+      "shopping_cart_display_price": 123,
       "shopping_cart_display_shipping": 987,
-      "shopping_cart_display_subtotal": 987,
+      "shopping_cart_display_subtotal": 123,
       "shopping_cart_display_tax_gift_wrapping": "DISPLAY_EXCLUDING_TAX",
-      "shopping_cart_display_zero_tax": true,
+      "shopping_cart_display_zero_tax": false,
       "store_code": "4",
-      "store_group_code": 4,
+      "store_group_code": "4",
       "store_group_name": "xyz789",
-      "store_name": "abc123",
-      "store_sort_order": 123,
-      "timezone": "xyz789",
-      "title_separator": "abc123",
-      "use_store_in_url": true,
+      "store_name": "xyz789",
+      "store_sort_order": 987,
+      "timezone": "abc123",
+      "title_separator": "xyz789",
+      "use_store_in_url": false,
       "website_code": "4",
-      "website_name": "xyz789",
+      "website_name": "abc123",
       "weight_unit": "xyz789",
       "zero_subtotal_enable_for_specific_countries": false,
       "zero_subtotal_enabled": false,
-      "zero_subtotal_new_order_status": "xyz789",
-      "zero_subtotal_payment_action": "abc123",
-      "zero_subtotal_payment_from_specific_countries": "xyz789",
-      "zero_subtotal_sort_order": 987,
-      "zero_subtotal_title": "xyz789"
+      "zero_subtotal_new_order_status": "abc123",
+      "zero_subtotal_payment_action": "xyz789",
+      "zero_subtotal_payment_from_specific_countries": "abc123",
+      "zero_subtotal_sort_order": 123,
+      "zero_subtotal_title": "abc123"
     }
   }
 }
@@ -4073,7 +4305,7 @@ query variants(
 ```json
 {
   "sku": "xyz789",
-  "optionIds": ["xyz789"],
+  "optionIds": ["abc123"],
   "pageSize": 987,
   "cursor": "xyz789"
 }
@@ -4086,7 +4318,7 @@ query variants(
   "data": {
     "variants": {
       "variants": [ProductViewVariant],
-      "cursor": "xyz789"
+      "cursor": "abc123"
     }
   }
 }

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-a-b.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-a-b.md
@@ -95,8 +95,8 @@ Defines a new registrant.
     GiftRegistryDynamicAttributeInput
   ],
   "email": "xyz789",
-  "firstname": "abc123",
-  "lastname": "abc123"
+  "firstname": "xyz789",
+  "lastname": "xyz789"
 }
 ```
 
@@ -156,10 +156,7 @@ Contains products to add to an existing compare list.
 #### Example
 
 ```json
-{
-  "products": ["4"],
-  "uid": "4"
-}
+{"products": [4], "uid": "4"}
 ```
 
 <HorizontalLine />
@@ -284,7 +281,7 @@ Defines the purchase order and cart to act on.
 {
   "cart_id": "xyz789",
   "purchase_order_uid": 4,
-  "replace_existing_cart_items": false
+  "replace_existing_cart_items": true
 }
 ```
 
@@ -305,7 +302,7 @@ Contains details about why an attempt to add items to the requistion list failed
 
 ```json
 {
-  "message": "abc123",
+  "message": "xyz789",
   "type": "OUT_OF_STOCK"
 }
 ```
@@ -351,7 +348,7 @@ Output of the request to add items in a requisition list to the cart.
     AddRequisitionListItemToCartUserError
   ],
   "cart": Cart,
-  "status": false
+  "status": true
 }
 ```
 
@@ -413,9 +410,9 @@ Defines tracking information to be added to the return.
 
 ```json
 {
-  "carrier_uid": 4,
+  "carrier_uid": "4",
   "return_uid": 4,
-  "tracking_number": "xyz789"
+  "tracking_number": "abc123"
 }
 ```
 
@@ -462,7 +459,7 @@ Contains the resultant wish list and any error information.
   "add_wishlist_items_to_cart_user_errors": [
     WishlistCartUserInputError
   ],
-  "status": false,
+  "status": true,
   "wishlist": Wishlist
 }
 ```
@@ -511,7 +508,7 @@ Paginated admin assistance actions for the customer.
 {
   "items": [AdminAssistanceAction],
   "page_info": SearchResultPageInfo,
-  "total_count": 987
+  "total_count": 123
 }
 ```
 
@@ -534,7 +531,7 @@ A bucket that contains information for each filterable option
 
 ```json
 {
-  "attribute": "abc123",
+  "attribute": "xyz789",
   "buckets": [Bucket],
   "title": "xyz789",
   "type": "INTELLIGENT"
@@ -584,12 +581,12 @@ Identifies the data type of the aggregation
 {
   "button_styles": ButtonStyles,
   "code": "abc123",
-  "is_visible": false,
-  "payment_intent": "abc123",
-  "payment_source": "xyz789",
+  "is_visible": true,
+  "payment_intent": "xyz789",
+  "payment_source": "abc123",
   "sdk_params": [SDKParams],
   "sort_order": "xyz789",
-  "title": "xyz789"
+  "title": "abc123"
 }
 ```
 
@@ -611,7 +608,7 @@ Apple Pay inputs
 
 ```json
 {
-  "payment_source": "abc123",
+  "payment_source": "xyz789",
   "payments_order_id": "xyz789",
   "paypal_order_id": "xyz789"
 }
@@ -632,7 +629,7 @@ Contains the applied coupon code.
 #### Example
 
 ```json
-{"code": "abc123"}
+{"code": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -806,8 +803,8 @@ Apply coupons to the cart.
 
 ```json
 {
-  "cart_id": "xyz789",
-  "coupon_codes": ["abc123"],
+  "cart_id": "abc123",
+  "coupon_codes": ["xyz789"],
   "type": "APPEND"
 }
 ```
@@ -829,8 +826,8 @@ Defines the input required to run the `applyGiftCardToCart` mutation.
 
 ```json
 {
-  "cart_id": "abc123",
-  "gift_card_code": "xyz789"
+  "cart_id": "xyz789",
+  "gift_card_code": "abc123"
 }
 ```
 
@@ -961,6 +958,7 @@ Contains information about an asset image.
 | `disabled` - [`Boolean`](#boolean) | Indicates whether the image is hidden from view. |
 | `label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The label of the product image or video. |
 | `position` - [`Int`](/reference/graphql/saas/types-f-i.md#int) | The media item's position after it has been sorted. |
+| `types` - [`[String]`](/reference/graphql/saas/types-q-s.md#string) | Array of image types. It can have the following values: image, small_image, thumbnail. |
 | `url` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The URL of the product image or video. |
 
 #### Example
@@ -968,9 +966,10 @@ Contains information about an asset image.
 ```json
 {
   "asset_image": ProductMediaGalleryEntriesAssetImage,
-  "disabled": false,
-  "label": "abc123",
-  "position": 987,
+  "disabled": true,
+  "label": "xyz789",
+  "position": 123,
+  "types": ["abc123"],
   "url": "abc123"
 }
 ```
@@ -989,6 +988,7 @@ Contains information about an asset video.
 | `disabled` - [`Boolean`](#boolean) | Indicates whether the image is hidden from view. |
 | `label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The label of the product image or video. |
 | `position` - [`Int`](/reference/graphql/saas/types-f-i.md#int) | The media item's position after it has been sorted. |
+| `types` - [`[String]`](/reference/graphql/saas/types-q-s.md#string) | Array of image types. It can have the following values: image, small_image, thumbnail. |
 | `url` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The URL of the product image or video. |
 
 #### Example
@@ -998,8 +998,9 @@ Contains information about an asset video.
   "asset_video": ProductMediaGalleryEntriesAssetVideo,
   "disabled": false,
   "label": "abc123",
-  "position": 123,
-  "url": "xyz789"
+  "position": 987,
+  "types": ["xyz789"],
+  "url": "abc123"
 }
 ```
 
@@ -1019,10 +1020,7 @@ Defines the input schema for assigning a child company to a parent company.
 #### Example
 
 ```json
-{
-  "child_company_id": "4",
-  "parent_company_id": 4
-}
+{"child_company_id": 4, "parent_company_id": 4}
 ```
 
 <HorizontalLine />
@@ -1102,8 +1100,8 @@ List of all entity types. Populated by the modules introducing EAV entities.
 ```json
 {
   "attribute_type": "abc123",
-  "code": "4",
-  "url": "abc123",
+  "code": 4,
+  "url": "xyz789",
   "value": "abc123"
 }
 ```
@@ -1135,18 +1133,18 @@ An input object that specifies the filters used for attributes.
 
 ```json
 {
-  "is_comparable": false,
+  "is_comparable": true,
   "is_filterable": false,
-  "is_filterable_in_search": false,
-  "is_html_allowed_on_front": true,
-  "is_searchable": true,
-  "is_used_for_customer_segment": false,
-  "is_used_for_price_rules": true,
+  "is_filterable_in_search": true,
+  "is_html_allowed_on_front": false,
+  "is_searchable": false,
+  "is_used_for_customer_segment": true,
+  "is_used_for_price_rules": false,
   "is_used_for_promo_rules": false,
   "is_visible_in_advanced_search": false,
-  "is_visible_on_front": true,
+  "is_visible_on_front": false,
   "is_wysiwyg_enabled": false,
-  "used_in_product_listing": false
+  "used_in_product_listing": true
 }
 ```
 
@@ -1200,9 +1198,9 @@ EAV attribute frontend input types.
 
 ```json
 {
-  "attribute_type": "xyz789",
-  "code": 4,
-  "url": "abc123",
+  "attribute_type": "abc123",
+  "code": "4",
+  "url": "xyz789",
   "value": "xyz789"
 }
 ```
@@ -1224,7 +1222,7 @@ Defines the attribute characteristics to search for the `attribute_code` and `en
 
 ```json
 {
-  "attribute_code": "xyz789",
+  "attribute_code": "abc123",
   "entity_type": "xyz789"
 }
 ```
@@ -1277,7 +1275,7 @@ Base EAV implementation of CustomAttributeMetadataInterface.
   "frontend_class": "abc123",
   "frontend_input": "BOOLEAN",
   "is_required": false,
-  "is_unique": true,
+  "is_unique": false,
   "label": "xyz789",
   "options": [CustomAttributeOptionInterface]
 }
@@ -1300,7 +1298,7 @@ Attribute metadata retrieval error.
 
 ```json
 {
-  "message": "xyz789",
+  "message": "abc123",
   "type": "ENTITY_NOT_FOUND"
 }
 ```
@@ -1367,8 +1365,8 @@ Base EAV implementation of CustomAttributeOptionInterface.
 ```json
 {
   "is_default": true,
-  "label": "xyz789",
-  "value": "abc123"
+  "label": "abc123",
+  "value": "xyz789"
 }
 ```
 
@@ -1387,8 +1385,8 @@ Base EAV implementation of CustomAttributeOptionInterface.
 
 ```json
 {
-  "label": "xyz789",
-  "value": "xyz789"
+  "label": "abc123",
+  "value": "abc123"
 }
 ```
 
@@ -1414,7 +1412,7 @@ Base EAV implementation of CustomAttributeOptionInterface.
 ```json
 {
   "label": "xyz789",
-  "value": "xyz789"
+  "value": "abc123"
 }
 ```
 
@@ -1434,8 +1432,8 @@ Base EAV implementation of CustomAttributeOptionInterface.
 
 ```json
 {
-  "attribute_type": "xyz789",
-  "code": "4",
+  "attribute_type": "abc123",
+  "code": 4,
   "selected_options": [AttributeSelectedOptionInterface]
 }
 ```
@@ -1456,9 +1454,9 @@ Base EAV implementation of CustomAttributeOptionInterface.
 
 ```json
 {
-  "attribute_type": "abc123",
+  "attribute_type": "xyz789",
   "code": 4,
-  "value": "abc123"
+  "value": "xyz789"
 }
 ```
 
@@ -1480,7 +1478,7 @@ Specifies the value for attribute.
 
 ```json
 {
-  "attribute_code": "abc123",
+  "attribute_code": "xyz789",
   "selected_options": [AttributeInputSelectedOption],
   "value": "abc123"
 }
@@ -1505,12 +1503,16 @@ Specifies the value for attribute.
 | [`AttributeImage`](#attributeimage) |
 | [`AttributeSelectedOptions`](#attributeselectedoptions) |
 | [`AttributeValue`](#attributevalue) |
+| [`GiftCartAttributeValue`](/reference/graphql/saas/types-f-i.md#giftcartattributevalue) |
 | [`ProductAttributeFile`](/reference/graphql/saas/types-k-p.md#productattributefile) |
 
 #### Example
 
 ```json
-{"attribute_type": "xyz789", "code": 4}
+{
+  "attribute_type": "abc123",
+  "code": "4"
+}
 ```
 
 <HorizontalLine />
@@ -1594,6 +1596,34 @@ Defines the code and symbol of a currency that can be used for purchase orders.
 
 <HorizontalLine />
 
+### AvailableFreeGift
+
+A free-gift cart price rule that has not yet had a gift added because the customer must choose between multiple SKUs and/or product options.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `available_skus` - [`[String]!`](/reference/graphql/saas/types-q-s.md#string) | SKUs configured on the rule that resolved to a salable product. |
+| `gift_qty` - [`Int!`](/reference/graphql/saas/types-f-i.md#int) | Quantity of the chosen gift product to be added. |
+| `products` - [`[ProductInterface]!`](/reference/graphql/saas/types-k-p.md#productinterface) | Product details for the configured gift SKUs (parents for configurable/bundle), so the storefront picker can render without an extra round-trip. |
+| `rule_id` - [`Int!`](/reference/graphql/saas/types-f-i.md#int) | Identifier of the cart price rule offering the gift. |
+| `rule_label` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | Storefront-facing label for this rule (per-store label when set, otherwise description or a default). |
+
+#### Example
+
+```json
+{
+  "available_skus": ["xyz789"],
+  "gift_qty": 123,
+  "products": [ProductInterface],
+  "rule_id": 987,
+  "rule_label": "xyz789"
+}
+```
+
+<HorizontalLine />
+
 ### AvailablePaymentMethod
 
 Describes a payment method that the shopper can use to pay for the order.
@@ -1611,10 +1641,10 @@ Describes a payment method that the shopper can use to pay for the order.
 
 ```json
 {
-  "code": "abc123",
-  "is_deferred": true,
+  "code": "xyz789",
+  "is_deferred": false,
   "oope_payment_method_config": OopePaymentMethodConfig,
-  "title": "abc123"
+  "title": "xyz789"
 }
 ```
 
@@ -1645,12 +1675,12 @@ Contains details about the possible shipping methods and carriers.
 {
   "additional_data": [ShippingAdditionalData],
   "amount": Money,
-  "available": true,
-  "carrier_code": "abc123",
-  "carrier_title": "abc123",
+  "available": false,
+  "carrier_code": "xyz789",
+  "carrier_title": "xyz789",
   "error_message": "abc123",
   "method_code": "xyz789",
-  "method_title": "abc123",
+  "method_title": "xyz789",
   "price_excl_tax": Money,
   "price_incl_tax": Money
 }
@@ -1685,6 +1715,7 @@ Defines the billing address.
 | Input Field | Description |
 |-------------|-------------|
 | `address` - [`CartAddressInput`](/reference/graphql/saas/types-c-e.md#cartaddressinput) | Defines a billing address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | UID of a company address to use for billing. |
 | `customer_address_id` - [`Int`](/reference/graphql/saas/types-f-i.md#int) | An ID from the customer's address book that uniquely identifies the address to be used for billing. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID from the customer's address book that uniquely identifies the address to be used for billing. |
 | `same_as_shipping` - [`Boolean`](#boolean) | Indicates whether to set the billing address to be the same as the existing shipping address on the cart. |
@@ -1695,10 +1726,11 @@ Defines the billing address.
 ```json
 {
   "address": CartAddressInput,
+  "company_address_id": "4",
   "customer_address_id": 987,
   "customer_address_uid": 4,
-  "same_as_shipping": false,
-  "use_for_shipping": true
+  "same_as_shipping": true,
+  "use_for_shipping": false
 }
 ```
 
@@ -1723,12 +1755,12 @@ The billing address information
 
 ```json
 {
-  "address_line_1": "abc123",
-  "address_line_2": "abc123",
-  "city": "abc123",
+  "address_line_1": "xyz789",
+  "address_line_2": "xyz789",
+  "city": "xyz789",
   "country_code": "abc123",
   "postal_code": "xyz789",
-  "region": "xyz789"
+  "region": "abc123"
 }
 ```
 
@@ -1744,6 +1776,7 @@ Contains details about the billing address.
 |------------|-------------|
 | `city` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The city specified for the billing or shipping address. |
 | `company` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The company specified for the billing or shipping address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | UID of the company address referenced by this cart address, if any. |
 | `country` - [`CartAddressCountry!`](/reference/graphql/saas/types-c-e.md#cartaddresscountry) | An object containing the country label and code. |
 | `custom_attributes` - [`[AttributeValueInterface]!`](#attributevalueinterface) | The custom attribute values of the billing or shipping address. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID from the customer's address book that uniquely identifies the address. |
@@ -1766,23 +1799,24 @@ Contains details about the billing address.
 ```json
 {
   "city": "abc123",
-  "company": "abc123",
+  "company": "xyz789",
+  "company_address_id": 4,
   "country": CartAddressCountry,
   "custom_attributes": [AttributeValueInterface],
-  "customer_address_uid": "4",
+  "customer_address_uid": 4,
   "fax": "abc123",
-  "firstname": "abc123",
+  "firstname": "xyz789",
   "id": 987,
-  "lastname": "xyz789",
+  "lastname": "abc123",
   "middlename": "xyz789",
   "postcode": "abc123",
   "prefix": "abc123",
   "region": CartAddressRegion,
   "street": ["abc123"],
-  "suffix": "abc123",
+  "suffix": "xyz789",
   "telephone": "abc123",
   "uid": 4,
-  "vat_id": "abc123"
+  "vat_id": "xyz789"
 }
 ```
 
@@ -1819,9 +1853,9 @@ Contains details about an individual category that comprises a breadcrumb.
 ```json
 {
   "category_level": 123,
-  "category_name": "abc123",
-  "category_uid": "4",
-  "category_url_key": "xyz789",
+  "category_name": "xyz789",
+  "category_uid": 4,
+  "category_url_key": "abc123",
   "category_url_path": "xyz789"
 }
 ```
@@ -1874,9 +1908,12 @@ An implementation for bundle product cart items.
 | `gift_message` - [`GiftMessage`](/reference/graphql/saas/types-f-i.md#giftmessage) | The entered gift message for the cart item |
 | `gift_wrapping` - [`GiftWrapping`](/reference/graphql/saas/types-f-i.md#giftwrapping) | The selected gift wrapping for the cart item. |
 | `is_available` - [`Boolean!`](#boolean) | True if requested quantity is less than available stock, false otherwise. *(Deprecated: Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration.)* |
+| `is_free_gift` - [`Boolean!`](#boolean) | True if this line item was added by a Free Gift cart price rule. |
 | `is_salable` - [`Boolean!`](#boolean) | True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed. |
 | `max_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item max qty in quote template |
 | `min_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item min qty in quote template |
+| `nominated_source` - [`SourceAvailability`](/reference/graphql/saas/types-q-s.md#sourceavailability) | The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors). |
+| `nominated_source_errors` - [`[NominatedSourceError]!`](/reference/graphql/saas/types-k-p.md#nominatedsourceerror) | Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart. |
 | `not_available_message` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Shortage or unavailability message for the line; null when the item is salable. |
 | `note_from_buyer` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The buyer's quote line item note. |
 | `note_from_seller` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The seller's quote line item note. |
@@ -1899,10 +1936,13 @@ An implementation for bundle product cart items.
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
   "is_available": true,
+  "is_free_gift": true,
   "is_salable": false,
   "max_qty": 123.45,
-  "min_qty": 123.45,
-  "not_available_message": "xyz789",
+  "min_qty": 987.65,
+  "nominated_source": SourceAvailability,
+  "nominated_source_errors": [NominatedSourceError],
+  "not_available_message": "abc123",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
@@ -1943,7 +1983,7 @@ Defines bundle product options for `CreditMemoItemInterface`.
   "order_item": OrderItemInterface,
   "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
+  "product_sku": "abc123",
   "quantity_refunded": 987.65
 }
 ```
@@ -1979,8 +2019,8 @@ Defines bundle product options for `InvoiceItemInterface`.
   "order_item": OrderItemInterface,
   "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
-  "quantity_invoiced": 123.45
+  "product_sku": "abc123",
+  "quantity_invoiced": 987.65
 }
 ```
 
@@ -2008,13 +2048,13 @@ Defines an individual item within a bundle product.
 ```json
 {
   "options": [BundleItemOption],
-  "position": 987,
+  "position": 123,
   "price_range": PriceRange,
   "required": true,
   "sku": "xyz789",
   "title": "abc123",
-  "type": "xyz789",
-  "uid": 4
+  "type": "abc123",
+  "uid": "4"
 }
 ```
 
@@ -2045,12 +2085,12 @@ Defines the characteristics that comprise a specific bundle item and its options
   "can_change_quantity": false,
   "is_default": true,
   "label": "xyz789",
-  "position": 987,
+  "position": 123,
   "price": 987.65,
   "price_type": "FIXED",
   "product": ProductInterface,
   "quantity": 987.65,
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -2069,6 +2109,7 @@ Defines bundle product options for `OrderItemInterface`.
 | `discounts` - [`[Discount]`](/reference/graphql/saas/types-c-e.md#discount) | The final discount information for the product. |
 | `eligible_for_return` - [`Boolean`](#boolean) | Indicates whether the order item is eligible to be in a return request. |
 | `entered_options` - [`[OrderItemOption]`](/reference/graphql/saas/types-k-p.md#orderitemoption) | The entered option for the base product, such as a logo or image. |
+| `free_gift_label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The discount rule label for free gift items. Null if the item is not a free gift. |
 | `gift_message` - [`GiftMessage`](/reference/graphql/saas/types-f-i.md#giftmessage) | The selected gift message for the order item |
 | `gift_wrapping` - [`GiftWrapping`](/reference/graphql/saas/types-f-i.md#giftwrapping) | The selected gift wrapping for the order item. |
 | `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID for an `OrderItemInterface` object. |
@@ -2099,26 +2140,27 @@ Defines bundle product options for `OrderItemInterface`.
   "discounts": [Discount],
   "eligible_for_return": false,
   "entered_options": [OrderItemOption],
+  "free_gift_label": "abc123",
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
-  "id": 4,
-  "parent_sku": "xyz789",
+  "id": "4",
+  "parent_sku": "abc123",
   "prices": OrderItemPrices,
   "product": ProductInterface,
-  "product_name": "xyz789",
+  "product_name": "abc123",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
-  "product_type": "abc123",
-  "product_url_key": "xyz789",
+  "product_sku": "abc123",
+  "product_type": "xyz789",
+  "product_url_key": "abc123",
   "quantity_canceled": 123.45,
-  "quantity_invoiced": 987.65,
+  "quantity_invoiced": 123.45,
   "quantity_ordered": 123.45,
   "quantity_refunded": 987.65,
   "quantity_return_requested": 987.65,
-  "quantity_returned": 123.45,
+  "quantity_returned": 987.65,
   "quantity_shipped": 123.45,
   "selected_options": [OrderItemOption],
-  "status": "xyz789"
+  "status": "abc123"
 }
 ```
 
@@ -2191,24 +2233,24 @@ Defines basic features of a bundle product and contains multiple BundleItems.
   "crosssell_products": [ProductInterface],
   "custom_attributesV2": ProductCustomAttributes,
   "description": ComplexTextValue,
-  "dynamic_price": false,
+  "dynamic_price": true,
   "dynamic_sku": false,
-  "dynamic_weight": true,
-  "gift_message_available": false,
+  "dynamic_weight": false,
+  "gift_message_available": true,
   "gift_wrapping_available": true,
   "gift_wrapping_price": Money,
   "image": ProductImage,
   "is_returnable": "abc123",
   "items": [BundleItem],
-  "manufacturer": 987,
+  "manufacturer": 123,
   "max_sale_qty": 987.65,
   "media_gallery": [MediaGalleryInterface],
   "meta_description": "abc123",
-  "meta_keyword": "xyz789",
-  "meta_title": "abc123",
+  "meta_keyword": "abc123",
+  "meta_title": "xyz789",
   "min_sale_qty": 987.65,
   "name": "abc123",
-  "new_from_date": "xyz789",
+  "new_from_date": "abc123",
   "new_to_date": "abc123",
   "only_x_left_in_stock": 123.45,
   "options": [CustomizableOptionInterface],
@@ -2222,9 +2264,9 @@ Defines basic features of a bundle product and contains multiple BundleItems.
   "related_products": [ProductInterface],
   "ship_bundle_items": "TOGETHER",
   "short_description": ComplexTextValue,
-  "sku": "xyz789",
+  "sku": "abc123",
   "small_image": ProductImage,
-  "special_price": 123.45,
+  "special_price": 987.65,
   "special_to_date": "abc123",
   "stock_status": "IN_STOCK",
   "swatch_image": "abc123",
@@ -2261,7 +2303,7 @@ Contains details about bundle products added to a requisition list.
   "customizable_options": [SelectedCustomizableOption],
   "product": ProductInterface,
   "quantity": 123.45,
-  "sku": "abc123",
+  "sku": "xyz789",
   "uid": 4
 }
 ```
@@ -2289,12 +2331,12 @@ Defines bundle product options for `ShipmentItemInterface`.
 ```json
 {
   "bundle_options": [ItemSelectedBundleOption],
-  "id": "4",
+  "id": 4,
   "order_item": OrderItemInterface,
   "product_name": "abc123",
   "product_sale_price": Money,
   "product_sku": "xyz789",
-  "quantity_shipped": 123.45
+  "quantity_shipped": 987.65
 }
 ```
 
@@ -2324,7 +2366,7 @@ Defines bundle product options for `WishlistItemInterface`.
   "bundle_options": [SelectedBundleOption],
   "customizable_options": [SelectedCustomizableOption],
   "description": "xyz789",
-  "id": "4",
+  "id": 4,
   "product": ProductInterface,
   "quantity": 987.65
 }
@@ -2352,10 +2394,10 @@ Defines bundle product options for `WishlistItemInterface`.
 {
   "color": "xyz789",
   "height": 123,
-  "label": "xyz789",
-  "layout": "xyz789",
-  "shape": "xyz789",
-  "tagline": true,
+  "label": "abc123",
+  "layout": "abc123",
+  "shape": "abc123",
+  "tagline": false,
   "use_default_height": true
 }
 ```

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-c-e.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-c-e.md
@@ -16,7 +16,7 @@ Specifies the quote template id of the quote template to cancel
 ```json
 {
   "cancellation_comment": "xyz789",
-  "template_id": 4
+  "template_id": "4"
 }
 ```
 
@@ -36,7 +36,7 @@ Specifies the quote template id of the quote template to cancel
 ```json
 {
   "code": "ORDER_CANCELLATION_DISABLED",
-  "message": "abc123"
+  "message": "xyz789"
 }
 ```
 
@@ -77,7 +77,10 @@ Defines the order to cancel.
 #### Example
 
 ```json
-{"order_id": 4, "reason": "abc123"}
+{
+  "order_id": "4",
+  "reason": "xyz789"
+}
 ```
 
 <HorizontalLine />
@@ -117,7 +120,7 @@ Contains the updated customer order and error message if any.
 #### Example
 
 ```json
-{"description": "abc123"}
+{"description": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -143,7 +146,7 @@ Contains the updated customer order and error message if any.
   "bin_details": CardBin,
   "card_expiry_month": "xyz789",
   "card_expiry_year": "xyz789",
-  "last_digits": "xyz789",
+  "last_digits": "abc123",
   "name": "abc123"
 }
 ```
@@ -161,7 +164,7 @@ Contains the updated customer order and error message if any.
 #### Example
 
 ```json
-{"bin": "xyz789"}
+{"bin": "abc123"}
 ```
 
 <HorizontalLine />
@@ -182,7 +185,7 @@ The card payment source information
 ```json
 {
   "billing_address": BillingAddressPaymentSourceInput,
-  "name": "abc123"
+  "name": "xyz789"
 }
 ```
 
@@ -224,6 +227,7 @@ Contains the contents and other details about a guest or customer cart.
 | `applied_gift_cards` - [`[AppliedGiftCard]`](/reference/graphql/saas/types-a-b.md#appliedgiftcard) | An array of gift card items applied to the cart. |
 | `applied_reward_points` - [`RewardPointsAmount`](/reference/graphql/saas/types-q-s.md#rewardpointsamount) | The amount of reward points applied to the cart. |
 | `applied_store_credit` - [`AppliedStoreCredit`](/reference/graphql/saas/types-a-b.md#appliedstorecredit) | Store credit information applied to the cart. |
+| `available_free_gifts` - [`[AvailableFreeGift]!`](/reference/graphql/saas/types-a-b.md#availablefreegift) | Free-gift rules applied to the cart that still need a SKU selection from the customer. |
 | `available_gift_wrappings` - [`[GiftWrapping]!`](/reference/graphql/saas/types-f-i.md#giftwrapping) | The list of available gift wrapping options for the cart. |
 | `available_payment_methods` - [`[AvailablePaymentMethod]`](/reference/graphql/saas/types-a-b.md#availablepaymentmethod) | An array of available payment methods. |
 | `billing_address` - [`BillingCartAddress`](/reference/graphql/saas/types-a-b.md#billingcartaddress) | The billing address assigned to the cart. |
@@ -232,6 +236,7 @@ Contains the contents and other details about a guest or customer cart.
 | `gift_message` - [`GiftMessage`](/reference/graphql/saas/types-f-i.md#giftmessage) | The entered gift message for the cart |
 | `gift_receipt_included` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the shopper requested gift receipt for the cart. |
 | `gift_wrapping` - [`GiftWrapping`](/reference/graphql/saas/types-f-i.md#giftwrapping) | The selected gift wrapping for the cart. |
+| `has_available_free_gifts` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if any applied free-gift rule requires the customer to choose a SKU before placing the order. |
 | `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID for a `Cart` object. |
 | `is_virtual` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the cart contains only virtual products. |
 | `itemsV2` - [`CartItems`](#cartitems) |  |
@@ -250,19 +255,21 @@ Contains the contents and other details about a guest or customer cart.
   "applied_gift_cards": [AppliedGiftCard],
   "applied_reward_points": RewardPointsAmount,
   "applied_store_credit": AppliedStoreCredit,
+  "available_free_gifts": [AvailableFreeGift],
   "available_gift_wrappings": [GiftWrapping],
   "available_payment_methods": [AvailablePaymentMethod],
   "billing_address": BillingCartAddress,
   "custom_attributes": [CustomAttribute],
   "email": "abc123",
   "gift_message": GiftMessage,
-  "gift_receipt_included": true,
+  "gift_receipt_included": false,
   "gift_wrapping": GiftWrapping,
+  "has_available_free_gifts": false,
   "id": "4",
   "is_virtual": false,
   "itemsV2": CartItems,
   "prices": CartPrices,
-  "printed_card_included": true,
+  "printed_card_included": false,
   "rules": [CartRuleStorefront],
   "selected_payment_method": SelectedPaymentMethod,
   "shipping_addresses": [ShippingCartAddress],
@@ -317,7 +324,7 @@ Defines the billing or shipping address to be applied to the cart.
 | `save_in_address_book` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Determines whether to save the address in the customer's address book. The default value is true. |
 | `street` - [`[String]!`](/reference/graphql/saas/types-q-s.md#string) | An array containing the street for the billing or shipping address. |
 | `suffix` - [`String`](/reference/graphql/saas/types-q-s.md#string) | A value such as Sr., Jr., or III. |
-| `telephone` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The telephone number for the billing or shipping address. |
+| `telephone` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The telephone number for the billing or shipping address. |
 | `vat_id` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The VAT company number for billing or shipping address. |
 
 #### Example
@@ -325,22 +332,22 @@ Defines the billing or shipping address to be applied to the cart.
 ```json
 {
   "city": "xyz789",
-  "company": "abc123",
-  "country_code": "abc123",
+  "company": "xyz789",
+  "country_code": "xyz789",
   "custom_attributes": [AttributeValueInput],
-  "fax": "xyz789",
-  "firstname": "xyz789",
-  "lastname": "abc123",
-  "middlename": "abc123",
-  "postcode": "abc123",
-  "prefix": "xyz789",
-  "region": "abc123",
+  "fax": "abc123",
+  "firstname": "abc123",
+  "lastname": "xyz789",
+  "middlename": "xyz789",
+  "postcode": "xyz789",
+  "prefix": "abc123",
+  "region": "xyz789",
   "region_id": 123,
   "save_in_address_book": true,
   "street": ["abc123"],
-  "suffix": "abc123",
-  "telephone": "xyz789",
-  "vat_id": "abc123"
+  "suffix": "xyz789",
+  "telephone": "abc123",
+  "vat_id": "xyz789"
 }
 ```
 
@@ -354,6 +361,7 @@ Defines the billing or shipping address to be applied to the cart.
 |------------|-------------|
 | `city` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The city specified for the billing or shipping address. |
 | `company` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The company specified for the billing or shipping address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | UID of the company address referenced by this cart address, if any. |
 | `country` - [`CartAddressCountry!`](#cartaddresscountry) | An object containing the country label and code. |
 | `custom_attributes` - [`[AttributeValueInterface]!`](/reference/graphql/saas/types-a-b.md#attributevalueinterface) | The custom attribute values of the billing or shipping address. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID from the customer's address book that uniquely identifies the address. |
@@ -382,22 +390,23 @@ Defines the billing or shipping address to be applied to the cart.
 
 ```json
 {
-  "city": "xyz789",
-  "company": "abc123",
+  "city": "abc123",
+  "company": "xyz789",
+  "company_address_id": "4",
   "country": CartAddressCountry,
   "custom_attributes": [AttributeValueInterface],
   "customer_address_uid": "4",
-  "fax": "abc123",
-  "firstname": "xyz789",
-  "id": 987,
-  "lastname": "abc123",
-  "middlename": "abc123",
+  "fax": "xyz789",
+  "firstname": "abc123",
+  "id": 123,
+  "lastname": "xyz789",
+  "middlename": "xyz789",
   "postcode": "abc123",
-  "prefix": "abc123",
+  "prefix": "xyz789",
   "region": CartAddressRegion,
-  "street": ["xyz789"],
+  "street": ["abc123"],
   "suffix": "xyz789",
-  "telephone": "xyz789",
+  "telephone": "abc123",
   "uid": "4",
   "vat_id": "xyz789"
 }
@@ -421,9 +430,9 @@ Contains details about the region in a billing or shipping address.
 
 ```json
 {
-  "code": "abc123",
+  "code": "xyz789",
   "label": "abc123",
-  "region_id": 123
+  "region_id": 987
 }
 ```
 
@@ -444,7 +453,7 @@ Defines a cart custom attributes.
 
 ```json
 {
-  "cart_id": "abc123",
+  "cart_id": "xyz789",
   "custom_attributes": [CustomAttributeInput]
 }
 ```
@@ -485,7 +494,7 @@ Defines a cart item custom attributes.
 ```json
 {
   "cart_id": "xyz789",
-  "cart_item_id": "abc123",
+  "cart_item_id": "xyz789",
   "custom_attributes": [CustomAttributeInput]
 }
 ```
@@ -504,7 +513,7 @@ Defines a cart item custom attributes.
 #### Example
 
 ```json
-{"code": "UNDEFINED", "message": "xyz789"}
+{"code": "UNDEFINED", "message": "abc123"}
 ```
 
 <HorizontalLine />
@@ -547,7 +556,7 @@ Defines an item to be added to the cart.
 {
   "entered_options": [EnteredOptionInput],
   "parent_sku": "xyz789",
-  "quantity": 987.65,
+  "quantity": 123.45,
   "selected_options": [4],
   "sku": "xyz789"
 }
@@ -568,9 +577,12 @@ An interface for products in a cart.
 | `discount` - [`[Discount]`](#discount) | Contains discount for quote line item. |
 | `errors` - [`[CartItemError]`](#cartitemerror) | An array of errors encountered while loading the cart item |
 | `is_available` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if requested quantity is less than available stock, false otherwise. *(Deprecated: Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration.)* |
+| `is_free_gift` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if this line item was added by a Free Gift cart price rule. |
 | `is_salable` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed. |
 | `max_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item max qty in quote template |
 | `min_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item min qty in quote template |
+| `nominated_source` - [`SourceAvailability`](/reference/graphql/saas/types-q-s.md#sourceavailability) | The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors). |
+| `nominated_source_errors` - [`[NominatedSourceError]!`](/reference/graphql/saas/types-k-p.md#nominatedsourceerror) | Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart. |
 | `not_available_message` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Shortage or unavailability message for the line; null when the item is salable. |
 | `note_from_buyer` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The buyer's quote line item note. |
 | `note_from_seller` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The seller's quote line item note. |
@@ -594,21 +606,24 @@ An interface for products in a cart.
 
 ```json
 {
-  "backorder_message": "xyz789",
+  "backorder_message": "abc123",
   "custom_attributes": [CustomAttribute],
   "discount": [Discount],
   "errors": [CartItemError],
   "is_available": false,
+  "is_free_gift": true,
   "is_salable": true,
-  "max_qty": 123.45,
-  "min_qty": 123.45,
+  "max_qty": 987.65,
+  "min_qty": 987.65,
+  "nominated_source": SourceAvailability,
+  "nominated_source_errors": [NominatedSourceError],
   "not_available_message": "xyz789",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
-  "quantity": 987.65,
-  "uid": "4"
+  "quantity": 123.45,
+  "uid": 4
 }
 ```
 
@@ -672,7 +687,7 @@ Contains details about the price of a selected customizable value.
 {
   "type": "FIXED",
   "units": "abc123",
-  "value": 987.65
+  "value": 123.45
 }
 ```
 
@@ -699,7 +714,7 @@ A single item to be updated.
   "cart_item_uid": "4",
   "customizable_options": [CustomizableOptionInput],
   "gift_message": GiftMessageInput,
-  "gift_wrapping_id": 4,
+  "gift_wrapping_id": "4",
   "quantity": 123.45
 }
 ```
@@ -722,7 +737,7 @@ A single item to be updated.
 {
   "items": [CartItemInterface],
   "page_info": SearchResultPageInfo,
-  "total_count": 987
+  "total_count": 123
 }
 ```
 
@@ -775,7 +790,7 @@ Contains details about the final price of items in the cart, including discount 
 #### Example
 
 ```json
-{"uid": 4}
+{"uid": "4"}
 ```
 
 <HorizontalLine />
@@ -908,17 +923,17 @@ Swatch attribute metadata.
   "code": 4,
   "default_value": "xyz789",
   "entity_type": "CATALOG_PRODUCT",
-  "frontend_class": "xyz789",
+  "frontend_class": "abc123",
   "frontend_input": "BOOLEAN",
   "is_comparable": false,
-  "is_filterable": false,
+  "is_filterable": true,
   "is_filterable_in_search": true,
   "is_html_allowed_on_front": true,
   "is_required": true,
-  "is_searchable": true,
-  "is_unique": false,
+  "is_searchable": false,
+  "is_unique": true,
   "is_used_for_price_rules": false,
-  "is_used_for_promo_rules": true,
+  "is_used_for_promo_rules": false,
   "is_visible_in_advanced_search": true,
   "is_visible_on_front": true,
   "is_wysiwyg_enabled": false,
@@ -927,7 +942,7 @@ Swatch attribute metadata.
   "swatch_input_type": "BOOLEAN",
   "update_product_preview_image": true,
   "use_product_image_for_swatch": false,
-  "used_in_product_listing": true
+  "used_in_product_listing": false
 }
 ```
 
@@ -950,10 +965,10 @@ New category bucket for federation
 
 ```json
 {
-  "count": 123,
+  "count": 987,
   "id": "4",
   "path": "abc123",
-  "title": "xyz789"
+  "title": "abc123"
 }
 ```
 
@@ -976,7 +991,7 @@ New category bucket for federation
 #### Example
 
 ```json
-{"id": 4}
+{"id": "4"}
 ```
 
 <HorizontalLine />
@@ -1027,27 +1042,27 @@ Contains the full set of attributes that can be returned in a category search.
 {
   "available_sort_by": ["abc123"],
   "breadcrumbs": [Breadcrumb],
-  "canonical_url": "abc123",
-  "children_count": "xyz789",
+  "canonical_url": "xyz789",
+  "children_count": "abc123",
   "custom_layout_update_file": "xyz789",
   "default_sort_by": "abc123",
   "description": "abc123",
   "display_mode": "xyz789",
-  "filter_price_range": 123.45,
+  "filter_price_range": 987.65,
   "image": "xyz789",
   "include_in_menu": 987,
-  "is_anchor": 123,
+  "is_anchor": 987,
   "landing_page": 987,
   "level": 123,
   "meta_description": "xyz789",
-  "meta_keywords": "abc123",
+  "meta_keywords": "xyz789",
   "meta_title": "xyz789",
-  "name": "abc123",
-  "path": "xyz789",
+  "name": "xyz789",
+  "path": "abc123",
   "path_in_store": "xyz789",
   "position": 123,
   "product_count": 987,
-  "uid": 4,
+  "uid": "4",
   "url_key": "xyz789",
   "url_path": "xyz789"
 }
@@ -1096,28 +1111,28 @@ Contains the hierarchy of categories.
   "available_sort_by": ["xyz789"],
   "breadcrumbs": [Breadcrumb],
   "canonical_url": "xyz789",
-  "children_count": "abc123",
+  "children_count": "xyz789",
   "custom_layout_update_file": "xyz789",
   "default_sort_by": "xyz789",
   "description": "abc123",
   "display_mode": "xyz789",
   "filter_price_range": 987.65,
-  "image": "abc123",
-  "include_in_menu": 123,
+  "image": "xyz789",
+  "include_in_menu": 987,
   "is_anchor": 987,
   "landing_page": 987,
   "level": 123,
-  "meta_description": "xyz789",
-  "meta_keywords": "xyz789",
-  "meta_title": "abc123",
+  "meta_description": "abc123",
+  "meta_keywords": "abc123",
+  "meta_title": "xyz789",
   "name": "xyz789",
-  "path": "xyz789",
-  "path_in_store": "xyz789",
+  "path": "abc123",
+  "path_in_store": "abc123",
   "position": 123,
-  "product_count": 987,
+  "product_count": 123,
   "uid": "4",
   "url_key": "xyz789",
-  "url_path": "abc123"
+  "url_path": "xyz789"
 }
 ```
 
@@ -1150,19 +1165,19 @@ Represents a category. Contains information about a category, including the cate
 
 ```json
 {
-  "availableSortBy": ["abc123"],
-  "children": ["xyz789"],
-  "defaultSortBy": "xyz789",
-  "id": 4,
-  "level": 123,
+  "availableSortBy": ["xyz789"],
+  "children": ["abc123"],
+  "defaultSortBy": "abc123",
+  "id": "4",
+  "level": 987,
   "name": "xyz789",
   "parentId": "xyz789",
   "position": 987,
   "path": "xyz789",
-  "roles": ["xyz789"],
-  "urlKey": "abc123",
-  "urlPath": "xyz789",
-  "count": 123,
+  "roles": ["abc123"],
+  "urlKey": "xyz789",
+  "urlPath": "abc123",
+  "count": 987,
   "title": "abc123"
 }
 ```
@@ -1197,14 +1212,14 @@ Base interface defining essential category fields shared across all category vie
 
 ```json
 {
-  "availableSortBy": ["xyz789"],
-  "defaultSortBy": "xyz789",
+  "availableSortBy": ["abc123"],
+  "defaultSortBy": "abc123",
   "id": "4",
   "level": 123,
   "name": "abc123",
-  "path": "xyz789",
+  "path": "abc123",
   "roles": ["abc123"],
-  "urlKey": "abc123",
+  "urlKey": "xyz789",
   "urlPath": "abc123"
 }
 ```
@@ -1231,13 +1246,13 @@ Defines details about an individual checkout agreement.
 
 ```json
 {
-  "agreement_id": 123,
+  "agreement_id": 987,
   "checkbox_text": "xyz789",
   "content": "xyz789",
   "content_height": "abc123",
-  "is_html": false,
+  "is_html": true,
   "mode": "AUTO",
-  "name": "xyz789"
+  "name": "abc123"
 }
 ```
 
@@ -1279,7 +1294,7 @@ An error encountered while adding an item to the cart.
 ```json
 {
   "code": "REORDER_NOT_AVAILABLE",
-  "message": "abc123",
+  "message": "xyz789",
   "path": ["xyz789"]
 }
 ```
@@ -1302,6 +1317,84 @@ An error encountered while adding an item to the cart.
 
 ```json
 ""REORDER_NOT_AVAILABLE""
+```
+
+<HorizontalLine />
+
+### ClearCartError
+
+Contains details about errors encountered when a customer clear cart.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `message` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | A localized error message |
+| `type` - [`ClearCartErrorType!`](#clearcarterrortype) | A cart-specific error type. |
+
+#### Example
+
+```json
+{"message": "abc123", "type": "NOT_FOUND"}
+```
+
+<HorizontalLine />
+
+### ClearCartErrorType
+
+#### Values
+
+| Enum Value | Description |
+|------------|-------------|
+| `NOT_FOUND` |  |
+| `UNAUTHORISED` |  |
+| `INACTIVE` |  |
+| `UNDEFINED` |  |
+
+#### Example
+
+```json
+""NOT_FOUND""
+```
+
+<HorizontalLine />
+
+### ClearCartInput
+
+Assigns a specific `cart_id` to the empty cart.
+
+#### Input Fields
+
+| Input Field | Description |
+|-------------|-------------|
+| `uid` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of a `Cart` object. |
+
+#### Example
+
+```json
+{"uid": "4"}
+```
+
+<HorizontalLine />
+
+### ClearCartOutput
+
+Output of the request to clear the customer cart.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `cart` - [`Cart`](#cart) | The cart after clear cart items. |
+| `errors` - [`[ClearCartError]`](#clearcarterror) | An array of errors encountered while clearing the cart item |
+
+#### Example
+
+```json
+{
+  "cart": Cart,
+  "errors": [ClearCartError]
+}
 ```
 
 <HorizontalLine />
@@ -1359,7 +1452,7 @@ Contains details about a failed close operation on a negotiable quote.
 ```json
 {
   "errors": [NegotiableQuoteInvalidStateError],
-  "quote_uid": "4"
+  "quote_uid": 4
 }
 ```
 
@@ -1455,7 +1548,7 @@ Commerce Optimizer entities
 #### Example
 
 ```json
-{"priceBookId": "4"}
+{"priceBookId": 4}
 ```
 
 <HorizontalLine />
@@ -1506,12 +1599,16 @@ Contains the output schema for a company.
 | Field Name | Description |
 |------------|-------------|
 | `acl_resources` - [`[CompanyAclResource]`](#companyaclresource) | The list of all resources defined within the company. |
+| `addresses` - [`CompanyAddresses!`](#companyaddresses) | A paginated list of company addresses assigned to the company. |
 | `available_payment_methods` - [`[AvailablePaymentMethod]`](/reference/graphql/saas/types-a-b.md#availablepaymentmethod) | Available payment methods for the company with proper B2B configuration and company-specific filtering. |
 | `available_shipping_methods` - [`[CompanyAvailableShippingMethod]`](#companyavailableshippingmethod) | Available shipping carriers for the company with proper B2B configuration and company-specific filtering. |
 | `company_admin` - [`Customer`](#customer) | An object containing information about the company administrator. |
+| `config` - [`CompanyConfig!`](#companyconfig) | Company address book configuration settings. |
 | `credit` - [`CompanyCredit!`](#companycredit) | Company credit balances and limits. |
 | `credit_history` - [`CompanyCreditHistory!`](#companycredithistory) | Details about the history of company credit operations. |
 | `custom_attributes` - [`[CustomAttribute]`](#customattribute) | The custom attributes for the company |
+| `default_billing_address` - [`CompanyAddress`](#companyaddress) | The company's default billing address, if set. |
+| `default_shipping_address` - [`CompanyAddress`](#companyaddress) | The company's default shipping address, if set. |
 | `email` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The email address of the company contact. |
 | `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of a `Company` object. |
 | `legal_address` - [`CompanyLegalAddress`](#companylegaladdress) | The address where the company is registered to conduct business. |
@@ -1534,21 +1631,25 @@ Contains the output schema for a company.
 ```json
 {
   "acl_resources": [CompanyAclResource],
+  "addresses": CompanyAddresses,
   "available_payment_methods": [AvailablePaymentMethod],
   "available_shipping_methods": [
     CompanyAvailableShippingMethod
   ],
   "company_admin": Customer,
+  "config": CompanyConfig,
   "credit": CompanyCredit,
   "credit_history": CompanyCreditHistory,
   "custom_attributes": [CustomAttribute],
-  "email": "xyz789",
+  "default_billing_address": CompanyAddress,
+  "default_shipping_address": CompanyAddress,
+  "email": "abc123",
   "id": "4",
   "legal_address": CompanyLegalAddress,
-  "legal_name": "abc123",
+  "legal_name": "xyz789",
   "name": "abc123",
-  "payment_methods": ["abc123"],
-  "reseller_id": "xyz789",
+  "payment_methods": ["xyz789"],
+  "reseller_id": "abc123",
   "role": CompanyRole,
   "roles": CompanyRoles,
   "sales_representative": CompanySalesRepresentative,
@@ -1557,7 +1658,7 @@ Contains the output schema for a company.
   "team": CompanyTeam,
   "user": Customer,
   "users": CompanyUsers,
-  "vat_tax_id": "abc123"
+  "vat_tax_id": "xyz789"
 }
 ```
 
@@ -1581,9 +1682,216 @@ Contains details about the access control list settings of a resource.
 ```json
 {
   "children": [CompanyAclResource],
-  "id": "4",
-  "sort_order": 123,
+  "id": 4,
+  "sort_order": 987,
   "text": "abc123"
+}
+```
+
+<HorizontalLine />
+
+### CompanyAddress
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `address_type` - [`CompanyAddressTypeEnum!`](#companyaddresstypeenum) | The address type: BILLING or SHIPPING. |
+| `city` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The city. |
+| `company` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The company name. |
+| `company_id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of the company that owns the address. |
+| `country_code` - [`CountryCodeEnum`](#countrycodeenum) | The two-letter country code representing the company's country. |
+| `custom_attributes` - [`[AttributeValueInterface]!`](/reference/graphql/saas/types-a-b.md#attributevalueinterface) |  |
+| `extension_attributes` - [`[CustomerAddressAttribute]`](#customeraddressattribute) | Extension attributes for the company address. |
+| `fax` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The fax number. |
+| `firstname` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The first name. |
+| `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID for a `CompanyAddress` object. |
+| `is_default` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the address is the default for its type. |
+| `lastname` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The last name. |
+| `middlename` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The middle name. |
+| `nickname` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Optional nickname for the address. |
+| `postcode` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The postal code. |
+| `prefix` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The name prefix. |
+| `region` - [`CustomerAddressRegion`](#customeraddressregion) | An object containing the region name, region code, and region ID. |
+| `region_id` - [`Int`](/reference/graphql/saas/types-f-i.md#int) | The unique ID for a pre-defined region. |
+| `street` - [`[String]`](/reference/graphql/saas/types-q-s.md#string) | Street lines of the address. |
+| `suffix` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The name suffix. |
+| `telephone` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The telephone number. |
+| `vat_id` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The VAT ID. |
+
+#### Example
+
+```json
+{
+  "address_type": "BILLING",
+  "city": "xyz789",
+  "company": "abc123",
+  "company_id": "4",
+  "country_code": "AF",
+  "custom_attributes": [AttributeValueInterface],
+  "extension_attributes": [CustomerAddressAttribute],
+  "fax": "xyz789",
+  "firstname": "abc123",
+  "id": 4,
+  "is_default": true,
+  "lastname": "abc123",
+  "middlename": "xyz789",
+  "nickname": "xyz789",
+  "postcode": "xyz789",
+  "prefix": "xyz789",
+  "region": CustomerAddressRegion,
+  "region_id": 987,
+  "street": ["abc123"],
+  "suffix": "abc123",
+  "telephone": "abc123",
+  "vat_id": "xyz789"
+}
+```
+
+<HorizontalLine />
+
+### CompanyAddressInput
+
+Defines the input schema for creating a company address.
+
+#### Input Fields
+
+| Input Field | Description |
+|-------------|-------------|
+| `address_type` - [`CompanyAddressTypeEnum!`](#companyaddresstypeenum) | The address type. |
+| `city` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The city. |
+| `company` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The company name. |
+| `country_code` - [`CountryCodeEnum`](#countrycodeenum) | The two-letter code representing the company's country. |
+| `custom_attributes` - [`[AttributeValueInput]`](/reference/graphql/saas/types-a-b.md#attributevalueinput) | Custom attributes assigned to the company address. |
+| `fax` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The fax number. |
+| `firstname` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The first name. |
+| `is_default` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Whether the address is the default for its type. |
+| `lastname` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The last name. |
+| `middlename` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The middle name. |
+| `nickname` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Optional nickname for the address. |
+| `postcode` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The postal code. |
+| `prefix` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The name prefix. |
+| `region` - [`CustomerAddressRegionInput`](#customeraddressregioninput) | An object containing the region name, region code, and region ID. |
+| `street` - [`[String]`](/reference/graphql/saas/types-q-s.md#string) | Street lines. |
+| `suffix` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The name suffix. |
+| `telephone` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The telephone number. |
+| `vat_id` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The VAT ID. |
+
+#### Example
+
+```json
+{
+  "address_type": "BILLING",
+  "city": "xyz789",
+  "company": "abc123",
+  "country_code": "AF",
+  "custom_attributes": [AttributeValueInput],
+  "fax": "abc123",
+  "firstname": "abc123",
+  "is_default": true,
+  "lastname": "abc123",
+  "middlename": "abc123",
+  "nickname": "abc123",
+  "postcode": "abc123",
+  "prefix": "abc123",
+  "region": CustomerAddressRegionInput,
+  "street": ["abc123"],
+  "suffix": "xyz789",
+  "telephone": "abc123",
+  "vat_id": "abc123"
+}
+```
+
+<HorizontalLine />
+
+### CompanyAddressTypeEnum
+
+#### Values
+
+| Enum Value | Description |
+|------------|-------------|
+| `BILLING` | Billing address. |
+| `SHIPPING` | Shipping address. |
+
+#### Example
+
+```json
+""BILLING""
+```
+
+<HorizontalLine />
+
+### CompanyAddressUpdateInput
+
+Defines the input schema for updating a company address. The address type cannot be changed once an address is created.
+
+#### Input Fields
+
+| Input Field | Description |
+|-------------|-------------|
+| `city` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The city. |
+| `company` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The company name. |
+| `country_code` - [`CountryCodeEnum`](#countrycodeenum) | The two-letter code representing the company's country. |
+| `custom_attributes` - [`[AttributeValueInput]`](/reference/graphql/saas/types-a-b.md#attributevalueinput) | Custom attributes assigned to the company address. |
+| `fax` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The fax number. |
+| `firstname` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The first name. |
+| `is_default` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Whether the address is the default for its type. |
+| `lastname` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The last name. |
+| `middlename` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The middle name. |
+| `nickname` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Optional nickname for the address. |
+| `postcode` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The postal code. |
+| `prefix` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The name prefix. |
+| `region` - [`CustomerAddressRegionInput`](#customeraddressregioninput) | An object containing the region name, region code, and region ID. |
+| `street` - [`[String]`](/reference/graphql/saas/types-q-s.md#string) | Street lines. |
+| `suffix` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The name suffix. |
+| `telephone` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The telephone number. |
+| `vat_id` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The VAT ID. |
+
+#### Example
+
+```json
+{
+  "city": "xyz789",
+  "company": "abc123",
+  "country_code": "AF",
+  "custom_attributes": [AttributeValueInput],
+  "fax": "xyz789",
+  "firstname": "abc123",
+  "is_default": false,
+  "lastname": "xyz789",
+  "middlename": "abc123",
+  "nickname": "abc123",
+  "postcode": "abc123",
+  "prefix": "abc123",
+  "region": CustomerAddressRegionInput,
+  "street": ["xyz789"],
+  "suffix": "xyz789",
+  "telephone": "xyz789",
+  "vat_id": "xyz789"
+}
+```
+
+<HorizontalLine />
+
+### CompanyAddresses
+
+Contains a paginated list of company addresses.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `items` - [`[CompanyAddress]!`](#companyaddress) | An array of company addresses. |
+| `page_info` - [`SearchResultPageInfo!`](/reference/graphql/saas/types-q-s.md#searchresultpageinfo) | Pagination metadata. |
+| `total_count` - [`Int!`](/reference/graphql/saas/types-f-i.md#int) | The number of objects returned. |
+
+#### Example
+
+```json
+{
+  "items": [CompanyAddress],
+  "page_info": SearchResultPageInfo,
+  "total_count": 123
 }
 ```
 
@@ -1613,7 +1921,7 @@ Defines the input schema for creating a company administrator.
   "email": "abc123",
   "firstname": "xyz789",
   "gender": 123,
-  "job_title": "abc123",
+  "job_title": "xyz789",
   "lastname": "abc123",
   "telephone": "xyz789"
 }
@@ -1661,11 +1969,33 @@ The minimal required information to identify and display the company.
 
 ```json
 {
-  "id": 4,
+  "id": "4",
   "is_admin": true,
   "legal_name": "xyz789",
   "name": "abc123",
   "status": "PENDING"
+}
+```
+
+<HorizontalLine />
+
+### CompanyConfig
+
+Company address book configuration settings.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `address_book_custom_shipping_address_enabled` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether custom shipping address entry is allowed when the company address book is enabled. |
+| `address_book_enabled` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the company address book is enabled. |
+
+#### Example
+
+```json
+{
+  "address_book_custom_shipping_address_enabled": false,
+  "address_book_enabled": false
 }
 ```
 
@@ -1697,7 +2027,7 @@ Defines the input schema for creating a new company.
   "legal_address": CompanyLegalAddressCreateInput,
   "legal_name": "xyz789",
   "reseller_id": "xyz789",
-  "vat_tax_id": "xyz789"
+  "vat_tax_id": "abc123"
 }
 ```
 
@@ -1722,7 +2052,7 @@ Contains company credit balances and limits.
 {
   "available_credit": Money,
   "credit_limit": Money,
-  "exceed_limit": false,
+  "exceed_limit": true,
   "outstanding_balance": Money
 }
 ```
@@ -1771,7 +2101,7 @@ Defines a filter for narrowing the results of a credit history search.
 {
   "custom_reference_number": "abc123",
   "operation_type": "ALLOCATION",
-  "updated_by": "abc123"
+  "updated_by": "xyz789"
 }
 ```
 
@@ -1842,7 +2172,7 @@ Defines the administrator or company user that submitted a company credit operat
 #### Example
 
 ```json
-{"name": "abc123", "type": "CUSTOMER"}
+{"name": "xyz789", "type": "CUSTOMER"}
 ```
 
 <HorizontalLine />
@@ -1902,8 +2232,8 @@ Defines the input schema for accepting the company invitation.
 
 ```json
 {
-  "code": "xyz789",
-  "role_id": "4",
+  "code": "abc123",
+  "role_id": 4,
   "user": CompanyInvitationUserInput
 }
 ```
@@ -1923,7 +2253,7 @@ The result of accepting the company invitation.
 #### Example
 
 ```json
-{"success": false}
+{"success": true}
 ```
 
 <HorizontalLine />
@@ -1947,7 +2277,7 @@ Company user attributes in the invitation.
 ```json
 {
   "company_id": 4,
-  "customer_id": 4,
+  "customer_id": "4",
   "job_title": "abc123",
   "status": "ACTIVE",
   "telephone": "abc123"
@@ -1975,11 +2305,11 @@ Contains details about the address where the company is registered to conduct bu
 
 ```json
 {
-  "city": "abc123",
+  "city": "xyz789",
   "country_code": "AF",
-  "postcode": "abc123",
+  "postcode": "xyz789",
   "region": CustomerAddressRegion,
-  "street": ["abc123"],
+  "street": ["xyz789"],
   "telephone": "xyz789"
 }
 ```
@@ -2005,7 +2335,7 @@ Defines the input schema for defining a company's legal address.
 
 ```json
 {
-  "city": "xyz789",
+  "city": "abc123",
   "country_id": "AF",
   "postcode": "abc123",
   "region": CustomerAddressRegionInput,
@@ -2035,11 +2365,11 @@ Defines the input schema for updating a company's legal address.
 
 ```json
 {
-  "city": "xyz789",
+  "city": "abc123",
   "country_id": "AF",
   "postcode": "abc123",
   "region": CustomerAddressRegionInput,
-  "street": ["abc123"],
+  "street": ["xyz789"],
   "telephone": "abc123"
 }
 ```
@@ -2064,7 +2394,7 @@ Contails details about a single role.
 ```json
 {
   "id": 4,
-  "name": "abc123",
+  "name": "xyz789",
   "permissions": [CompanyAclResource],
   "users_count": 987
 }
@@ -2110,9 +2440,9 @@ Defines the input schema for updating a company role.
 
 ```json
 {
-  "id": 4,
-  "name": "xyz789",
-  "permissions": ["xyz789"]
+  "id": "4",
+  "name": "abc123",
+  "permissions": ["abc123"]
 }
 ```
 
@@ -2159,7 +2489,7 @@ Contains details about a company sales representative.
 ```json
 {
   "email": "abc123",
-  "firstname": "xyz789",
+  "firstname": "abc123",
   "lastname": "abc123"
 }
 ```
@@ -2282,10 +2612,10 @@ Describes a company team.
 
 ```json
 {
-  "description": "abc123",
-  "id": 4,
-  "name": "xyz789",
-  "structure_id": 4
+  "description": "xyz789",
+  "id": "4",
+  "name": "abc123",
+  "structure_id": "4"
 }
 ```
 
@@ -2308,8 +2638,8 @@ Defines the input schema for creating a company team.
 ```json
 {
   "description": "xyz789",
-  "name": "xyz789",
-  "target_id": 4
+  "name": "abc123",
+  "target_id": "4"
 }
 ```
 
@@ -2331,9 +2661,9 @@ Defines the input schema for updating a company team.
 
 ```json
 {
-  "description": "abc123",
-  "id": 4,
-  "name": "xyz789"
+  "description": "xyz789",
+  "id": "4",
+  "name": "abc123"
 }
 ```
 
@@ -2358,11 +2688,11 @@ Defines the input schema for updating a company.
 
 ```json
 {
-  "company_email": "xyz789",
-  "company_name": "xyz789",
+  "company_email": "abc123",
+  "company_name": "abc123",
   "legal_address": CompanyLegalAddressUpdateInput,
-  "legal_name": "xyz789",
-  "reseller_id": "xyz789",
+  "legal_name": "abc123",
+  "reseller_id": "abc123",
   "vat_tax_id": "abc123"
 }
 ```
@@ -2393,11 +2723,11 @@ Defines the input schema for creating a company user.
   "email": "xyz789",
   "firstname": "xyz789",
   "job_title": "abc123",
-  "lastname": "abc123",
+  "lastname": "xyz789",
   "role_id": "4",
   "status": "ACTIVE",
-  "target_id": 4,
-  "telephone": "abc123"
+  "target_id": "4",
+  "telephone": "xyz789"
 }
 ```
 
@@ -2445,12 +2775,12 @@ Defines the input schema for updating a company user.
 {
   "email": "xyz789",
   "firstname": "xyz789",
-  "id": "4",
-  "job_title": "xyz789",
+  "id": 4,
+  "job_title": "abc123",
   "lastname": "xyz789",
-  "role_id": "4",
+  "role_id": 4,
   "status": "ACTIVE",
-  "telephone": "xyz789"
+  "telephone": "abc123"
 }
 ```
 
@@ -2514,7 +2844,7 @@ Contains an attribute code that is used for product comparisons.
 ```json
 {
   "code": "xyz789",
-  "label": "abc123"
+  "label": "xyz789"
 }
 ```
 
@@ -2538,7 +2868,7 @@ Defines an object used to iterate through items for product comparisons.
 {
   "attributes": [ProductAttribute],
   "product": ProductInterface,
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -2562,7 +2892,7 @@ Contains iterable information such as the array of items, the count, and attribu
 ```json
 {
   "attributes": [ComparableAttribute],
-  "item_count": 987,
+  "item_count": 123,
   "items": [ComparableItem],
   "uid": "4"
 }
@@ -2619,6 +2949,7 @@ Represents all product types, except simple products. Complex product prices are
 | `shortDescription` - [`String`](/reference/graphql/saas/types-q-s.md#string) | A summary of the product. |
 | `sku` - [`String`](/reference/graphql/saas/types-q-s.md#string) | A unique code used for identification of a product. |
 | `externalId` - [`String`](/reference/graphql/saas/types-q-s.md#string) | External Id *(Deprecated: This field is deprecated and will be removed.)* |
+| `externalIds` - [`[ExternalId]`](#externalid) | External Ids |
 | `url` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Canonical URL of the product. *(Deprecated: This field is deprecated and will be removed.)* |
 | `urlKey` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The URL key of the product. |
 | `links` - [`[ProductViewLink]`](/reference/graphql/saas/types-k-p.md#productviewlink) | A list of product links. Links are used to navigate from one product to another. |
@@ -2629,29 +2960,30 @@ Represents all product types, except simple products. Complex product prices are
 
 ```json
 {
-  "addToCartAllowed": false,
-  "inStock": false,
+  "addToCartAllowed": true,
+  "inStock": true,
   "lowStock": false,
   "attributes": [ProductViewAttribute],
-  "description": "xyz789",
-  "id": 4,
+  "description": "abc123",
+  "id": "4",
   "images": [ProductViewImage],
   "videos": [ProductViewVideo],
   "lastModifiedAt": "2007-12-03T10:15:30Z",
   "metaDescription": "xyz789",
-  "metaKeyword": "xyz789",
+  "metaKeyword": "abc123",
   "metaTitle": "abc123",
-  "name": "abc123",
+  "name": "xyz789",
   "inputOptions": [ProductViewInputOption],
   "options": [ProductViewOption],
   "priceRange": ProductViewPriceRange,
   "shortDescription": "abc123",
-  "sku": "abc123",
-  "externalId": "xyz789",
+  "sku": "xyz789",
+  "externalId": "abc123",
+  "externalIds": [ExternalId],
   "url": "abc123",
-  "urlKey": "xyz789",
+  "urlKey": "abc123",
   "links": [ProductViewLink],
-  "queryType": "xyz789",
+  "queryType": "abc123",
   "visibility": "xyz789"
 }
 ```
@@ -2690,7 +3022,7 @@ Represents all product types, except simple products. Complex product prices are
 {
   "field": "UNKNOWN_FIELD",
   "operator": OperatorInput,
-  "enabled": false
+  "enabled": true
 }
 ```
 
@@ -2713,10 +3045,10 @@ Contains details about a configurable product attribute option.
 
 ```json
 {
-  "code": "xyz789",
+  "code": "abc123",
   "label": "abc123",
   "uid": "4",
-  "value_index": 987
+  "value_index": 123
 }
 ```
 
@@ -2741,9 +3073,12 @@ An implementation for configurable product cart items.
 | `gift_message` - [`GiftMessage`](/reference/graphql/saas/types-f-i.md#giftmessage) | The entered gift message for the cart item |
 | `gift_wrapping` - [`GiftWrapping`](/reference/graphql/saas/types-f-i.md#giftwrapping) | The selected gift wrapping for the cart item. |
 | `is_available` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if requested quantity is less than available stock, false otherwise. *(Deprecated: Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration.)* |
+| `is_free_gift` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if this line item was added by a Free Gift cart price rule. |
 | `is_salable` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed. |
 | `max_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item max qty in quote template |
 | `min_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item min qty in quote template |
+| `nominated_source` - [`SourceAvailability`](/reference/graphql/saas/types-q-s.md#sourceavailability) | The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors). |
+| `nominated_source_errors` - [`[NominatedSourceError]!`](/reference/graphql/saas/types-k-p.md#nominatedsourceerror) | Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart. |
 | `not_available_message` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Shortage or unavailability message for the line; null when the item is salable. |
 | `note_from_buyer` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The buyer's quote line item note. |
 | `note_from_seller` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The seller's quote line item note. |
@@ -2757,7 +3092,7 @@ An implementation for configurable product cart items.
 ```json
 {
   "available_gift_wrapping": [GiftWrapping],
-  "backorder_message": "abc123",
+  "backorder_message": "xyz789",
   "configurable_options": [SelectedConfigurableOption],
   "configured_variant": ProductInterface,
   "custom_attributes": [CustomAttribute],
@@ -2767,16 +3102,19 @@ An implementation for configurable product cart items.
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
   "is_available": false,
+  "is_free_gift": true,
   "is_salable": false,
   "max_qty": 123.45,
-  "min_qty": 987.65,
-  "not_available_message": "abc123",
+  "min_qty": 123.45,
+  "nominated_source": SourceAvailability,
+  "nominated_source_errors": [NominatedSourceError],
+  "not_available_message": "xyz789",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
   "quantity": 987.65,
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -2797,8 +3135,8 @@ Describes configurable options that have been selected and can be selected as a 
 
 ```json
 {
-  "attribute_code": "abc123",
-  "option_value_uids": ["4"]
+  "attribute_code": "xyz789",
+  "option_value_uids": [4]
 }
 ```
 
@@ -2814,6 +3152,7 @@ Describes configurable options that have been selected and can be selected as a 
 | `discounts` - [`[Discount]`](#discount) | The final discount information for the product. |
 | `eligible_for_return` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the order item is eligible to be in a return request. |
 | `entered_options` - [`[OrderItemOption]`](/reference/graphql/saas/types-k-p.md#orderitemoption) | The entered option for the base product, such as a logo or image. |
+| `free_gift_label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The discount rule label for free gift items. Null if the item is not a free gift. |
 | `gift_message` - [`GiftMessage`](/reference/graphql/saas/types-f-i.md#giftmessage) | The selected gift message for the order item |
 | `gift_wrapping` - [`GiftWrapping`](/reference/graphql/saas/types-f-i.md#giftwrapping) | The selected gift wrapping for the order item. |
 | `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID for an `OrderItemInterface` object. |
@@ -2843,26 +3182,27 @@ Describes configurable options that have been selected and can be selected as a 
   "discounts": [Discount],
   "eligible_for_return": true,
   "entered_options": [OrderItemOption],
+  "free_gift_label": "abc123",
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
   "id": 4,
-  "parent_sku": "abc123",
+  "parent_sku": "xyz789",
   "prices": OrderItemPrices,
   "product": ProductInterface,
   "product_name": "xyz789",
   "product_sale_price": Money,
   "product_sku": "xyz789",
-  "product_type": "xyz789",
-  "product_url_key": "abc123",
-  "quantity_canceled": 123.45,
+  "product_type": "abc123",
+  "product_url_key": "xyz789",
+  "quantity_canceled": 987.65,
   "quantity_invoiced": 987.65,
   "quantity_ordered": 123.45,
   "quantity_refunded": 123.45,
   "quantity_return_requested": 987.65,
-  "quantity_returned": 987.65,
-  "quantity_shipped": 987.65,
+  "quantity_returned": 123.45,
+  "quantity_shipped": 123.45,
   "selected_options": [OrderItemOption],
-  "status": "xyz789"
+  "status": "abc123"
 }
 ```
 
@@ -2933,42 +3273,42 @@ Defines basic features of a configurable product and its simple product variants
   "crosssell_products": [ProductInterface],
   "custom_attributesV2": ProductCustomAttributes,
   "description": ComplexTextValue,
-  "gift_message_available": true,
-  "gift_wrapping_available": true,
+  "gift_message_available": false,
+  "gift_wrapping_available": false,
   "gift_wrapping_price": Money,
   "image": ProductImage,
-  "is_returnable": "xyz789",
+  "is_returnable": "abc123",
   "manufacturer": 987,
-  "max_sale_qty": 123.45,
+  "max_sale_qty": 987.65,
   "media_gallery": [MediaGalleryInterface],
-  "meta_description": "abc123",
-  "meta_keyword": "xyz789",
-  "meta_title": "xyz789",
+  "meta_description": "xyz789",
+  "meta_keyword": "abc123",
+  "meta_title": "abc123",
   "min_sale_qty": 123.45,
   "name": "abc123",
-  "new_from_date": "xyz789",
+  "new_from_date": "abc123",
   "new_to_date": "abc123",
   "only_x_left_in_stock": 987.65,
   "options": [CustomizableOptionInterface],
-  "options_container": "abc123",
+  "options_container": "xyz789",
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
   "product_links": [ProductLinksInterface],
   "quantity": 123.45,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
-  "sku": "abc123",
+  "sku": "xyz789",
   "small_image": ProductImage,
-  "special_price": 123.45,
-  "special_to_date": "abc123",
+  "special_price": 987.65,
+  "special_to_date": "xyz789",
   "stock_status": "IN_STOCK",
   "swatch_image": "abc123",
   "thumbnail": ProductImage,
   "uid": 4,
   "upsell_products": [ProductInterface],
-  "url_key": "abc123",
+  "url_key": "xyz789",
   "variants": [ConfigurableVariant],
-  "weight": 123.45
+  "weight": 987.65
 }
 ```
 
@@ -3018,11 +3358,11 @@ Defines a value for a configurable product option.
 
 ```json
 {
-  "is_available": true,
-  "is_use_default": true,
-  "label": "xyz789",
+  "is_available": false,
+  "is_use_default": false,
+  "label": "abc123",
   "swatch": SwatchDataInterface,
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -3050,8 +3390,8 @@ Defines configurable attributes for the specified product.
 {
   "attribute_code": "abc123",
   "attribute_uid": 4,
-  "label": "abc123",
-  "position": 987,
+  "label": "xyz789",
+  "position": 123,
   "uid": "4",
   "use_default": false,
   "values": [ConfigurableProductOptionsValues]
@@ -3107,9 +3447,9 @@ Contains the index number assigned to a configurable product option.
 
 ```json
 {
-  "default_label": "abc123",
-  "label": "xyz789",
-  "store_label": "xyz789",
+  "default_label": "xyz789",
+  "label": "abc123",
+  "store_label": "abc123",
   "swatch_data": SwatchDataInterface,
   "uid": "4",
   "use_default_value": false
@@ -3140,9 +3480,9 @@ Contains details about configurable products added to a requisition list.
   "configurable_options": [SelectedConfigurableOption],
   "customizable_options": [SelectedCustomizableOption],
   "product": ProductInterface,
-  "quantity": 123.45,
+  "quantity": 987.65,
   "sku": "abc123",
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -3191,14 +3531,14 @@ A configurable product wish list item.
 
 ```json
 {
-  "added_at": "xyz789",
+  "added_at": "abc123",
   "configurable_options": [SelectedConfigurableOption],
   "configured_variant": ProductInterface,
   "customizable_options": [SelectedCustomizableOption],
-  "description": "abc123",
-  "id": "4",
+  "description": "xyz789",
+  "id": 4,
   "product": ProductInterface,
-  "quantity": 123.45
+  "quantity": 987.65
 }
 ```
 
@@ -3300,10 +3640,10 @@ List of account confirmation statuses.
 
 ```json
 {
-  "comment": "xyz789",
+  "comment": "abc123",
   "email": "abc123",
-  "name": "xyz789",
-  "telephone": "abc123"
+  "name": "abc123",
+  "telephone": "xyz789"
 }
 ```
 
@@ -3406,9 +3746,9 @@ Contains the source and target wish lists after copying products.
 {
   "available_regions": [Region],
   "full_name_english": "abc123",
-  "full_name_locale": "abc123",
+  "full_name_locale": "xyz789",
   "id": "abc123",
-  "three_letter_abbreviation": "abc123",
+  "three_letter_abbreviation": "xyz789",
   "two_letter_abbreviation": "abc123"
 }
 ```
@@ -3832,7 +4172,7 @@ Contains the results of a request to create a gift registry.
 #### Example
 
 ```json
-{"cart_uid": "4"}
+{"cart_uid": 4}
 ```
 
 <HorizontalLine />
@@ -3849,6 +4189,30 @@ Contains the results of a request to create a gift registry.
 
 ```json
 {"cart": Cart}
+```
+
+<HorizontalLine />
+
+### CreatePaymentLinkOutput
+
+Result of createPaymentLink.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `expiresAt` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | UTC expiry timestamp of the link. |
+| `payUrl` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The absolute payment link URL. |
+| `token` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The payment link token. |
+
+#### Example
+
+```json
+{
+  "expiresAt": "abc123",
+  "payUrl": "abc123",
+  "token": "abc123"
+}
 ```
 
 <HorizontalLine />
@@ -3899,11 +4263,11 @@ Contains payment order details that are used while processing the payment order
 
 ```json
 {
-  "amount": 987.65,
+  "amount": 123.45,
   "currency_code": "xyz789",
-  "id": "abc123",
+  "id": "xyz789",
   "mp_order_id": "abc123",
-  "status": "xyz789"
+  "status": "abc123"
 }
 ```
 
@@ -3948,7 +4312,7 @@ Defines a set of conditions that apply to a rule.
   "amount": CreatePurchaseOrderApprovalRuleConditionAmountInput,
   "attribute": "GRAND_TOTAL",
   "operator": "MORE_THAN",
-  "quantity": 123
+  "quantity": 987
 }
 ```
 
@@ -3969,7 +4333,7 @@ An input object that identifies and describes a new requisition list.
 
 ```json
 {
-  "description": "abc123",
+  "description": "xyz789",
   "name": "xyz789"
 }
 ```
@@ -4010,7 +4374,7 @@ Describe the variables needed to create a vault payment token
 ```json
 {
   "card_description": "xyz789",
-  "setup_token_id": "abc123"
+  "setup_token_id": "xyz789"
 }
 ```
 
@@ -4032,7 +4396,7 @@ The vault token id and information about the payment source
 ```json
 {
   "payment_source": PaymentSourceOutput,
-  "vault_token_id": "xyz789"
+  "vault_token_id": "abc123"
 }
 ```
 
@@ -4092,7 +4456,7 @@ Defines the name and visibility of a new wish list.
 #### Example
 
 ```json
-{"name": "xyz789", "visibility": "PUBLIC"}
+{"name": "abc123", "visibility": "PUBLIC"}
 ```
 
 <HorizontalLine />
@@ -4136,7 +4500,7 @@ Contains credit memo details.
 {
   "comments": [SalesCommentItem],
   "custom_attributes": [CustomAttribute],
-  "id": 4,
+  "id": "4",
   "items": [CreditMemoItemInterface],
   "number": "abc123",
   "total": CreditMemoTotal
@@ -4160,7 +4524,7 @@ Defines a credit memo item's custom attributes.
 
 ```json
 {
-  "credit_memo_id": "abc123",
+  "credit_memo_id": "xyz789",
   "custom_attributes": [CustomAttributeInput]
 }
 ```
@@ -4188,12 +4552,12 @@ Defines a credit memo item's custom attributes.
 {
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
-  "id": 4,
+  "id": "4",
   "order_item": OrderItemInterface,
   "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
-  "quantity_refunded": 987.65
+  "product_sku": "abc123",
+  "quantity_refunded": 123.45
 }
 ```
 
@@ -4215,7 +4579,7 @@ Defines a credit memo's custom attributes.
 
 ```json
 {
-  "credit_memo_id": "abc123",
+  "credit_memo_id": "xyz789",
   "credit_memo_item_id": "abc123",
   "custom_attributes": [CustomAttributeInput]
 }
@@ -4259,8 +4623,8 @@ Credit memo item details.
   "order_item": OrderItemInterface,
   "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
-  "quantity_refunded": 123.45
+  "product_sku": "abc123",
+  "quantity_refunded": 987.65
 }
 ```
 
@@ -4337,10 +4701,10 @@ Contains credit memo price details.
 
 ```json
 {
-  "available_currency_codes": ["xyz789"],
-  "base_currency_code": "abc123",
+  "available_currency_codes": ["abc123"],
+  "base_currency_code": "xyz789",
   "base_currency_symbol": "xyz789",
-  "default_display_currency_code": "abc123",
+  "default_display_currency_code": "xyz789",
   "default_display_currency_symbol": "xyz789",
   "exchange_rates": [ExchangeRate]
 }
@@ -4548,7 +4912,7 @@ Attributes of the product currently being viewed on PDP
 #### Example
 
 ```json
-{"sku": "abc123", "price": 987.65}
+{"sku": "xyz789", "price": 987.65}
 ```
 
 <HorizontalLine />
@@ -4569,7 +4933,7 @@ Specifies the custom attribute code and value.
 ```json
 {
   "attribute_code": "abc123",
-  "value": "xyz789"
+  "value": "abc123"
 }
 ```
 
@@ -4591,7 +4955,7 @@ Defines a custom attribute.
 ```json
 {
   "attribute_code": "xyz789",
-  "value": "xyz789"
+  "value": "abc123"
 }
 ```
 
@@ -4628,10 +4992,10 @@ An interface containing fields that define the EAV attribute.
 
 ```json
 {
-  "code": 4,
-  "default_value": "xyz789",
+  "code": "4",
+  "default_value": "abc123",
   "entity_type": "CATALOG_PRODUCT",
-  "frontend_class": "xyz789",
+  "frontend_class": "abc123",
   "frontend_input": "BOOLEAN",
   "is_required": false,
   "is_unique": true,
@@ -4662,9 +5026,9 @@ An interface containing fields that define the EAV attribute.
 
 ```json
 {
-  "is_default": true,
-  "label": "xyz789",
-  "value": "xyz789"
+  "is_default": false,
+  "label": "abc123",
+  "value": "abc123"
 }
 ```
 
@@ -4685,8 +5049,8 @@ A simple key value object.
 
 ```json
 {
-  "key": "abc123",
-  "value": "abc123"
+  "key": "xyz789",
+  "value": "xyz789"
 }
 ```
 
@@ -4706,7 +5070,7 @@ A simple key value object.
 ```json
 {
   "type": "UNKNOWN_CUSTOMOPERATOR_TYPE",
-  "value": ["xyz789"]
+  "value": ["abc123"]
 }
 ```
 
@@ -4756,7 +5120,7 @@ Defines the customer name, addresses, and other details.
 | `gift_registries` - [`[GiftRegistry]`](/reference/graphql/saas/types-f-i.md#giftregistry) | Details about all of the customer's gift registries. |
 | `gift_registry` - [`GiftRegistry`](/reference/graphql/saas/types-f-i.md#giftregistry) | Details about a specific gift registry. |
 | `group` - [`CustomerGroupStorefront`](#customergroupstorefront) | Customer group assigned to the customer |
-| `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID assigned to the customer. *(Deprecated: `id` is not needed as part of `Customer`, because on the server side, it can be identified based on the customer token used for authentication. There is no need to know customer ID on the client side.)* |
+| `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID assigned to the customer. |
 | `is_subscribed` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the customer is subscribed to the company's newsletter. |
 | `job_title` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The job title of a company user. |
 | `lastname` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The customer's family name. |
@@ -4793,7 +5157,7 @@ Defines the customer name, addresses, and other details.
   "addresses": [CustomerAddress],
   "addressesV2": CustomerAddresses,
   "admin_assistance_actions": AdminAssistanceActions,
-  "allow_remote_shopping_assistance": false,
+  "allow_remote_shopping_assistance": true,
   "companies": UserCompaniesOutput,
   "company_hierarchy": [CompanyHierarchy],
   "compare_list": CompareList,
@@ -4801,28 +5165,28 @@ Defines the customer name, addresses, and other details.
   "created_at": "abc123",
   "custom_attributes": [AttributeValueInterface],
   "date_of_birth": "abc123",
-  "default_billing": "xyz789",
+  "default_billing": "abc123",
   "default_shipping": "abc123",
-  "email": "abc123",
+  "email": "xyz789",
   "firstname": "xyz789",
   "gender": 987,
   "gift_registries": [GiftRegistry],
   "gift_registry": GiftRegistry,
   "group": CustomerGroupStorefront,
-  "id": 4,
-  "is_subscribed": false,
+  "id": "4",
+  "is_subscribed": true,
   "job_title": "abc123",
-  "lastname": "xyz789",
-  "middlename": "xyz789",
+  "lastname": "abc123",
+  "middlename": "abc123",
   "orders": CustomerOrders,
-  "prefix": "xyz789",
+  "prefix": "abc123",
   "purchase_order": PurchaseOrder,
   "purchase_order_approval_rule": PurchaseOrderApprovalRule,
   "purchase_order_approval_rule_metadata": PurchaseOrderApprovalRuleMetadata,
   "purchase_order_approval_rules": PurchaseOrderApprovalRules,
   "purchase_orders": PurchaseOrders,
   "purchase_orders_enabled": true,
-  "quote_enabled": false,
+  "quote_enabled": true,
   "requisition_lists": RequisitionLists,
   "return": Return,
   "returns": Returns,
@@ -4835,7 +5199,7 @@ Defines the customer name, addresses, and other details.
   "suffix": "xyz789",
   "taxvat": "abc123",
   "team": CompanyTeam,
-  "telephone": "xyz789",
+  "telephone": "abc123",
   "wishlist_v2": Wishlist,
   "wishlists": [Wishlist]
 }
@@ -4877,27 +5241,27 @@ Contains detailed information about a customer's billing or shipping address.
 
 ```json
 {
-  "city": "xyz789",
-  "company": "xyz789",
+  "city": "abc123",
+  "company": "abc123",
   "country_code": "AF",
   "custom_attributesV2": [AttributeValueInterface],
   "default_billing": false,
   "default_shipping": false,
   "extension_attributes": [CustomerAddressAttribute],
   "fax": "xyz789",
-  "firstname": "abc123",
-  "id": 123,
+  "firstname": "xyz789",
+  "id": 987,
   "lastname": "xyz789",
   "middlename": "abc123",
   "postcode": "abc123",
-  "prefix": "xyz789",
+  "prefix": "abc123",
   "region": CustomerAddressRegion,
-  "region_id": 123,
-  "street": ["abc123"],
+  "region_id": 987,
+  "street": ["xyz789"],
   "suffix": "xyz789",
   "telephone": "xyz789",
   "uid": "4",
-  "vat_id": "abc123"
+  "vat_id": "xyz789"
 }
 ```
 
@@ -4918,8 +5282,8 @@ Specifies the attribute code and value of a customer address attribute.
 
 ```json
 {
-  "attribute_code": "xyz789",
-  "value": "abc123"
+  "attribute_code": "abc123",
+  "value": "xyz789"
 }
 ```
 
@@ -4959,9 +5323,9 @@ Contains details about a billing or shipping address.
   "company": "xyz789",
   "country_code": "AF",
   "custom_attributesV2": [AttributeValueInput],
-  "default_billing": true,
+  "default_billing": false,
   "default_shipping": false,
-  "fax": "xyz789",
+  "fax": "abc123",
   "firstname": "xyz789",
   "lastname": "xyz789",
   "middlename": "xyz789",
@@ -4993,9 +5357,9 @@ Defines the customer's state or province.
 
 ```json
 {
-  "region": "xyz789",
-  "region_code": "xyz789",
-  "region_id": 987
+  "region": "abc123",
+  "region_code": "abc123",
+  "region_id": 123
 }
 ```
 
@@ -5017,8 +5381,8 @@ Defines the customer's state or province.
 
 ```json
 {
-  "region": "xyz789",
-  "region_code": "abc123",
+  "region": "abc123",
+  "region_code": "xyz789",
   "region_id": 123
 }
 ```
@@ -5041,7 +5405,7 @@ Defines the customer's state or province.
 {
   "items": [CustomerAddress],
   "page_info": SearchResultPageInfo,
-  "total_count": 123
+  "total_count": 987
 }
 ```
 
@@ -5076,15 +5440,15 @@ Customer attribute metadata.
   "code": "4",
   "default_value": "abc123",
   "entity_type": "CATALOG_PRODUCT",
-  "frontend_class": "xyz789",
+  "frontend_class": "abc123",
   "frontend_input": "BOOLEAN",
   "input_filter": "NONE",
   "is_required": false,
-  "is_unique": true,
-  "label": "abc123",
-  "multiline_count": 987,
+  "is_unique": false,
+  "label": "xyz789",
+  "multiline_count": 123,
   "options": [CustomAttributeOptionInterface],
-  "sort_order": 123,
+  "sort_order": 987,
   "validate_rules": [ValidationRule]
 }
 ```
@@ -5119,15 +5483,15 @@ An input object for creating a customer.
 {
   "allow_remote_shopping_assistance": false,
   "custom_attributes": [AttributeValueInput],
-  "date_of_birth": "xyz789",
-  "email": "xyz789",
-  "firstname": "abc123",
-  "gender": 987,
-  "is_subscribed": false,
+  "date_of_birth": "abc123",
+  "email": "abc123",
+  "firstname": "xyz789",
+  "gender": 123,
+  "is_subscribed": true,
   "lastname": "xyz789",
   "middlename": "xyz789",
-  "password": "abc123",
-  "prefix": "xyz789",
+  "password": "xyz789",
+  "prefix": "abc123",
   "suffix": "xyz789",
   "taxvat": "abc123"
 }
@@ -5155,8 +5519,8 @@ Contains details about a single downloadable product.
 {
   "date": "abc123",
   "download_url": "abc123",
-  "order_increment_id": "xyz789",
-  "remaining_downloads": "xyz789",
+  "order_increment_id": "abc123",
+  "remaining_downloads": "abc123",
   "status": "xyz789"
 }
 ```
@@ -5244,7 +5608,7 @@ Contains details about each of the customer's orders.
 
 ```json
 {
-  "admin_assisted_order": 987,
+  "admin_assisted_order": 123,
   "applied_coupons": [AppliedCoupon],
   "applied_gift_cards": [ApplyGiftCardToOrder],
   "available_actions": ["REORDER"],
@@ -5256,9 +5620,9 @@ Contains details about each of the customer's orders.
   "customer_info": OrderCustomerInfo,
   "email": "abc123",
   "gift_message": GiftMessage,
-  "gift_receipt_included": false,
+  "gift_receipt_included": true,
   "gift_wrapping": GiftWrapping,
-  "id": 4,
+  "id": "4",
   "invoices": [Invoice],
   "is_virtual": true,
   "items": [OrderItemInterface],
@@ -5272,9 +5636,9 @@ Contains details about each of the customer's orders.
   "returns": Returns,
   "shipments": [OrderShipment],
   "shipping_address": OrderAddress,
-  "shipping_method": "abc123",
-  "status": "abc123",
-  "token": "xyz789",
+  "shipping_method": "xyz789",
+  "status": "xyz789",
+  "token": "abc123",
   "total": OrderTotal
 }
 ```
@@ -5336,7 +5700,7 @@ The collection of orders that match the conditions defined in the filter.
 
 ```json
 {
-  "date_of_first_order": "xyz789",
+  "date_of_first_order": "abc123",
   "items": [CustomerOrder],
   "page_info": SearchResultPageInfo,
   "total_count": 123
@@ -5356,6 +5720,7 @@ Identifies the filter to use for filtering orders.
 | `grand_total` - [`FilterRangeTypeInput`](/reference/graphql/saas/types-f-i.md#filterrangetypeinput) | Filters by order base grand total value. |
 | `number` - [`FilterStringTypeInput`](/reference/graphql/saas/types-f-i.md#filterstringtypeinput) | Filters by order number. |
 | `order_date` - [`FilterRangeTypeInput`](/reference/graphql/saas/types-f-i.md#filterrangetypeinput) | Filters by order created_at time. |
+| `search` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Searches orders by order number, product name, or SKU. |
 | `status` - [`FilterEqualTypeInput`](/reference/graphql/saas/types-f-i.md#filterequaltypeinput) | Filters by order status. |
 
 #### Example
@@ -5365,6 +5730,7 @@ Identifies the filter to use for filtering orders.
   "grand_total": FilterRangeTypeInput,
   "number": FilterStringTypeInput,
   "order_date": FilterRangeTypeInput,
+  "search": "xyz789",
   "status": FilterEqualTypeInput
 }
 ```
@@ -5420,7 +5786,7 @@ Customer segment details
 #### Example
 
 ```json
-{"uid": "4"}
+{"uid": 4}
 ```
 
 <HorizontalLine />
@@ -5467,7 +5833,7 @@ Lists changes to the amount of store credit available to the customer.
 {
   "items": [CustomerStoreCreditHistoryItem],
   "page_info": SearchResultPageInfo,
-  "total_count": 123
+  "total_count": 987
 }
 ```
 
@@ -5490,7 +5856,7 @@ Contains store credit history information.
 
 ```json
 {
-  "action": "xyz789",
+  "action": "abc123",
   "actual_balance": Money,
   "balance_change": Money,
   "date_time_changed": "xyz789"
@@ -5541,17 +5907,17 @@ An input object for updating a customer.
 
 ```json
 {
-  "allow_remote_shopping_assistance": false,
+  "allow_remote_shopping_assistance": true,
   "custom_attributes": [AttributeValueInput],
   "date_of_birth": "abc123",
-  "firstname": "xyz789",
-  "gender": 987,
+  "firstname": "abc123",
+  "gender": 123,
   "is_subscribed": true,
-  "lastname": "abc123",
+  "lastname": "xyz789",
   "middlename": "abc123",
-  "prefix": "xyz789",
-  "suffix": "xyz789",
-  "taxvat": "abc123"
+  "prefix": "abc123",
+  "suffix": "abc123",
+  "taxvat": "xyz789"
 }
 ```
 
@@ -5576,11 +5942,11 @@ Contains information about a text area that is defined as part of a customizable
 
 ```json
 {
-  "product_sku": "abc123",
+  "product_sku": "xyz789",
   "required": false,
   "sort_order": 987,
-  "title": "xyz789",
-  "uid": 4,
+  "title": "abc123",
+  "uid": "4",
   "value": CustomizableAreaValue
 }
 ```
@@ -5606,10 +5972,10 @@ Defines the price and sku of a product whose page contains a customized text are
 ```json
 {
   "max_characters": 987,
-  "price": 123.45,
+  "price": 987.65,
   "price_type": "FIXED",
-  "sku": "abc123",
-  "uid": 4
+  "sku": "xyz789",
+  "uid": "4"
 }
 ```
 
@@ -5633,10 +5999,10 @@ Contains information about a set of checkbox values that are defined as part of 
 
 ```json
 {
-  "required": true,
+  "required": false,
   "sort_order": 987,
-  "title": "xyz789",
-  "uid": 4,
+  "title": "abc123",
+  "uid": "4",
   "value": [CustomizableCheckboxValue]
 }
 ```
@@ -5664,12 +6030,12 @@ Defines the price and sku of a product whose page contains a customized set of c
 ```json
 {
   "option_type_id": 987,
-  "price": 123.45,
+  "price": 987.65,
   "price_type": "FIXED",
   "sku": "abc123",
   "sort_order": 123,
   "title": "abc123",
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -5694,11 +6060,11 @@ Contains information about a date picker that is defined as part of a customizab
 
 ```json
 {
-  "product_sku": "abc123",
+  "product_sku": "xyz789",
   "required": false,
-  "sort_order": 987,
-  "title": "abc123",
-  "uid": "4",
+  "sort_order": 123,
+  "title": "xyz789",
+  "uid": 4,
   "value": CustomizableDateValue
 }
 ```
@@ -5743,11 +6109,11 @@ Defines the price and sku of a product whose page contains a customized date pic
 
 ```json
 {
-  "price": 987.65,
+  "price": 123.45,
   "price_type": "FIXED",
   "sku": "xyz789",
   "type": "DATE",
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -5771,10 +6137,10 @@ Contains information about a drop down menu that is defined as part of a customi
 
 ```json
 {
-  "required": true,
+  "required": false,
   "sort_order": 987,
-  "title": "xyz789",
-  "uid": 4,
+  "title": "abc123",
+  "uid": "4",
   "value": [CustomizableDropDownValue]
 }
 ```
@@ -5835,8 +6201,8 @@ Contains information about a text field that is defined as part of a customizabl
   "product_sku": "xyz789",
   "required": false,
   "sort_order": 123,
-  "title": "xyz789",
-  "uid": 4,
+  "title": "abc123",
+  "uid": "4",
   "value": CustomizableFieldValue
 }
 ```
@@ -5862,7 +6228,7 @@ Defines the price and sku of a product whose page contains a customized text fie
 ```json
 {
   "max_characters": 123,
-  "price": 123.45,
+  "price": 987.65,
   "price_type": "FIXED",
   "sku": "xyz789",
   "uid": "4"
@@ -5892,9 +6258,9 @@ Contains information about a file picker that is defined as part of a customizab
 {
   "product_sku": "abc123",
   "required": true,
-  "sort_order": 123,
-  "title": "xyz789",
-  "uid": 4,
+  "sort_order": 987,
+  "title": "abc123",
+  "uid": "4",
   "value": CustomizableFileValue
 }
 ```
@@ -5923,11 +6289,11 @@ Defines the price and sku of a product whose page contains a customized file pic
 {
   "file_extension": "xyz789",
   "image_size_x": 987,
-  "image_size_y": 987,
-  "price": 987.65,
+  "image_size_y": 123,
+  "price": 123.45,
   "price_type": "FIXED",
-  "sku": "abc123",
-  "uid": 4
+  "sku": "xyz789",
+  "uid": "4"
 }
 ```
 
@@ -5951,7 +6317,7 @@ Contains information about a multiselect that is defined as part of a customizab
 
 ```json
 {
-  "required": false,
+  "required": true,
   "sort_order": 987,
   "title": "abc123",
   "uid": "4",
@@ -5981,11 +6347,11 @@ Defines the price and sku of a product whose page contains a customized multisel
 
 ```json
 {
-  "option_type_id": 987,
-  "price": 123.45,
+  "option_type_id": 123,
+  "price": 987.65,
   "price_type": "FIXED",
   "sku": "xyz789",
-  "sort_order": 987,
+  "sort_order": 123,
   "title": "abc123",
   "uid": 4
 }
@@ -6007,7 +6373,10 @@ Defines a customizable option.
 #### Example
 
 ```json
-{"uid": 4, "value_string": "xyz789"}
+{
+  "uid": "4",
+  "value_string": "xyz789"
+}
 ```
 
 <HorizontalLine />
@@ -6099,9 +6468,9 @@ Contains information about a set of radio buttons that are defined as part of a 
 ```json
 {
   "required": true,
-  "sort_order": 987,
+  "sort_order": 123,
   "title": "xyz789",
-  "uid": 4,
+  "uid": "4",
   "value": [CustomizableRadioValue]
 }
 ```
@@ -6128,13 +6497,13 @@ Defines the price and sku of a product whose page contains a customized set of r
 
 ```json
 {
-  "option_type_id": 987,
-  "price": 987.65,
+  "option_type_id": 123,
+  "price": 123.45,
   "price_type": "FIXED",
-  "sku": "xyz789",
+  "sku": "abc123",
   "sort_order": 123,
   "title": "abc123",
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -6201,7 +6570,7 @@ Contains the response to the request to delete the company user.
 #### Example
 
 ```json
-{"success": false}
+{"success": true}
 ```
 
 <HorizontalLine />
@@ -6258,7 +6627,7 @@ Contains details about a failed delete operation on a negotiable quote.
 ```json
 {
   "errors": [NegotiableQuoteInvalidStateError],
-  "quote_uid": "4"
+  "quote_uid": 4
 }
 ```
 
@@ -6310,7 +6679,7 @@ Specifies the quote template id of the quote template to delete
 #### Example
 
 ```json
-{"quote_uids": [4]}
+{"quote_uids": ["4"]}
 ```
 
 <HorizontalLine />
@@ -6357,7 +6726,7 @@ Indicates whether the request succeeded and returns the remaining customer payme
 ```json
 {
   "customerPaymentTokens": CustomerPaymentTokens,
-  "result": false
+  "result": true
 }
 ```
 
@@ -6377,7 +6746,7 @@ Contains details about an error that occurred when deleting an approval rule .
 #### Example
 
 ```json
-{"message": "abc123", "type": "UNDEFINED"}
+{"message": "xyz789", "type": "UNDEFINED"}
 ```
 
 <HorizontalLine />
@@ -6514,10 +6883,10 @@ Specifies the discount type and value for quote line item.
   "amount": Money,
   "applied_to": "ITEM",
   "coupon": AppliedCoupon,
-  "is_discounting_locked": true,
-  "label": "xyz789",
+  "is_discounting_locked": false,
+  "label": "abc123",
   "type": "abc123",
-  "value": 987.65
+  "value": 123.45
 }
 ```
 
@@ -6537,10 +6906,13 @@ An implementation for downloadable product cart items.
 | `discount` - [`[Discount]`](#discount) | Contains discount for quote line item. |
 | `errors` - [`[CartItemError]`](#cartitemerror) | An array of errors encountered while loading the cart item |
 | `is_available` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if requested quantity is less than available stock, false otherwise. *(Deprecated: Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration.)* |
+| `is_free_gift` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if this line item was added by a Free Gift cart price rule. |
 | `is_salable` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed. |
 | `links` - [`[DownloadableProductLinks]`](#downloadableproductlinks) | An array containing information about the links for the downloadable product added to the cart. |
 | `max_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item max qty in quote template |
 | `min_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item min qty in quote template |
+| `nominated_source` - [`SourceAvailability`](/reference/graphql/saas/types-q-s.md#sourceavailability) | The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors). |
+| `nominated_source_errors` - [`[NominatedSourceError]!`](/reference/graphql/saas/types-k-p.md#nominatedsourceerror) | Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart. |
 | `not_available_message` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Shortage or unavailability message for the line; null when the item is salable. |
 | `note_from_buyer` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The buyer's quote line item note. |
 | `note_from_seller` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The seller's quote line item note. |
@@ -6554,22 +6926,25 @@ An implementation for downloadable product cart items.
 
 ```json
 {
-  "backorder_message": "xyz789",
+  "backorder_message": "abc123",
   "custom_attributes": [CustomAttribute],
   "customizable_options": [SelectedCustomizableOption],
   "discount": [Discount],
   "errors": [CartItemError],
   "is_available": false,
+  "is_free_gift": true,
   "is_salable": true,
   "links": [DownloadableProductLinks],
   "max_qty": 987.65,
-  "min_qty": 987.65,
+  "min_qty": 123.45,
+  "nominated_source": SourceAvailability,
+  "nominated_source_errors": [NominatedSourceError],
   "not_available_message": "xyz789",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
-  "quantity": 123.45,
+  "quantity": 987.65,
   "samples": [DownloadableProductSamples],
   "uid": "4"
 }
@@ -6602,11 +6977,11 @@ Defines downloadable product options for `CreditMemoItemInterface`.
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
   "downloadable_links": [DownloadableItemsLinks],
-  "id": "4",
+  "id": 4,
   "order_item": OrderItemInterface,
-  "product_name": "abc123",
+  "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
+  "product_sku": "abc123",
   "quantity_refunded": 123.45
 }
 ```
@@ -6665,9 +7040,9 @@ Defines characteristics of the links for downloadable product.
 
 ```json
 {
-  "sort_order": 123,
+  "sort_order": 987,
   "title": "xyz789",
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -6686,6 +7061,7 @@ Defines downloadable product options for `OrderItemInterface`.
 | `downloadable_links` - [`[DownloadableItemsLinks]`](#downloadableitemslinks) | A list of downloadable links that are ordered from the downloadable product. |
 | `eligible_for_return` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the order item is eligible to be in a return request. |
 | `entered_options` - [`[OrderItemOption]`](/reference/graphql/saas/types-k-p.md#orderitemoption) | The entered option for the base product, such as a logo or image. |
+| `free_gift_label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The discount rule label for free gift items. Null if the item is not a free gift. |
 | `gift_message` - [`GiftMessage`](/reference/graphql/saas/types-f-i.md#giftmessage) | The selected gift message for the order item |
 | `gift_wrapping` - [`GiftWrapping`](/reference/graphql/saas/types-f-i.md#giftwrapping) | The selected gift wrapping for the order item. |
 | `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID for an `OrderItemInterface` object. |
@@ -6713,27 +7089,28 @@ Defines downloadable product options for `OrderItemInterface`.
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
   "downloadable_links": [DownloadableItemsLinks],
-  "eligible_for_return": true,
+  "eligible_for_return": false,
   "entered_options": [OrderItemOption],
+  "free_gift_label": "abc123",
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
-  "id": 4,
+  "id": "4",
   "prices": OrderItemPrices,
   "product": ProductInterface,
   "product_name": "xyz789",
   "product_sale_price": Money,
   "product_sku": "abc123",
-  "product_type": "xyz789",
+  "product_type": "abc123",
   "product_url_key": "xyz789",
   "quantity_canceled": 987.65,
-  "quantity_invoiced": 987.65,
+  "quantity_invoiced": 123.45,
   "quantity_ordered": 987.65,
   "quantity_refunded": 987.65,
   "quantity_return_requested": 123.45,
-  "quantity_returned": 987.65,
-  "quantity_shipped": 123.45,
+  "quantity_returned": 123.45,
+  "quantity_shipped": 987.65,
   "selected_options": [OrderItemOption],
-  "status": "abc123"
+  "status": "xyz789"
 }
 ```
 
@@ -6809,23 +7186,23 @@ Defines a product that the shopper downloads.
     DownloadableProductSamples
   ],
   "gift_message_available": false,
-  "gift_wrapping_available": false,
+  "gift_wrapping_available": true,
   "gift_wrapping_price": Money,
   "image": ProductImage,
-  "is_returnable": "abc123",
-  "links_purchased_separately": 123,
-  "links_title": "abc123",
-  "manufacturer": 987,
+  "is_returnable": "xyz789",
+  "links_purchased_separately": 987,
+  "links_title": "xyz789",
+  "manufacturer": 123,
   "max_sale_qty": 987.65,
   "media_gallery": [MediaGalleryInterface],
-  "meta_description": "abc123",
+  "meta_description": "xyz789",
   "meta_keyword": "xyz789",
   "meta_title": "abc123",
   "min_sale_qty": 123.45,
   "name": "xyz789",
   "new_from_date": "abc123",
-  "new_to_date": "xyz789",
-  "only_x_left_in_stock": 123.45,
+  "new_to_date": "abc123",
+  "only_x_left_in_stock": 987.65,
   "options": [CustomizableOptionInterface],
   "options_container": "xyz789",
   "price_range": PriceRange,
@@ -6834,12 +7211,12 @@ Defines a product that the shopper downloads.
   "quantity": 987.65,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
-  "sku": "abc123",
+  "sku": "xyz789",
   "small_image": ProductImage,
-  "special_price": 987.65,
-  "special_to_date": "xyz789",
+  "special_price": 123.45,
+  "special_to_date": "abc123",
   "stock_status": "IN_STOCK",
-  "swatch_image": "xyz789",
+  "swatch_image": "abc123",
   "thumbnail": ProductImage,
   "uid": 4,
   "upsell_products": [ProductInterface],
@@ -6894,9 +7271,9 @@ Defines characteristics of a downloadable product.
 ```json
 {
   "price": 987.65,
-  "sample_url": "abc123",
+  "sample_url": "xyz789",
   "sort_order": 123,
-  "title": "abc123",
+  "title": "xyz789",
   "uid": 4
 }
 ```
@@ -6938,7 +7315,7 @@ Defines characteristics of a downloadable product.
 ```json
 {
   "sample_url": "abc123",
-  "sort_order": 987,
+  "sort_order": 123,
   "title": "abc123"
 }
 ```
@@ -6970,8 +7347,8 @@ Contains details about downloadable products added to a requisition list.
   "product": ProductInterface,
   "quantity": 123.45,
   "samples": [DownloadableProductSamples],
-  "sku": "xyz789",
-  "uid": "4"
+  "sku": "abc123",
+  "uid": 4
 }
 ```
 
@@ -7000,7 +7377,7 @@ A downloadable product wish list item.
 {
   "added_at": "abc123",
   "customizable_options": [SelectedCustomizableOption],
-  "description": "xyz789",
+  "description": "abc123",
   "id": "4",
   "links_v2": [DownloadableProductLinks],
   "product": ProductInterface,
@@ -7025,7 +7402,10 @@ Identifies a quote to be duplicated
 #### Example
 
 ```json
-{"duplicated_quote_uid": 4, "quote_uid": 4}
+{
+  "duplicated_quote_uid": "4",
+  "quote_uid": "4"
+}
 ```
 
 <HorizontalLine />
@@ -7063,8 +7443,8 @@ Contains details about a custom text attribute that the buyer entered.
 
 ```json
 {
-  "attribute_code": "abc123",
-  "value": "abc123"
+  "attribute_code": "xyz789",
+  "value": "xyz789"
 }
 ```
 
@@ -7137,7 +7517,7 @@ An error encountered while adding an item to the the cart.
 #### Example
 
 ```json
-{"message": "xyz789"}
+{"message": "abc123"}
 ```
 
 <HorizontalLine />
@@ -7159,7 +7539,7 @@ Contains details about an address.
 ```json
 {
   "country_code": "AF",
-  "postcode": "xyz789",
+  "postcode": "abc123",
   "region": CustomerAddressRegionInput
 }
 ```
@@ -7260,7 +7640,29 @@ Lists the exchange rate.
 #### Example
 
 ```json
-{"currency_to": "xyz789", "rate": 987.65}
+{"currency_to": "abc123", "rate": 987.65}
+```
+
+<HorizontalLine />
+
+### ExternalId
+
+Represents an external identifier with its origin system
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `id` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The external identifier value |
+| `origin` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The origin system of the external identifier |
+
+#### Example
+
+```json
+{
+  "id": "abc123",
+  "origin": "abc123"
+}
 ```
 
 <HorizontalLine />

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-f-i.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-f-i.md
@@ -20,13 +20,13 @@
 ```json
 {
   "code": "xyz789",
-  "is_visible": true,
-  "payment_intent": "abc123",
-  "payment_source": "xyz789",
+  "is_visible": false,
+  "payment_intent": "xyz789",
+  "payment_source": "abc123",
   "sdk_params": [SDKParams],
-  "sort_order": "xyz789",
+  "sort_order": "abc123",
   "three_ds_mode": "OFF",
-  "title": "xyz789"
+  "title": "abc123"
 }
 ```
 
@@ -47,8 +47,8 @@ Fastlane Payment inputs
 
 ```json
 {
-  "payment_source": "xyz789",
-  "paypal_fastlane_token": "abc123"
+  "payment_source": "abc123",
+  "paypal_fastlane_token": "xyz789"
 }
 ```
 
@@ -150,7 +150,7 @@ Defines a filter that matches a range of values, such as prices or dates.
 
 ```json
 {
-  "from": "abc123",
+  "from": "xyz789",
   "to": "abc123"
 }
 ```
@@ -171,7 +171,7 @@ Defines a filter that matches a range of values, such as prices or dates.
 
 ```json
 {
-  "name": "xyz789",
+  "name": "abc123",
   "type": "UNKNOWN_FILTER_RULE_TYPE",
   "conditions": [ConditionInput]
 }
@@ -215,7 +215,7 @@ Defines a filter for an input string.
 {
   "eq": "xyz789",
   "in": ["abc123"],
-  "match": "xyz789"
+  "match": "abc123"
 }
 ```
 
@@ -250,10 +250,10 @@ Defines the comparison operators that can be used in a filter.
 {
   "eq": "abc123",
   "from": "abc123",
-  "gt": "abc123",
+  "gt": "xyz789",
   "gteq": "xyz789",
-  "in": ["abc123"],
-  "like": "xyz789",
+  "in": ["xyz789"],
+  "like": "abc123",
   "lt": "xyz789",
   "lteq": "abc123",
   "moreq": "xyz789",
@@ -284,7 +284,7 @@ Contains product attributes that can be used for filtering in a `productSearch` 
 
 ```json
 {
-  "attribute": "xyz789",
+  "attribute": "abc123",
   "frontendInput": "xyz789",
   "label": "abc123",
   "numeric": false
@@ -309,7 +309,7 @@ A single FPT that can be applied to a product price.
 ```json
 {
   "amount": Money,
-  "label": "xyz789"
+  "label": "abc123"
 }
 ```
 
@@ -344,7 +344,7 @@ The `Float` scalar type represents signed double-precision fractional values as 
 #### Example
 
 ```json
-123.45
+987.65
 ```
 
 <HorizontalLine />
@@ -416,7 +416,7 @@ Contains the generated negotiable quote id.
 #### Example
 
 ```json
-{"negotiable_quote_uid": "4"}
+{"negotiable_quote_uid": 4}
 ```
 
 <HorizontalLine />
@@ -456,7 +456,7 @@ Contains details about the gift card account.
 ```json
 {
   "balance": Money,
-  "code": "abc123",
+  "code": "xyz789",
   "expiration_date": "xyz789"
 }
 ```
@@ -501,9 +501,9 @@ Contains the value of a gift card, the website that generated the card, and rela
 {
   "attribute_id": 123,
   "uid": 4,
-  "value": 987.65,
+  "value": 123.45,
   "website_id": 123,
-  "website_value": 987.65
+  "website_value": 123.45
 }
 ```
 
@@ -527,10 +527,13 @@ Contains details about a gift card that has been added to a cart.
 | `gift_message` - [`GiftMessage`](#giftmessage) | The entered gift message data for the gift card cart item |
 | `gift_wrapping` - [`GiftWrapping`](#giftwrapping) | The selected gift wrapping option for the cart item. |
 | `is_available` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if requested quantity is less than available stock, false otherwise. *(Deprecated: Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration.)* |
+| `is_free_gift` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if this line item was added by a Free Gift cart price rule. |
 | `is_salable` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed. |
 | `max_qty` - [`Float`](#float) | Line item max qty in quote template |
 | `message` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The message from the sender to the recipient. |
 | `min_qty` - [`Float`](#float) | Line item min qty in quote template |
+| `nominated_source` - [`SourceAvailability`](/reference/graphql/saas/types-q-s.md#sourceavailability) | The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors). |
+| `nominated_source_errors` - [`[NominatedSourceError]!`](/reference/graphql/saas/types-k-p.md#nominatedsourceerror) | Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart. |
 | `not_available_message` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Shortage or unavailability message for the line; null when the item is salable. |
 | `note_from_buyer` - [`[ItemNote]`](#itemnote) | The buyer's quote line item note. |
 | `note_from_seller` - [`[ItemNote]`](#itemnote) | The seller's quote line item note. |
@@ -556,22 +559,25 @@ Contains details about a gift card that has been added to a cart.
   "errors": [CartItemError],
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
-  "is_available": false,
-  "is_salable": false,
+  "is_available": true,
+  "is_free_gift": false,
+  "is_salable": true,
   "max_qty": 123.45,
-  "message": "xyz789",
+  "message": "abc123",
   "min_qty": 987.65,
-  "not_available_message": "xyz789",
+  "nominated_source": SourceAvailability,
+  "nominated_source_errors": [NominatedSourceError],
+  "not_available_message": "abc123",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
-  "quantity": 987.65,
+  "quantity": 123.45,
   "recipient_email": "abc123",
-  "recipient_name": "xyz789",
+  "recipient_name": "abc123",
   "sender_email": "abc123",
   "sender_name": "abc123",
-  "uid": 4
+  "uid": "4"
 }
 ```
 
@@ -600,12 +606,12 @@ Contains details about a gift card that has been added to a cart.
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
   "gift_card": GiftCardItem,
-  "id": 4,
+  "id": "4",
   "order_item": OrderItemInterface,
   "product_name": "abc123",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
-  "quantity_refunded": 123.45
+  "product_sku": "abc123",
+  "quantity_refunded": 987.65
 }
 ```
 
@@ -634,11 +640,11 @@ Contains details about a gift card that has been added to a cart.
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
   "gift_card": GiftCardItem,
-  "id": 4,
+  "id": "4",
   "order_item": OrderItemInterface,
   "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
+  "product_sku": "abc123",
   "quantity_invoiced": 987.65
 }
 ```
@@ -663,8 +669,8 @@ Contains details about a gift card.
 
 ```json
 {
-  "message": "abc123",
-  "recipient_email": "xyz789",
+  "message": "xyz789",
+  "recipient_email": "abc123",
   "recipient_name": "xyz789",
   "sender_email": "xyz789",
   "sender_name": "xyz789"
@@ -695,11 +701,11 @@ Contains details about the sender, recipient, and amount of a gift card.
 {
   "amount": Money,
   "custom_giftcard_amount": Money,
-  "message": "xyz789",
-  "recipient_email": "xyz789",
+  "message": "abc123",
+  "recipient_email": "abc123",
   "recipient_name": "abc123",
   "sender_email": "xyz789",
-  "sender_name": "abc123"
+  "sender_name": "xyz789"
 }
 ```
 
@@ -715,6 +721,7 @@ Contains details about the sender, recipient, and amount of a gift card.
 | `discounts` - [`[Discount]`](/reference/graphql/saas/types-c-e.md#discount) | The final discount information for the product. |
 | `eligible_for_return` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the order item is eligible to be in a return request. |
 | `entered_options` - [`[OrderItemOption]`](/reference/graphql/saas/types-k-p.md#orderitemoption) | The entered option for the base product, such as a logo or image. |
+| `free_gift_label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The discount rule label for free gift items. Null if the item is not a free gift. |
 | `gift_card` - [`GiftCardItem`](#giftcarditem) | Selected gift card properties for an order item. |
 | `gift_message` - [`GiftMessage`](#giftmessage) | The selected gift message for the order item |
 | `gift_wrapping` - [`GiftWrapping`](#giftwrapping) | The selected gift wrapping for the order item. |
@@ -744,6 +751,7 @@ Contains details about the sender, recipient, and amount of a gift card.
   "discounts": [Discount],
   "eligible_for_return": true,
   "entered_options": [OrderItemOption],
+  "free_gift_label": "xyz789",
   "gift_card": GiftCardItem,
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
@@ -752,18 +760,18 @@ Contains details about the sender, recipient, and amount of a gift card.
   "product": ProductInterface,
   "product_name": "abc123",
   "product_sale_price": Money,
-  "product_sku": "abc123",
+  "product_sku": "xyz789",
   "product_type": "abc123",
-  "product_url_key": "xyz789",
+  "product_url_key": "abc123",
   "quantity_canceled": 123.45,
   "quantity_invoiced": 987.65,
   "quantity_ordered": 987.65,
-  "quantity_refunded": 123.45,
+  "quantity_refunded": 987.65,
   "quantity_return_requested": 123.45,
   "quantity_returned": 123.45,
   "quantity_shipped": 123.45,
   "selected_options": [OrderItemOption],
-  "status": "abc123"
+  "status": "xyz789"
 }
 ```
 
@@ -833,9 +841,9 @@ Defines properties of a gift card.
 
 ```json
 {
-  "allow_message": false,
-  "allow_open_amount": false,
-  "canonical_url": "abc123",
+  "allow_message": true,
+  "allow_open_amount": true,
+  "canonical_url": "xyz789",
   "categories": [CategoryInterface],
   "country_of_manufacture": "xyz789",
   "crosssell_products": [ProductInterface],
@@ -843,47 +851,47 @@ Defines properties of a gift card.
   "description": ComplexTextValue,
   "gift_card_options": [CustomizableOptionInterface],
   "gift_message_available": true,
-  "gift_wrapping_available": true,
+  "gift_wrapping_available": false,
   "gift_wrapping_price": Money,
   "giftcard_amounts": [GiftCardAmounts],
   "giftcard_type": "VIRTUAL",
   "image": ProductImage,
-  "is_redeemable": true,
+  "is_redeemable": false,
   "is_returnable": "abc123",
-  "lifetime": 123,
+  "lifetime": 987,
   "manufacturer": 123,
   "max_sale_qty": 123.45,
   "media_gallery": [MediaGalleryInterface],
-  "message_max_length": 987,
-  "meta_description": "abc123",
-  "meta_keyword": "abc123",
-  "meta_title": "abc123",
-  "min_sale_qty": 987.65,
+  "message_max_length": 123,
+  "meta_description": "xyz789",
+  "meta_keyword": "xyz789",
+  "meta_title": "xyz789",
+  "min_sale_qty": 123.45,
   "name": "abc123",
   "new_from_date": "abc123",
-  "new_to_date": "abc123",
-  "only_x_left_in_stock": 123.45,
-  "open_amount_max": 987.65,
-  "open_amount_min": 123.45,
+  "new_to_date": "xyz789",
+  "only_x_left_in_stock": 987.65,
+  "open_amount_max": 123.45,
+  "open_amount_min": 987.65,
   "options": [CustomizableOptionInterface],
   "options_container": "abc123",
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
   "product_links": [ProductLinksInterface],
-  "quantity": 987.65,
+  "quantity": 123.45,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
-  "sku": "abc123",
+  "sku": "xyz789",
   "small_image": ProductImage,
   "special_price": 123.45,
-  "special_to_date": "xyz789",
+  "special_to_date": "abc123",
   "stock_status": "IN_STOCK",
-  "swatch_image": "xyz789",
+  "swatch_image": "abc123",
   "thumbnail": ProductImage,
   "uid": 4,
   "upsell_products": [ProductInterface],
   "url_key": "abc123",
-  "weight": 123.45
+  "weight": 987.65
 }
 ```
 
@@ -911,9 +919,9 @@ Contains details about gift cards added to a requisition list.
   "customizable_options": [SelectedCustomizableOption],
   "gift_card_options": GiftCardOptions,
   "product": ProductInterface,
-  "quantity": 123.45,
+  "quantity": 987.65,
   "sku": "xyz789",
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -938,11 +946,11 @@ Contains details about gift cards added to a requisition list.
 ```json
 {
   "gift_card": GiftCardItem,
-  "id": 4,
+  "id": "4",
   "order_item": OrderItemInterface,
-  "product_name": "xyz789",
+  "product_name": "abc123",
   "product_sale_price": Money,
-  "product_sku": "abc123",
+  "product_sku": "xyz789",
   "quantity_shipped": 123.45
 }
 ```
@@ -989,13 +997,37 @@ A single gift card added to a wish list.
 
 ```json
 {
-  "added_at": "abc123",
+  "added_at": "xyz789",
   "customizable_options": [SelectedCustomizableOption],
   "description": "abc123",
   "gift_card_options": GiftCardOptions,
-  "id": 4,
+  "id": "4",
   "product": ProductInterface,
   "quantity": 987.65
+}
+```
+
+<HorizontalLine />
+
+### GiftCartAttributeValue
+
+Gift card custom attribute value containing array data.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `attribute_type` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Attribute type code. |
+| `code` - [`ID!`](#id) | The attribute code. |
+| `options` - [`[String]!`](/reference/graphql/saas/types-q-s.md#string) | Array of gift card attribute option values. |
+
+#### Example
+
+```json
+{
+  "attribute_type": "xyz789",
+  "code": "4",
+  "options": ["abc123"]
 }
 ```
 
@@ -1018,7 +1050,7 @@ Contains the text of a gift message, its sender, and recipient
 ```json
 {
   "from": "xyz789",
-  "message": "xyz789",
+  "message": "abc123",
   "to": "xyz789"
 }
 ```
@@ -1041,9 +1073,9 @@ Defines a gift message.
 
 ```json
 {
-  "from": "xyz789",
+  "from": "abc123",
   "message": "xyz789",
-  "to": "xyz789"
+  "to": "abc123"
 }
 ```
 
@@ -1104,11 +1136,11 @@ Contains details about a gift registry.
 
 ```json
 {
-  "created_at": "xyz789",
+  "created_at": "abc123",
   "dynamic_attributes": [GiftRegistryDynamicAttribute],
   "event_name": "xyz789",
   "items": [GiftRegistryItemInterface],
-  "message": "abc123",
+  "message": "xyz789",
   "owner_name": "xyz789",
   "privacy_settings": "PRIVATE",
   "registrants": [GiftRegistryRegistrant],
@@ -1136,9 +1168,9 @@ Contains details about a gift registry.
 
 ```json
 {
-  "code": 4,
+  "code": "4",
   "group": "EVENT_INFORMATION",
-  "label": "xyz789",
+  "label": "abc123",
   "value": "abc123"
 }
 ```
@@ -1208,9 +1240,9 @@ Defines a dynamic attribute.
 
 ```json
 {
-  "code": 4,
+  "code": "4",
   "label": "abc123",
-  "value": "abc123"
+  "value": "xyz789"
 }
 ```
 
@@ -1233,12 +1265,12 @@ Defines a dynamic attribute.
 
 ```json
 {
-  "attribute_group": "abc123",
+  "attribute_group": "xyz789",
   "code": 4,
-  "input_type": "xyz789",
-  "is_required": false,
-  "label": "xyz789",
-  "sort_order": 123
+  "input_type": "abc123",
+  "is_required": true,
+  "label": "abc123",
+  "sort_order": 987
 }
 ```
 
@@ -1267,11 +1299,11 @@ Defines a dynamic attribute.
 
 ```json
 {
-  "attribute_group": "xyz789",
-  "code": 4,
+  "attribute_group": "abc123",
+  "code": "4",
   "input_type": "abc123",
-  "is_required": false,
-  "label": "xyz789",
+  "is_required": true,
+  "label": "abc123",
   "sort_order": 987
 }
 ```
@@ -1296,11 +1328,11 @@ Defines a dynamic attribute.
 ```json
 {
   "created_at": "xyz789",
-  "note": "abc123",
+  "note": "xyz789",
   "product": ProductInterface,
   "quantity": 987.65,
   "quantity_fulfilled": 123.45,
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -1329,8 +1361,8 @@ Defines a dynamic attribute.
 
 ```json
 {
-  "created_at": "abc123",
-  "note": "xyz789",
+  "created_at": "xyz789",
+  "note": "abc123",
   "product": ProductInterface,
   "quantity": 987.65,
   "quantity_fulfilled": 987.65,
@@ -1361,7 +1393,7 @@ Contains the status and any errors that encountered with the customer's gift reg
 
 ```json
 {
-  "status": true,
+  "status": false,
   "user_errors": [GiftRegistryItemsUserError]
 }
 ```
@@ -1387,10 +1419,10 @@ Contains details about an error that occurred when processing a gift registry it
 ```json
 {
   "code": "OUT_OF_STOCK",
-  "gift_registry_item_uid": "4",
-  "gift_registry_uid": "4",
-  "message": "xyz789",
-  "product_uid": "4"
+  "gift_registry_item_uid": 4,
+  "gift_registry_uid": 4,
+  "message": "abc123",
+  "product_uid": 4
 }
 ```
 
@@ -1482,8 +1514,8 @@ Contains details about a registrant.
   ],
   "email": "abc123",
   "firstname": "abc123",
-  "lastname": "abc123",
-  "uid": "4"
+  "lastname": "xyz789",
+  "uid": 4
 }
 ```
 
@@ -1503,8 +1535,8 @@ Contains details about a registrant.
 
 ```json
 {
-  "code": "4",
-  "label": "xyz789",
+  "code": 4,
+  "label": "abc123",
   "value": "abc123"
 }
 ```
@@ -1530,11 +1562,11 @@ Contains the results of a gift registry search.
 
 ```json
 {
-  "event_date": "abc123",
+  "event_date": "xyz789",
   "event_title": "xyz789",
-  "gift_registry_uid": "4",
+  "gift_registry_uid": 4,
   "location": "abc123",
-  "name": "abc123",
+  "name": "xyz789",
   "type": "abc123"
 }
 ```
@@ -1627,10 +1659,10 @@ Contains details about the selected or available gift wrapping options.
 
 ```json
 {
-  "design": "abc123",
+  "design": "xyz789",
   "image": GiftWrappingImage,
   "price": Money,
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -1651,8 +1683,8 @@ Points to an image associated with a gift wrapping option.
 
 ```json
 {
-  "label": "xyz789",
-  "url": "xyz789"
+  "label": "abc123",
+  "url": "abc123"
 }
 ```
 
@@ -1673,7 +1705,7 @@ Points to an image associated with a gift wrapping option.
 ```json
 {
   "color": "xyz789",
-  "height": 123,
+  "height": 987,
   "type": "abc123"
 }
 ```
@@ -1705,8 +1737,8 @@ Points to an image associated with a gift wrapping option.
   "code": "xyz789",
   "google_pay_mode": "TEST",
   "is_visible": true,
-  "payment_intent": "abc123",
-  "payment_source": "xyz789",
+  "payment_intent": "xyz789",
+  "payment_source": "abc123",
   "sdk_params": [SDKParams],
   "sort_order": "xyz789",
   "three_ds_mode": "OFF",
@@ -1733,8 +1765,8 @@ Google Pay inputs
 ```json
 {
   "payment_source": "xyz789",
-  "payments_order_id": "abc123",
-  "paypal_order_id": "abc123"
+  "payments_order_id": "xyz789",
+  "paypal_order_id": "xyz789"
 }
 ```
 
@@ -1813,46 +1845,46 @@ Defines a grouped product, which consists of simple standalone products that are
 
 ```json
 {
-  "canonical_url": "xyz789",
+  "canonical_url": "abc123",
   "categories": [CategoryInterface],
   "country_of_manufacture": "abc123",
   "crosssell_products": [ProductInterface],
   "custom_attributesV2": ProductCustomAttributes,
   "description": ComplexTextValue,
-  "gift_message_available": false,
+  "gift_message_available": true,
   "gift_wrapping_available": true,
   "gift_wrapping_price": Money,
   "image": ProductImage,
   "is_returnable": "abc123",
   "items": [GroupedProductItem],
   "manufacturer": 123,
-  "max_sale_qty": 987.65,
+  "max_sale_qty": 123.45,
   "media_gallery": [MediaGalleryInterface],
-  "meta_description": "xyz789",
-  "meta_keyword": "xyz789",
-  "meta_title": "abc123",
+  "meta_description": "abc123",
+  "meta_keyword": "abc123",
+  "meta_title": "xyz789",
   "min_sale_qty": 987.65,
-  "name": "abc123",
-  "new_from_date": "xyz789",
+  "name": "xyz789",
+  "new_from_date": "abc123",
   "new_to_date": "xyz789",
   "only_x_left_in_stock": 123.45,
-  "options_container": "xyz789",
+  "options_container": "abc123",
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
   "product_links": [ProductLinksInterface],
-  "quantity": 987.65,
+  "quantity": 123.45,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
-  "sku": "abc123",
+  "sku": "xyz789",
   "small_image": ProductImage,
-  "special_price": 987.65,
+  "special_price": 123.45,
   "special_to_date": "xyz789",
   "stock_status": "IN_STOCK",
-  "swatch_image": "abc123",
+  "swatch_image": "xyz789",
   "thumbnail": ProductImage,
   "uid": "4",
   "upsell_products": [ProductInterface],
-  "url_key": "xyz789",
+  "url_key": "abc123",
   "weight": 123.45
 }
 ```
@@ -1905,7 +1937,7 @@ A grouped product wish list item.
   "added_at": "abc123",
   "customizable_options": [SelectedCustomizableOption],
   "description": "xyz789",
-  "id": "4",
+  "id": 4,
   "product": ProductInterface,
   "quantity": 123.45
 }
@@ -1928,8 +1960,8 @@ Input to retrieve a guest order based on token.
 
 ```json
 {
-  "reason": "abc123",
-  "token": "xyz789"
+  "reason": "xyz789",
+  "token": "abc123"
 }
 ```
 
@@ -1953,7 +1985,7 @@ Input to retrieve an order based on details.
 {
   "email": "abc123",
   "lastname": "xyz789",
-  "number": "abc123"
+  "number": "xyz789"
 }
 ```
 
@@ -2002,12 +2034,12 @@ Item note data that is added to the negotiable quote history object.
 
 ```json
 {
-  "created_at": "abc123",
-  "creator_name": "xyz789",
-  "creator_type": "xyz789",
+  "created_at": "xyz789",
+  "creator_name": "abc123",
+  "creator_type": "abc123",
   "item_id": 123,
-  "note": "abc123",
-  "product_name": "abc123"
+  "note": "xyz789",
+  "product_name": "xyz789"
 }
 ```
 
@@ -2035,13 +2067,13 @@ Item note data that is added to the negotiable quote history object.
 
 ```json
 {
-  "cc_vault_code": "abc123",
-  "code": "xyz789",
-  "is_vault_enabled": true,
-  "is_visible": true,
-  "payment_intent": "xyz789",
-  "payment_source": "xyz789",
-  "requires_card_details": false,
+  "cc_vault_code": "xyz789",
+  "code": "abc123",
+  "is_vault_enabled": false,
+  "is_visible": false,
+  "payment_intent": "abc123",
+  "payment_source": "abc123",
+  "requires_card_details": true,
   "sdk_params": [SDKParams],
   "sort_order": "abc123",
   "three_ds_mode": "OFF",
@@ -2073,11 +2105,11 @@ Hosted Fields payment inputs
 
 ```json
 {
-  "cardBin": "abc123",
+  "cardBin": "xyz789",
   "cardExpiryMonth": "xyz789",
   "cardExpiryYear": "xyz789",
   "cardLast4": "abc123",
-  "holderName": "xyz789",
+  "holderName": "abc123",
   "is_active_payment_token_enabler": false,
   "payment_source": "abc123",
   "payments_order_id": "abc123",
@@ -2094,7 +2126,7 @@ The `ID` scalar type represents a unique identifier, often used to refetch an ob
 #### Example
 
 ```json
-4
+"4"
 ```
 
 <HorizontalLine />
@@ -2178,8 +2210,8 @@ List of templates/filters applied to customer attribute input.
 ```json
 {
   "code": "PRODUCT_NOT_FOUND",
-  "message": "xyz789",
-  "quantity": 123.45
+  "message": "abc123",
+  "quantity": 987.65
 }
 ```
 
@@ -2192,7 +2224,7 @@ The `Int` scalar type represents non-fractional signed whole numeric values. Int
 #### Example
 
 ```json
-987
+123
 ```
 
 <HorizontalLine />
@@ -2210,7 +2242,7 @@ Contains an error message when an internal error occurred.
 #### Example
 
 ```json
-{"message": "xyz789"}
+{"message": "abc123"}
 ```
 
 <HorizontalLine />
@@ -2236,9 +2268,9 @@ Contains invoice details.
 {
   "comments": [SalesCommentItem],
   "custom_attributes": [CustomAttribute],
-  "id": 4,
+  "id": "4",
   "items": [InvoiceItemInterface],
-  "number": "abc123",
+  "number": "xyz789",
   "total": InvoiceTotal
 }
 ```
@@ -2261,7 +2293,7 @@ Defines an invoice custom attributes.
 ```json
 {
   "custom_attributes": [CustomAttributeInput],
-  "invoice_id": "abc123"
+  "invoice_id": "xyz789"
 }
 ```
 
@@ -2292,8 +2324,8 @@ Defines an invoice custom attributes.
   "order_item": OrderItemInterface,
   "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "abc123",
-  "quantity_invoiced": 987.65
+  "product_sku": "xyz789",
+  "quantity_invoiced": 123.45
 }
 ```
 
@@ -2316,8 +2348,8 @@ Defines an invoice item custom attributes.
 ```json
 {
   "custom_attributes": [CustomAttributeInput],
-  "invoice_id": "xyz789",
-  "invoice_item_id": "xyz789"
+  "invoice_id": "abc123",
+  "invoice_item_id": "abc123"
 }
 ```
 
@@ -2355,12 +2387,12 @@ Contains detailes about invoiced items.
 {
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
-  "id": 4,
+  "id": "4",
   "order_item": OrderItemInterface,
-  "product_name": "abc123",
+  "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
-  "quantity_invoiced": 123.45
+  "product_sku": "abc123",
+  "quantity_invoiced": 987.65
 }
 ```
 
@@ -2449,7 +2481,7 @@ Contains the response of a company email validation query.
 #### Example
 
 ```json
-{"is_email_available": false}
+{"is_email_available": true}
 ```
 
 <HorizontalLine />
@@ -2467,7 +2499,7 @@ Contains the response of a role name validation query.
 #### Example
 
 ```json
-{"is_role_name_available": true}
+{"is_role_name_available": false}
 ```
 
 <HorizontalLine />
@@ -2503,7 +2535,7 @@ Contains the result of the `isEmailAvailable` query.
 #### Example
 
 ```json
-{"is_email_available": true}
+{"is_email_available": false}
 ```
 
 <HorizontalLine />
@@ -2544,17 +2576,19 @@ Contains the result of the `isEmailAvailable` query.
 
 ### IsProductAlertSubscriptionResult
 
+Response returned when checking whether a customer is subscribed to a product alert.
+
 #### Fields
 
 | Field Name | Description |
 |------------|-------------|
-| `isSubscribed` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) |  |
-| `message` - [`String`](/reference/graphql/saas/types-q-s.md#string) |  |
+| `isSubscribed` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the customer is currently subscribed to the alert. |
+| `message` - [`String`](/reference/graphql/saas/types-q-s.md#string) | A human-readable message describing the current subscription status. |
 
 #### Example
 
 ```json
-{"isSubscribed": false, "message": "xyz789"}
+{"isSubscribed": true, "message": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -2579,13 +2613,13 @@ The note object for quote line item.
 
 ```json
 {
-  "created_at": "abc123",
+  "created_at": "xyz789",
   "creator_id": 123,
   "creator_name": "xyz789",
   "creator_type": 123,
-  "negotiable_quote_item_uid": "4",
-  "note": "xyz789",
-  "note_uid": "4"
+  "negotiable_quote_item_uid": 4,
+  "note": "abc123",
+  "note_uid": 4
 }
 ```
 
@@ -2607,7 +2641,7 @@ A list of options of the selected bundle product.
 
 ```json
 {
-  "label": "xyz789",
+  "label": "abc123",
   "uid": "4",
   "values": [ItemSelectedBundleOptionValue]
 }
@@ -2668,7 +2702,7 @@ A JSON scalar
 
 ```json
 {
-  "key": "xyz789",
+  "key": "abc123",
   "media_resource_type": "NEGOTIABLE_QUOTE_ATTACHMENT"
 }
 ```
@@ -2689,9 +2723,9 @@ A JSON scalar
 
 ```json
 {
-  "key": "xyz789",
-  "message": "abc123",
-  "success": false
+  "key": "abc123",
+  "message": "xyz789",
+  "success": true
 }
 ```
 
@@ -2710,7 +2744,7 @@ A JSON scalar
 
 ```json
 {
-  "key": "xyz789",
+  "key": "abc123",
   "media_resource_type": "NEGOTIABLE_QUOTE_ATTACHMENT"
 }
 ```
@@ -2733,6 +2767,6 @@ A JSON scalar
 {
   "expires_at": "xyz789",
   "key": "abc123",
-  "upload_url": "abc123"
+  "upload_url": "xyz789"
 }
 ```

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-k-p.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-k-p.md
@@ -59,7 +59,7 @@ Sets quote item note.
 ```json
 {
   "note": "xyz789",
-  "quote_item_uid": 4,
+  "quote_item_uid": "4",
   "quote_uid": "4"
 }
 ```
@@ -77,6 +77,7 @@ Contains basic information about a product image or video.
 | `disabled` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the image is hidden from view. |
 | `label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The label of the product image or video. |
 | `position` - [`Int`](/reference/graphql/saas/types-f-i.md#int) | The media item's position after it has been sorted. |
+| `types` - [`[String]`](/reference/graphql/saas/types-q-s.md#string) | Array of image types. It can have the following values: image, small_image, thumbnail. |
 | `url` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The URL of the product image or video. |
 
 #### Possible Types
@@ -92,9 +93,10 @@ Contains basic information about a product image or video.
 
 ```json
 {
-  "disabled": true,
-  "label": "xyz789",
-  "position": 987,
+  "disabled": false,
+  "label": "abc123",
+  "position": 123,
+  "types": ["xyz789"],
   "url": "xyz789"
 }
 ```
@@ -173,7 +175,7 @@ Defines a monetary value, including a numeric value and a currency code.
 #### Example
 
 ```json
-{"currency": "AFN", "value": 987.65}
+{"currency": "AFN", "value": 123.45}
 ```
 
 <HorizontalLine />
@@ -195,7 +197,7 @@ Contains the customer's gift registry and any errors encountered.
 ```json
 {
   "gift_registry": GiftRegistry,
-  "status": true,
+  "status": false,
   "user_errors": [GiftRegistryItemsUserError]
 }
 ```
@@ -215,7 +217,7 @@ An input object that defines the items in a requisition list to be moved.
 #### Example
 
 ```json
-{"requisitionListItemUids": [4]}
+{"requisitionListItemUids": ["4"]}
 ```
 
 <HorizontalLine />
@@ -257,11 +259,7 @@ Move Line Item to Requisition List.
 #### Example
 
 ```json
-{
-  "quote_item_uid": 4,
-  "quote_uid": "4",
-  "requisition_list_uid": 4
-}
+{"quote_item_uid": 4, "quote_uid": 4, "requisition_list_uid": 4}
 ```
 
 <HorizontalLine />
@@ -348,10 +346,10 @@ Contains details about a negotiable quote.
   "billing_address": NegotiableQuoteBillingAddress,
   "buyer": NegotiableQuoteUser,
   "comments": [NegotiableQuoteComment],
-  "created_at": "xyz789",
+  "created_at": "abc123",
   "custom_attributes": [CustomAttribute],
   "email": "abc123",
-  "expiration_date": "abc123",
+  "expiration_date": "xyz789",
   "history": [NegotiableQuoteHistoryEntry],
   "is_virtual": false,
   "items": [CartItemInterface],
@@ -362,11 +360,11 @@ Contains details about a negotiable quote.
   "selected_payment_method": SelectedPaymentMethod,
   "shipping_addresses": [NegotiableQuoteShippingAddress],
   "status": "SUBMITTED",
-  "template_id": 4,
-  "template_name": "xyz789",
-  "total_quantity": 987.65,
+  "template_id": "4",
+  "template_name": "abc123",
+  "total_quantity": 123.45,
   "uid": "4",
-  "updated_at": "xyz789"
+  "updated_at": "abc123"
 }
 ```
 
@@ -388,7 +386,7 @@ Defines the company's country.
 ```json
 {
   "code": "abc123",
-  "label": "abc123"
+  "label": "xyz789"
 }
 ```
 
@@ -424,23 +422,23 @@ Defines the billing or shipping address to be applied to the cart.
 
 ```json
 {
-  "city": "abc123",
+  "city": "xyz789",
   "company": "xyz789",
   "country_code": "xyz789",
   "custom_attributes": [AttributeValueInput],
-  "fax": "xyz789",
-  "firstname": "xyz789",
-  "lastname": "xyz789",
-  "middlename": "xyz789",
+  "fax": "abc123",
+  "firstname": "abc123",
+  "lastname": "abc123",
+  "middlename": "abc123",
   "postcode": "xyz789",
   "prefix": "xyz789",
   "region": "abc123",
-  "region_id": 987,
-  "save_in_address_book": true,
-  "street": ["abc123"],
-  "suffix": "xyz789",
-  "telephone": "abc123",
-  "vat_id": "xyz789"
+  "region_id": 123,
+  "save_in_address_book": false,
+  "street": ["xyz789"],
+  "suffix": "abc123",
+  "telephone": "xyz789",
+  "vat_id": "abc123"
 }
 ```
 
@@ -454,6 +452,7 @@ Defines the billing or shipping address to be applied to the cart.
 |------------|-------------|
 | `city` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The company's city or town. |
 | `company` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The company name associated with the shipping/billing address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of the company address referenced by this negotiable quote address, if any. |
 | `country` - [`NegotiableQuoteAddressCountry!`](#negotiablequoteaddresscountry) | The company's country. |
 | `custom_attributes` - [`[AttributeValueInterface]`](/reference/graphql/saas/types-a-b.md#attributevalueinterface) | The custom attribute values of the billing or shipping negotiable quote address. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID from the customer's address book that uniquely identifies the address. |
@@ -483,19 +482,20 @@ Defines the billing or shipping address to be applied to the cart.
 {
   "city": "abc123",
   "company": "xyz789",
+  "company_address_id": 4,
   "country": NegotiableQuoteAddressCountry,
   "custom_attributes": [AttributeValueInterface],
   "customer_address_uid": "4",
   "fax": "abc123",
   "firstname": "abc123",
   "lastname": "abc123",
-  "middlename": "abc123",
-  "postcode": "abc123",
+  "middlename": "xyz789",
+  "postcode": "xyz789",
   "prefix": "xyz789",
   "region": NegotiableQuoteAddressRegion,
   "street": ["xyz789"],
-  "suffix": "xyz789",
-  "telephone": "abc123",
+  "suffix": "abc123",
+  "telephone": "xyz789",
   "uid": 4,
   "vat_id": "abc123"
 }
@@ -521,7 +521,7 @@ Defines the company's state or province.
 {
   "code": "xyz789",
   "label": "xyz789",
-  "region_id": 123
+  "region_id": 987
 }
 ```
 
@@ -535,6 +535,7 @@ Defines the company's state or province.
 |------------|-------------|
 | `city` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The company's city or town. |
 | `company` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The company name associated with the shipping/billing address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of the company address referenced by this negotiable quote address, if any. |
 | `country` - [`NegotiableQuoteAddressCountry!`](#negotiablequoteaddresscountry) | The company's country. |
 | `custom_attributes` - [`[AttributeValueInterface]`](/reference/graphql/saas/types-a-b.md#attributevalueinterface) | The custom attribute values of the billing or shipping negotiable quote address. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID from the customer's address book that uniquely identifies the address. |
@@ -555,22 +556,23 @@ Defines the company's state or province.
 
 ```json
 {
-  "city": "abc123",
+  "city": "xyz789",
   "company": "xyz789",
+  "company_address_id": "4",
   "country": NegotiableQuoteAddressCountry,
   "custom_attributes": [AttributeValueInterface],
   "customer_address_uid": 4,
   "fax": "abc123",
   "firstname": "abc123",
-  "lastname": "abc123",
-  "middlename": "abc123",
+  "lastname": "xyz789",
+  "middlename": "xyz789",
   "postcode": "abc123",
   "prefix": "abc123",
   "region": NegotiableQuoteAddressRegion,
-  "street": ["xyz789"],
+  "street": ["abc123"],
   "suffix": "abc123",
-  "telephone": "xyz789",
-  "uid": 4,
+  "telephone": "abc123",
+  "uid": "4",
   "vat_id": "xyz789"
 }
 ```
@@ -586,6 +588,7 @@ Defines the billing address.
 | Input Field | Description |
 |-------------|-------------|
 | `address` - [`NegotiableQuoteAddressInput`](#negotiablequoteaddressinput) | Defines a billing address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of a company address to use as the billing address. Requires the company's address book to be enabled. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of a `CustomerAddress` object. |
 | `same_as_shipping` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether to set the billing address to be the same as the existing shipping address on the negotiable quote. |
 | `use_for_shipping` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether to set the shipping address to be the same as this billing address. |
@@ -595,8 +598,9 @@ Defines the billing address.
 ```json
 {
   "address": NegotiableQuoteAddressInput,
+  "company_address_id": 4,
   "customer_address_uid": 4,
-  "same_as_shipping": true,
+  "same_as_shipping": false,
   "use_for_shipping": true
 }
 ```
@@ -626,8 +630,8 @@ Contains a single plain text comment from either the buyer or seller.
   "author": NegotiableQuoteUser,
   "created_at": "abc123",
   "creator_type": "BUYER",
-  "text": "abc123",
-  "uid": 4
+  "text": "xyz789",
+  "uid": "4"
 }
 ```
 
@@ -648,7 +652,7 @@ Negotiable quote comment file attachment.
 
 ```json
 {
-  "name": "abc123",
+  "name": "xyz789",
   "url": "xyz789"
 }
 ```
@@ -828,9 +832,9 @@ Contains details about a change for a negotiable quote.
   "author": NegotiableQuoteUser,
   "change_type": "CREATED",
   "changes": NegotiableQuoteHistoryChanges,
-  "created_at": "xyz789",
+  "created_at": "abc123",
   "item_note": HistoryItemNoteData,
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -870,8 +874,8 @@ Contains a new expiration date and the previous date.
 
 ```json
 {
-  "new_expiration": "abc123",
-  "old_expiration": "xyz789"
+  "new_expiration": "xyz789",
+  "old_expiration": "abc123"
 }
 ```
 
@@ -892,7 +896,7 @@ Contains lists of products that have been removed from the catalog and negotiabl
 
 ```json
 {
-  "products_removed_from_catalog": ["4"],
+  "products_removed_from_catalog": [4],
   "products_removed_from_quote": [ProductInterface]
 }
 ```
@@ -971,7 +975,7 @@ An error indicating that an operation was attempted on a negotiable quote in an 
 #### Example
 
 ```json
-{"message": "abc123"}
+{"message": "xyz789"}
 ```
 
 <HorizontalLine />
@@ -990,7 +994,7 @@ Specifies the updated quantity of an item.
 #### Example
 
 ```json
-{"quantity": 123.45, "quote_item_uid": "4"}
+{"quantity": 987.65, "quote_item_uid": "4"}
 ```
 
 <HorizontalLine />
@@ -1010,7 +1014,7 @@ Defines the payment method to be applied to the negotiable quote.
 
 ```json
 {
-  "code": "xyz789",
+  "code": "abc123",
   "purchase_order_number": "xyz789"
 }
 ```
@@ -1035,9 +1039,9 @@ Contains a reference document link for a negotiable quote template.
 ```json
 {
   "document_identifier": "abc123",
-  "document_name": "xyz789",
+  "document_name": "abc123",
   "link_id": "4",
-  "reference_document_url": "xyz789"
+  "reference_document_url": "abc123"
 }
 ```
 
@@ -1052,6 +1056,7 @@ Contains a reference document link for a negotiable quote template.
 | `available_shipping_methods` - [`[AvailableShippingMethod]`](/reference/graphql/saas/types-a-b.md#availableshippingmethod) | An array of shipping methods available to the buyer. |
 | `city` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The company's city or town. |
 | `company` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The company name associated with the shipping/billing address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of the company address referenced by this negotiable quote address, if any. |
 | `country` - [`NegotiableQuoteAddressCountry!`](#negotiablequoteaddresscountry) | The company's country. |
 | `custom_attributes` - [`[AttributeValueInterface]`](/reference/graphql/saas/types-a-b.md#attributevalueinterface) | The custom attribute values of the billing or shipping negotiable quote address. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID from the customer's address book that uniquely identifies the address. |
@@ -1074,23 +1079,24 @@ Contains a reference document link for a negotiable quote template.
 ```json
 {
   "available_shipping_methods": [AvailableShippingMethod],
-  "city": "xyz789",
+  "city": "abc123",
   "company": "xyz789",
+  "company_address_id": "4",
   "country": NegotiableQuoteAddressCountry,
   "custom_attributes": [AttributeValueInterface],
-  "customer_address_uid": "4",
-  "fax": "xyz789",
+  "customer_address_uid": 4,
+  "fax": "abc123",
   "firstname": "abc123",
   "lastname": "xyz789",
   "middlename": "abc123",
-  "postcode": "abc123",
-  "prefix": "abc123",
+  "postcode": "xyz789",
+  "prefix": "xyz789",
   "region": NegotiableQuoteAddressRegion,
   "selected_shipping_method": SelectedShippingMethod,
   "street": ["abc123"],
   "suffix": "abc123",
   "telephone": "abc123",
-  "uid": 4,
+  "uid": "4",
   "vat_id": "abc123"
 }
 ```
@@ -1106,6 +1112,7 @@ Defines shipping addresses for the negotiable quote.
 | Input Field | Description |
 |-------------|-------------|
 | `address` - [`NegotiableQuoteAddressInput`](#negotiablequoteaddressinput) | A shipping address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of a company address to use as the shipping address. Requires the company's address book to be enabled. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | An ID from the company user's address book that uniquely identifies the address to be used for shipping. |
 | `customer_notes` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Text provided by the company user. |
 
@@ -1114,7 +1121,8 @@ Defines shipping addresses for the negotiable quote.
 ```json
 {
   "address": NegotiableQuoteAddressInput,
-  "customer_address_uid": "4",
+  "company_address_id": "4",
+  "customer_address_uid": 4,
   "customer_notes": "abc123"
 }
 ```
@@ -1220,11 +1228,11 @@ Contains details about a negotiable quote template.
   "buyer": NegotiableQuoteUser,
   "comments": [NegotiableQuoteComment],
   "created_at": "xyz789",
-  "expiration_date": "xyz789",
+  "expiration_date": "abc123",
   "history": [NegotiableQuoteHistoryEntry],
   "historyV2": [NegotiableQuoteTemplateHistoryEntry],
   "is_min_max_qty_used": true,
-  "is_virtual": false,
+  "is_virtual": true,
   "items": [CartItemInterface],
   "max_order_commitment": 987,
   "min_order_commitment": 123,
@@ -1236,11 +1244,11 @@ Contains details about a negotiable quote template.
   ],
   "sales_rep_name": "xyz789",
   "shipping_addresses": [NegotiableQuoteShippingAddress],
-  "status": "xyz789",
+  "status": "abc123",
   "template_id": "4",
   "total_quantity": 123.45,
   "uid": "4",
-  "updated_at": "abc123"
+  "updated_at": "xyz789"
 }
 ```
 
@@ -1301,24 +1309,24 @@ Contains data for a negotiable quote template in a grid.
 
 ```json
 {
-  "activated_at": "abc123",
-  "company_name": "xyz789",
+  "activated_at": "xyz789",
+  "company_name": "abc123",
   "created_at": "xyz789",
   "expiration_date": "xyz789",
-  "is_min_max_qty_used": false,
-  "last_ordered_at": "abc123",
-  "last_shared_at": "abc123",
-  "max_order_commitment": 123,
-  "min_negotiated_grand_total": 987.65,
-  "min_order_commitment": 987,
-  "name": "abc123",
+  "is_min_max_qty_used": true,
+  "last_ordered_at": "xyz789",
+  "last_shared_at": "xyz789",
+  "max_order_commitment": 987,
+  "min_negotiated_grand_total": 123.45,
+  "min_order_commitment": 123,
+  "name": "xyz789",
   "orders_placed": 123,
   "prices": CartPrices,
   "sales_rep_name": "abc123",
-  "state": "xyz789",
-  "status": "abc123",
+  "state": "abc123",
+  "status": "xyz789",
   "submitted_by": "abc123",
-  "template_id": 4,
+  "template_id": "4",
   "uid": 4,
   "updated_at": "abc123"
 }
@@ -1377,7 +1385,7 @@ Contains details about a change for a negotiable quote template.
   "author": NegotiableQuoteUser,
   "change_type": "CREATED",
   "changes": NegotiableQuoteTemplateHistoryChanges,
-  "created_at": "xyz789",
+  "created_at": "abc123",
   "uid": "4"
 }
 ```
@@ -1399,8 +1407,8 @@ Lists a new status change applied to a negotiable quote template and the previou
 
 ```json
 {
-  "new_status": "abc123",
-  "old_status": "abc123"
+  "new_status": "xyz789",
+  "old_status": "xyz789"
 }
 ```
 
@@ -1440,12 +1448,7 @@ Specifies the updated quantity of an item.
 #### Example
 
 ```json
-{
-  "item_id": "4",
-  "max_qty": 987.65,
-  "min_qty": 123.45,
-  "quantity": 123.45
-}
+{"item_id": 4, "max_qty": 987.65, "min_qty": 987.65, "quantity": 123.45}
 ```
 
 <HorizontalLine />
@@ -1468,8 +1471,8 @@ Defines the reference document link to add to a negotiable quote template.
 ```json
 {
   "document_identifier": "xyz789",
-  "document_name": "abc123",
-  "link_id": 4,
+  "document_name": "xyz789",
+  "link_id": "4",
   "reference_document_url": "abc123"
 }
 ```
@@ -1485,6 +1488,7 @@ Defines shipping addresses for the negotiable quote template.
 | Input Field | Description |
 |-------------|-------------|
 | `address` - [`NegotiableQuoteAddressInput`](#negotiablequoteaddressinput) | A shipping address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of a company address to use as the shipping address. Requires the company's address book to be enabled. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | An ID from the company user's address book that uniquely identifies the address to be used for shipping. |
 | `customer_notes` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Text provided by the company user. |
 
@@ -1493,6 +1497,7 @@ Defines shipping addresses for the negotiable quote template.
 ```json
 {
   "address": NegotiableQuoteAddressInput,
+  "company_address_id": 4,
   "customer_address_uid": 4,
   "customer_notes": "abc123"
 }
@@ -1556,7 +1561,7 @@ Contains a list of negotiable templates that match the specified filter.
   "items": [NegotiableQuoteTemplateGridItem],
   "page_info": SearchResultPageInfo,
   "sort_fields": SortFields,
-  "total_count": 987
+  "total_count": 123
 }
 ```
 
@@ -1579,7 +1584,7 @@ Contains a list of negotiable templates that match the specified filter.
 #### Example
 
 ```json
-{"quote_uid": "4"}
+{"quote_uid": 4}
 ```
 
 <HorizontalLine />
@@ -1617,8 +1622,8 @@ A limited view of a Buyer or Seller in the negotiable quote process.
 
 ```json
 {
-  "firstname": "abc123",
-  "lastname": "xyz789"
+  "firstname": "xyz789",
+  "lastname": "abc123"
 }
 ```
 
@@ -1665,8 +1670,73 @@ Contains an error message when an invalid UID was specified.
 
 ```json
 {
-  "message": "xyz789",
+  "message": "abc123",
   "uid": "4"
+}
+```
+
+<HorizontalLine />
+
+### NominatedSourceError
+
+Error wrapper describing the nomination state of a cart item.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `code` - [`NominatedSourceErrorCode!`](#nominatedsourceerrorcode) | Machine-readable error code. |
+| `message` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | Human-readable description of the error. |
+
+#### Example
+
+```json
+{
+  "code": "UNKNOWN_SOURCE",
+  "message": "xyz789"
+}
+```
+
+<HorizontalLine />
+
+### NominatedSourceErrorCode
+
+Reasons a nominated-source operation can fail for a given cart item.
+
+#### Values
+
+| Enum Value | Description |
+|------------|-------------|
+| `UNKNOWN_SOURCE` |  |
+| `SOURCE_DISABLED` |  |
+| `NOT_ENOUGH_QTY` |  |
+| `SKU_SOURCE_CONFLICT` |  |
+
+#### Example
+
+```json
+""UNKNOWN_SOURCE""
+```
+
+<HorizontalLine />
+
+### NominatedSourceItemInput
+
+A single cart item's source nomination.
+
+#### Input Fields
+
+| Input Field | Description |
+|-------------|-------------|
+| `cart_item_uid` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of the cart item to nominate a source for. |
+| `source_code` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The inventory source code to nominate. A null or empty value clears the nomination. |
+
+#### Example
+
+```json
+{
+  "cart_item_uid": 4,
+  "source_code": "xyz789"
 }
 ```
 
@@ -1763,7 +1833,7 @@ Specifies the quote template id to open quote template.
 #### Example
 
 ```json
-{"template_id": 4}
+{"template_id": "4"}
 ```
 
 <HorizontalLine />
@@ -1807,7 +1877,7 @@ Contains the order ID.
 #### Example
 
 ```json
-{"order_number": "xyz789"}
+{"order_number": "abc123"}
 ```
 
 <HorizontalLine />
@@ -1842,6 +1912,7 @@ Contains detailed information about an order's billing and shipping addresses.
 |------------|-------------|
 | `city` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The city or town. |
 | `company` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The customer's company. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | UID of the company address referenced by this order address, if any. |
 | `country_code` - [`CountryCodeEnum`](/reference/graphql/saas/types-c-e.md#countrycodeenum) | The customer's country. |
 | `custom_attributesV2` - [`[AttributeValueInterface]!`](/reference/graphql/saas/types-a-b.md#attributevalueinterface) | Custom attributes assigned to the customer address. |
 | `fax` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The fax number. |
@@ -1861,21 +1932,22 @@ Contains detailed information about an order's billing and shipping addresses.
 
 ```json
 {
-  "city": "xyz789",
+  "city": "abc123",
   "company": "abc123",
+  "company_address_id": "4",
   "country_code": "AF",
   "custom_attributesV2": [AttributeValueInterface],
-  "fax": "xyz789",
-  "firstname": "abc123",
+  "fax": "abc123",
+  "firstname": "xyz789",
   "lastname": "xyz789",
   "middlename": "xyz789",
-  "postcode": "xyz789",
-  "prefix": "xyz789",
+  "postcode": "abc123",
+  "prefix": "abc123",
   "region": "xyz789",
   "region_id": 4,
-  "street": ["abc123"],
-  "suffix": "abc123",
-  "telephone": "xyz789",
+  "street": ["xyz789"],
+  "suffix": "xyz789",
+  "telephone": "abc123",
   "vat_id": "abc123"
 }
 ```
@@ -1898,11 +1970,11 @@ Contains detailed information about an order's billing and shipping addresses.
 
 ```json
 {
-  "firstname": "xyz789",
-  "lastname": "xyz789",
+  "firstname": "abc123",
+  "lastname": "abc123",
   "middlename": "xyz789",
-  "prefix": "abc123",
-  "suffix": "abc123"
+  "prefix": "xyz789",
+  "suffix": "xyz789"
 }
 ```
 
@@ -1918,6 +1990,7 @@ Contains detailed information about an order's billing and shipping addresses.
 | `discounts` - [`[Discount]`](/reference/graphql/saas/types-c-e.md#discount) | The final discount information for the product. |
 | `eligible_for_return` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the order item is eligible to be in a return request. |
 | `entered_options` - [`[OrderItemOption]`](#orderitemoption) | The entered option for the base product, such as a logo or image. |
+| `free_gift_label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The discount rule label for free gift items. Null if the item is not a free gift. |
 | `gift_message` - [`GiftMessage`](/reference/graphql/saas/types-f-i.md#giftmessage) | The selected gift message for the order item |
 | `gift_wrapping` - [`GiftWrapping`](/reference/graphql/saas/types-f-i.md#giftwrapping) | The selected gift wrapping for the order item. |
 | `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID for an `OrderItemInterface` object. |
@@ -1946,6 +2019,7 @@ Contains detailed information about an order's billing and shipping addresses.
   "discounts": [Discount],
   "eligible_for_return": false,
   "entered_options": [OrderItemOption],
+  "free_gift_label": "abc123",
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
   "id": "4",
@@ -1953,16 +2027,16 @@ Contains detailed information about an order's billing and shipping addresses.
   "product": ProductInterface,
   "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "abc123",
+  "product_sku": "xyz789",
   "product_type": "abc123",
-  "product_url_key": "xyz789",
-  "quantity_canceled": 123.45,
+  "product_url_key": "abc123",
+  "quantity_canceled": 987.65,
   "quantity_invoiced": 123.45,
-  "quantity_ordered": 123.45,
+  "quantity_ordered": 987.65,
   "quantity_refunded": 987.65,
   "quantity_return_requested": 987.65,
   "quantity_returned": 123.45,
-  "quantity_shipped": 123.45,
+  "quantity_shipped": 987.65,
   "selected_options": [OrderItemOption],
   "status": "abc123"
 }
@@ -1982,6 +2056,7 @@ Order item details.
 | `discounts` - [`[Discount]`](/reference/graphql/saas/types-c-e.md#discount) | The final discount information for the product. |
 | `eligible_for_return` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the order item is eligible to be in a return request. |
 | `entered_options` - [`[OrderItemOption]`](#orderitemoption) | The entered option for the base product, such as a logo or image. |
+| `free_gift_label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The discount rule label for free gift items. Null if the item is not a free gift. |
 | `gift_message` - [`GiftMessage`](/reference/graphql/saas/types-f-i.md#giftmessage) | The selected gift message for the order item |
 | `gift_wrapping` - [`GiftWrapping`](/reference/graphql/saas/types-f-i.md#giftwrapping) | The selected gift wrapping for the order item. |
 | `id` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID for an `OrderItemInterface` object. |
@@ -2018,16 +2093,17 @@ Order item details.
 {
   "custom_attributes": [CustomAttribute],
   "discounts": [Discount],
-  "eligible_for_return": false,
+  "eligible_for_return": true,
   "entered_options": [OrderItemOption],
+  "free_gift_label": "abc123",
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
-  "id": "4",
+  "id": 4,
   "prices": OrderItemPrices,
   "product": ProductInterface,
-  "product_name": "abc123",
+  "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "xyz789",
+  "product_sku": "abc123",
   "product_type": "xyz789",
   "product_url_key": "abc123",
   "quantity_canceled": 123.45,
@@ -2035,10 +2111,10 @@ Order item details.
   "quantity_ordered": 123.45,
   "quantity_refunded": 123.45,
   "quantity_return_requested": 123.45,
-  "quantity_returned": 987.65,
-  "quantity_shipped": 123.45,
+  "quantity_returned": 123.45,
+  "quantity_shipped": 987.65,
   "selected_options": [OrderItemOption],
-  "status": "abc123"
+  "status": "xyz789"
 }
 ```
 
@@ -2059,7 +2135,7 @@ Represents order item options like selected or entered.
 
 ```json
 {
-  "label": "xyz789",
+  "label": "abc123",
   "value": "xyz789"
 }
 ```
@@ -2121,7 +2197,7 @@ Contains details about the payment method used to pay for the order.
 ```json
 {
   "additional_data": [KeyValue],
-  "name": "abc123",
+  "name": "xyz789",
   "type": "xyz789"
 }
 ```
@@ -2147,9 +2223,9 @@ Contains order shipment details.
 ```json
 {
   "comments": [SalesCommentItem],
-  "id": "4",
+  "id": 4,
   "items": [ShipmentItemInterface],
-  "number": "xyz789",
+  "number": "abc123",
   "tracking": [ShipmentTracking]
 }
 ```
@@ -2243,6 +2319,24 @@ Type of page on which recommendations are requested
 
 <HorizontalLine />
 
+### PayByLinkCartOutput
+
+Result of payByLinkCart.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `masked_cart_id` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | Masked id of the guest cart to resume the standard checkout against. |
+
+#### Example
+
+```json
+{"masked_cart_id": "xyz789"}
+```
+
+<HorizontalLine />
+
 ### PaymentAttributeInput
 
 Defines the payment attribute.
@@ -2258,7 +2352,7 @@ Defines the payment attribute.
 
 ```json
 {
-  "key": "abc123",
+  "key": "xyz789",
   "value": "xyz789"
 }
 ```
@@ -2295,10 +2389,10 @@ Contains payment fields that are common to all types of payment methods.
 ```json
 {
   "code": "xyz789",
-  "is_visible": false,
+  "is_visible": true,
   "payment_intent": "xyz789",
   "sdk_params": [SDKParams],
-  "sort_order": "xyz789",
+  "sort_order": "abc123",
   "title": "xyz789"
 }
 ```
@@ -2386,7 +2480,7 @@ Defines the payment method.
   "payment_services_paypal_hosted_fields": HostedFieldsInput,
   "payment_services_paypal_smart_buttons": SmartButtonMethodInput,
   "payment_services_paypal_vault": VaultMethodInput,
-  "purchase_order_number": "xyz789"
+  "purchase_order_number": "abc123"
 }
 ```
 
@@ -2431,7 +2525,7 @@ Contains the payment order details
 
 ```json
 {
-  "code": "abc123",
+  "code": "xyz789",
   "params": [SDKParams]
 }
 ```
@@ -2507,8 +2601,8 @@ The stored payment method available to the customer.
 
 ```json
 {
-  "details": "abc123",
-  "payment_method_code": "abc123",
+  "details": "xyz789",
+  "payment_method_code": "xyz789",
   "public_hash": "abc123",
   "type": "card"
 }
@@ -2596,16 +2690,16 @@ Defines Pickup Location information.
   "country_id": "xyz789",
   "description": "abc123",
   "email": "xyz789",
-  "fax": "xyz789",
+  "fax": "abc123",
   "latitude": 123.45,
   "longitude": 123.45,
-  "name": "xyz789",
-  "phone": "abc123",
+  "name": "abc123",
+  "phone": "xyz789",
   "pickup_location_code": "abc123",
-  "postcode": "abc123",
-  "region": "abc123",
+  "postcode": "xyz789",
+  "region": "xyz789",
   "region_id": 987,
-  "street": "abc123"
+  "street": "xyz789"
 }
 ```
 
@@ -2732,7 +2826,7 @@ Specifies the negotiable quote to convert to an order.
 #### Example
 
 ```json
-{"quote_uid": "4"}
+{"quote_uid": 4}
 ```
 
 <HorizontalLine />
@@ -2832,7 +2926,7 @@ Specifies the purchase order to convert to an order.
 #### Example
 
 ```json
-{"purchase_order_uid": 4}
+{"purchase_order_uid": "4"}
 ```
 
 <HorizontalLine />
@@ -2868,7 +2962,7 @@ Specifies the quote to be converted to an order.
 #### Example
 
 ```json
-{"cart_id": "xyz789"}
+{"cart_id": "abc123"}
 ```
 
 <HorizontalLine />
@@ -2881,7 +2975,7 @@ Contains the results of the request to place an order.
 
 | Field Name | Description |
 |------------|-------------|
-| `errors` - [`[PlaceOrderError]!`](#placeordererror) | An array of place order errors. |
+| `errors` - [`[PlaceOrderError]`](#placeordererror) | An array of place order errors. |
 | `orderV2` - [`CustomerOrder`](/reference/graphql/saas/types-c-e.md#customerorder) | Full order information. |
 
 #### Example
@@ -2908,7 +3002,7 @@ Specifies the quote to be converted to a purchase order.
 #### Example
 
 ```json
-{"cart_id": "xyz789"}
+{"cart_id": "abc123"}
 ```
 
 <HorizontalLine />
@@ -2967,7 +3061,7 @@ Specifies the amount and type of price adjustment.
 #### Example
 
 ```json
-{"amount": 123.45, "code": "abc123"}
+{"amount": 987.65, "code": "abc123"}
 ```
 
 <HorizontalLine />
@@ -2988,9 +3082,9 @@ Can be used to retrieve the main price details in case of bundle product
 
 ```json
 {
-  "discount_percentage": 987.65,
-  "main_final_price": 123.45,
-  "main_price": 987.65
+  "discount_percentage": 123.45,
+  "main_final_price": 987.65,
+  "main_price": 123.45
 }
 ```
 
@@ -3059,27 +3153,31 @@ Defines whether a bundle product's price is displayed as the lowest possible val
 
 ### ProductAlertPriceInput
 
+Input to identify a product by SKU for a price alert subscription.
+
 #### Input Fields
 
 | Input Field | Description |
 |-------------|-------------|
-| `sku` - [`String!`](/reference/graphql/saas/types-q-s.md#string) |  |
+| `sku` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The SKU of the product to subscribe to price alerts for. |
 
 #### Example
 
 ```json
-{"sku": "abc123"}
+{"sku": "xyz789"}
 ```
 
 <HorizontalLine />
 
 ### ProductAlertStockInput
 
+Input to identify a product by SKU for a stock alert subscription.
+
 #### Input Fields
 
 | Input Field | Description |
 |-------------|-------------|
-| `sku` - [`String!`](/reference/graphql/saas/types-q-s.md#string) |  |
+| `sku` - [`String!`](/reference/graphql/saas/types-q-s.md#string) | The SKU of the product to subscribe to stock alerts for. |
 
 #### Example
 
@@ -3091,17 +3189,19 @@ Defines whether a bundle product's price is displayed as the lowest possible val
 
 ### ProductAlertSubscriptionResult
 
+Response returned after a product alert subscribe or unsubscribe mutation.
+
 #### Fields
 
 | Field Name | Description |
 |------------|-------------|
-| `message` - [`String`](/reference/graphql/saas/types-q-s.md#string) |  |
-| `success` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) |  |
+| `message` - [`String`](/reference/graphql/saas/types-q-s.md#string) | A human-readable message describing the result of the subscription action. |
+| `success` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the subscription action was successful. |
 
 #### Example
 
 ```json
-{"message": "xyz789", "success": false}
+{"message": "abc123", "success": true}
 ```
 
 <HorizontalLine />
@@ -3121,8 +3221,8 @@ Contains a product attribute code and value.
 
 ```json
 {
-  "code": "xyz789",
-  "value": "xyz789"
+  "code": "abc123",
+  "value": "abc123"
 }
 ```
 
@@ -3144,7 +3244,7 @@ Contains a product attribute code and value.
 ```json
 {
   "attribute_type": "abc123",
-  "code": 4,
+  "code": "4",
   "url": "abc123",
   "value": "abc123"
 }
@@ -3188,7 +3288,7 @@ Contains the discount applied to a product price.
 #### Example
 
 ```json
-{"amount_off": 123.45, "percent_off": 987.65}
+{"amount_off": 987.65, "percent_off": 987.65}
 ```
 
 <HorizontalLine />
@@ -3204,16 +3304,18 @@ Contains product image information, including the image URL and label.
 | `disabled` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the image is hidden from view. |
 | `label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The label of the product image or video. |
 | `position` - [`Int`](/reference/graphql/saas/types-f-i.md#int) | The media item's position after it has been sorted. |
+| `types` - [`[String]`](/reference/graphql/saas/types-q-s.md#string) | Array of image types. It can have the following values: image, small_image, thumbnail. |
 | `url` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The URL of the product image or video. |
 
 #### Example
 
 ```json
 {
-  "disabled": true,
+  "disabled": false,
   "label": "xyz789",
   "position": 123,
-  "url": "abc123"
+  "types": ["abc123"],
+  "url": "xyz789"
 }
 ```
 
@@ -3318,7 +3420,7 @@ Contains fields that are common to all types of products.
 
 ```json
 {
-  "canonical_url": "abc123",
+  "canonical_url": "xyz789",
   "categories": [CategoryInterface],
   "country_of_manufacture": "abc123",
   "crosssell_products": [ProductInterface],
@@ -3328,33 +3430,33 @@ Contains fields that are common to all types of products.
   "gift_wrapping_available": true,
   "gift_wrapping_price": Money,
   "image": ProductImage,
-  "is_returnable": "xyz789",
+  "is_returnable": "abc123",
   "manufacturer": 123,
-  "max_sale_qty": 987.65,
+  "max_sale_qty": 123.45,
   "media_gallery": [MediaGalleryInterface],
   "meta_description": "xyz789",
   "meta_keyword": "abc123",
-  "meta_title": "abc123",
+  "meta_title": "xyz789",
   "min_sale_qty": 123.45,
   "name": "xyz789",
-  "new_from_date": "abc123",
+  "new_from_date": "xyz789",
   "new_to_date": "xyz789",
-  "only_x_left_in_stock": 123.45,
-  "options_container": "abc123",
+  "only_x_left_in_stock": 987.65,
+  "options_container": "xyz789",
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
   "product_links": [ProductLinksInterface],
   "quantity": 987.65,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
-  "sku": "xyz789",
+  "sku": "abc123",
   "small_image": ProductImage,
   "special_price": 987.65,
-  "special_to_date": "xyz789",
+  "special_to_date": "abc123",
   "stock_status": "IN_STOCK",
-  "swatch_image": "xyz789",
+  "swatch_image": "abc123",
   "thumbnail": ProductImage,
-  "uid": 4,
+  "uid": "4",
   "upsell_products": [ProductInterface],
   "url_key": "xyz789"
 }
@@ -3384,7 +3486,7 @@ An implementation of `ProductLinksInterface`.
   "linked_product_sku": "abc123",
   "linked_product_type": "abc123",
   "position": 123,
-  "sku": "abc123"
+  "sku": "xyz789"
 }
 ```
 
@@ -3415,9 +3517,9 @@ Contains information about linked products, including the link type and product 
 ```json
 {
   "link_type": "xyz789",
-  "linked_product_sku": "abc123",
+  "linked_product_sku": "xyz789",
   "linked_product_type": "abc123",
-  "position": 987,
+  "position": 123,
   "sku": "abc123"
 }
 ```
@@ -3464,8 +3566,8 @@ Contains basic information about the video asset.
 
 ```json
 {
-  "media_type": "xyz789",
-  "video_asset_id": "abc123",
+  "media_type": "abc123",
+  "video_asset_id": "xyz789",
   "video_media_url": "abc123"
 }
 ```
@@ -3491,11 +3593,11 @@ Contains a link to a video file and basic information about the video.
 
 ```json
 {
-  "media_type": "xyz789",
-  "video_description": "xyz789",
+  "media_type": "abc123",
+  "video_description": "abc123",
   "video_metadata": "xyz789",
   "video_provider": "abc123",
-  "video_title": "xyz789",
+  "video_title": "abc123",
   "video_url": "xyz789"
 }
 ```
@@ -3575,9 +3677,9 @@ Contains the output of a `productSearch` query
   "facets": [Aggregation],
   "items": [ProductSearchItem],
   "page_info": SearchResultPageInfo,
-  "related_terms": ["abc123"],
-  "suggestions": ["abc123"],
-  "total_count": 987,
+  "related_terms": ["xyz789"],
+  "suggestions": ["xyz789"],
+  "total_count": 123,
   "warnings": [ProductSearchWarning]
 }
 ```
@@ -3598,7 +3700,7 @@ The product attribute to sort on
 #### Example
 
 ```json
-{"attribute": "xyz789", "direction": "ASC"}
+{"attribute": "abc123", "direction": "ASC"}
 ```
 
 <HorizontalLine />
@@ -3619,7 +3721,7 @@ Structured warning with code and message for easier client handling
 ```json
 {
   "code": "xyz789",
-  "message": "xyz789"
+  "message": "abc123"
 }
 ```
 
@@ -3655,6 +3757,7 @@ Contains information about a product video.
 | `disabled` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the image is hidden from view. |
 | `label` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The label of the product image or video. |
 | `position` - [`Int`](/reference/graphql/saas/types-f-i.md#int) | The media item's position after it has been sorted. |
+| `types` - [`[String]`](/reference/graphql/saas/types-q-s.md#string) | Array of image types. It can have the following values: image, small_image, thumbnail. |
 | `url` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The URL of the product image or video. |
 | `video_content` - [`ProductMediaGalleryEntriesVideoContent`](#productmediagalleryentriesvideocontent) | Contains a `ProductMediaGalleryEntriesVideoContent` object. |
 
@@ -3663,8 +3766,9 @@ Contains information about a product video.
 ```json
 {
   "disabled": false,
-  "label": "xyz789",
+  "label": "abc123",
   "position": 123,
+  "types": ["xyz789"],
   "url": "abc123",
   "video_content": ProductMediaGalleryEntriesVideoContent
 }
@@ -3697,6 +3801,7 @@ Defines the product fields available to the SimpleProductView and ComplexProduct
 | `inputOptions` - [`[ProductViewInputOption]`](#productviewinputoption) | A list of input options. For example, a text field, a number field or a date field. *(Deprecated: This field is deprecated and will be removed.)* |
 | `sku` - [`String`](/reference/graphql/saas/types-q-s.md#string) | A unique code used for identification of a product. |
 | `externalId` - [`String`](/reference/graphql/saas/types-q-s.md#string) | External Id *(Deprecated: This field is deprecated and will be removed.)* |
+| `externalIds` - [`[ExternalId]`](/reference/graphql/saas/types-c-e.md#externalid) | External Ids |
 | `url` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Canonical URL of the product. *(Deprecated: This field is deprecated and will be removed.)* |
 | `urlKey` - [`String`](/reference/graphql/saas/types-q-s.md#string) | The URL key of the product. This is a unique identifier for the product that is used to create the product's URL. |
 | `links` - [`[ProductViewLink]`](#productviewlink) | A list of product links. For example, related, up-sell, and cross-sell links. |
@@ -3714,28 +3819,29 @@ Defines the product fields available to the SimpleProductView and ComplexProduct
 
 ```json
 {
-  "addToCartAllowed": true,
-  "inStock": false,
+  "addToCartAllowed": false,
+  "inStock": true,
   "lowStock": false,
   "attributes": [ProductViewAttribute],
-  "description": "abc123",
-  "id": "4",
+  "description": "xyz789",
+  "id": 4,
   "images": [ProductViewImage],
   "videos": [ProductViewVideo],
   "lastModifiedAt": "2007-12-03T10:15:30Z",
   "metaDescription": "abc123",
-  "metaKeyword": "abc123",
-  "metaTitle": "xyz789",
+  "metaKeyword": "xyz789",
+  "metaTitle": "abc123",
   "name": "abc123",
-  "shortDescription": "xyz789",
+  "shortDescription": "abc123",
   "inputOptions": [ProductViewInputOption],
   "sku": "xyz789",
-  "externalId": "xyz789",
-  "url": "xyz789",
-  "urlKey": "abc123",
+  "externalId": "abc123",
+  "externalIds": [ExternalId],
+  "url": "abc123",
+  "urlKey": "xyz789",
   "links": [ProductViewLink],
-  "queryType": "abc123",
-  "visibility": "xyz789"
+  "queryType": "xyz789",
+  "visibility": "abc123"
 }
 ```
 
@@ -3759,7 +3865,7 @@ A container for customer-defined attributes that are displayed the storefront.
 ```json
 {
   "label": "xyz789",
-  "name": "xyz789",
+  "name": "abc123",
   "roles": ["xyz789"],
   "value": {}
 }
@@ -3971,7 +4077,7 @@ Contains details about a product image.
 ```json
 {
   "label": "xyz789",
-  "roles": ["xyz789"],
+  "roles": ["abc123"],
   "url": "xyz789"
 }
 ```
@@ -4002,15 +4108,15 @@ Product options provide a way to configure products by making selections of part
 ```json
 {
   "id": 4,
-  "title": "abc123",
-  "required": true,
-  "type": "xyz789",
+  "title": "xyz789",
+  "required": false,
+  "type": "abc123",
   "markupAmount": 123.45,
   "suffix": "abc123",
-  "sortOrder": 987,
+  "sortOrder": 123,
   "range": ProductViewInputOptionRange,
   "imageSize": ProductViewInputOptionImageSize,
-  "fileExtensions": "abc123"
+  "fileExtensions": "xyz789"
 }
 ```
 
@@ -4030,7 +4136,7 @@ Dimensions of the image associated with the input option.
 #### Example
 
 ```json
-{"width": 123, "height": 987}
+{"width": 987, "height": 987}
 ```
 
 <HorizontalLine />
@@ -4049,7 +4155,7 @@ Lists the value range associated with a `ProductViewInputOption`. For example, i
 #### Example
 
 ```json
-{"from": 123.45, "to": 987.65}
+{"from": 987.65, "to": 987.65}
 ```
 
 <HorizontalLine />
@@ -4070,7 +4176,7 @@ The product link type. Contains details about product links for related products
 ```json
 {
   "product": ProductView,
-  "linkTypes": ["xyz789"]
+  "linkTypes": ["abc123"]
 }
 ```
 
@@ -4090,7 +4196,7 @@ Defines a monetary value, including a numeric value and a currency code.
 #### Example
 
 ```json
-{"currency": "AED", "value": 123.45}
+{"currency": "AED", "value": 987.65}
 ```
 
 <HorizontalLine />
@@ -4114,9 +4220,9 @@ Product options provide a way to configure products by making selections of part
 ```json
 {
   "id": "4",
-  "multi": false,
+  "multi": true,
   "required": false,
-  "title": "xyz789",
+  "title": "abc123",
   "values": [ProductViewOptionValue]
 }
 ```
@@ -4147,8 +4253,8 @@ Defines the product fields available to the ProductViewOptionValueProduct and Pr
 
 ```json
 {
-  "id": 4,
-  "title": "xyz789",
+  "id": "4",
+  "title": "abc123",
   "inStock": true
 }
 ```
@@ -4171,8 +4277,8 @@ An implementation of ProductViewOptionValue for configuration values.
 
 ```json
 {
-  "id": 4,
-  "title": "xyz789",
+  "id": "4",
+  "title": "abc123",
   "inStock": false
 }
 ```
@@ -4200,12 +4306,12 @@ An implementation of ProductViewOptionValue that adds details about a simple pro
 ```json
 {
   "id": "4",
-  "isDefault": false,
+  "isDefault": true,
   "product": SimpleProductView,
   "quantity": 987.65,
   "canEditQuantity": false,
-  "title": "abc123",
-  "inStock": true
+  "title": "xyz789",
+  "inStock": false
 }
 ```
 
@@ -4229,11 +4335,11 @@ An implementation of ProductViewOptionValueSwatch for swatches.
 
 ```json
 {
-  "id": 4,
+  "id": "4",
   "title": "abc123",
   "type": "TEXT",
   "value": "xyz789",
-  "inStock": true
+  "inStock": false
 }
 ```
 
@@ -4317,7 +4423,7 @@ Minimum quantity (inclusive) required to activate this tier price. For example, 
 #### Example
 
 ```json
-{"in": [123.45]}
+{"in": [987.65]}
 ```
 
 <HorizontalLine />
@@ -4358,7 +4464,7 @@ Minimum quantity (inclusive) required to activate this tier price. For example, 
 #### Example
 
 ```json
-{"gte": 987.65, "lt": 123.45}
+{"gte": 123.45, "lt": 123.45}
 ```
 
 <HorizontalLine />
@@ -4425,8 +4531,8 @@ Contains details about a product video. For example, a video of the product bein
 ```json
 {
   "preview": ProductViewImage,
-  "url": "abc123",
-  "description": "abc123",
+  "url": "xyz789",
+  "description": "xyz789",
   "title": "abc123"
 }
 ```
@@ -4449,7 +4555,7 @@ User purchase history
 ```json
 {
   "date": "2007-12-03T10:15:30Z",
-  "items": ["abc123"]
+  "items": ["xyz789"]
 }
 ```
 
@@ -4486,12 +4592,12 @@ Contains details about a purchase order.
   "created_at": "xyz789",
   "created_by": Customer,
   "history_log": [PurchaseOrderHistoryItem],
-  "number": "xyz789",
+  "number": "abc123",
   "order": CustomerOrder,
   "quote": Cart,
   "status": "PENDING",
   "uid": 4,
-  "updated_at": "xyz789"
+  "updated_at": "abc123"
 }
 ```
 
@@ -4554,9 +4660,9 @@ Contains details about a single event in the approval flow of the purchase order
 
 ```json
 {
-  "message": "xyz789",
+  "message": "abc123",
   "name": "xyz789",
-  "role": "abc123",
+  "role": "xyz789",
   "status": "PENDING",
   "updated_at": "xyz789"
 }
@@ -4608,13 +4714,13 @@ Contains details about a purchase order approval rule.
   "applies_to_roles": [CompanyRole],
   "approver_roles": [CompanyRole],
   "condition": PurchaseOrderApprovalRuleConditionInterface,
-  "created_at": "abc123",
-  "created_by": "xyz789",
+  "created_at": "xyz789",
+  "created_by": "abc123",
   "description": "xyz789",
   "name": "abc123",
   "status": "ENABLED",
   "uid": 4,
-  "updated_at": "abc123"
+  "updated_at": "xyz789"
 }
 ```
 
@@ -4704,7 +4810,7 @@ Contains approval rule condition details, including the quantity to be evaluated
 #### Example
 
 ```json
-{"attribute": "GRAND_TOTAL", "operator": "MORE_THAN", "quantity": 123}
+{"attribute": "GRAND_TOTAL", "operator": "MORE_THAN", "quantity": 987}
 ```
 
 <HorizontalLine />
@@ -4728,11 +4834,11 @@ Defines a new purchase order approval rule.
 
 ```json
 {
-  "applies_to": ["4"],
-  "approvers": [4],
+  "applies_to": [4],
+  "approvers": ["4"],
   "condition": CreatePurchaseOrderApprovalRuleConditionInput,
   "description": "xyz789",
-  "name": "xyz789",
+  "name": "abc123",
   "status": "ENABLED"
 }
 ```
@@ -4840,8 +4946,8 @@ Contains details about a comment.
 ```json
 {
   "author": Customer,
-  "created_at": "abc123",
-  "text": "xyz789",
+  "created_at": "xyz789",
+  "text": "abc123",
   "uid": "4"
 }
 ```
@@ -4885,10 +4991,10 @@ Contains details about a status change.
 
 ```json
 {
-  "activity": "abc123",
-  "created_at": "xyz789",
+  "activity": "xyz789",
+  "created_at": "abc123",
   "message": "xyz789",
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -4977,7 +5083,7 @@ Defines which purchase orders to act on.
 #### Example
 
 ```json
-{"purchase_order_uids": ["4"]}
+{"purchase_order_uids": [4]}
 ```
 
 <HorizontalLine />
@@ -5022,10 +5128,10 @@ Defines the criteria to use to filter the list of purchase orders.
 
 ```json
 {
-  "company_purchase_orders": false,
+  "company_purchase_orders": true,
   "created_date": FilterRangeTypeInput,
   "my_approvals": true,
-  "require_my_approval": true,
+  "require_my_approval": false,
   "status": "PENDING"
 }
 ```

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-q-s.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-q-s.md
@@ -13,7 +13,7 @@
 
 ```json
 {
-  "customerGroup": "abc123",
+  "customerGroup": "xyz789",
   "userViewHistory": [ViewHistoryInput]
 }
 ```
@@ -55,7 +55,7 @@ Sets quote template expiration date.
 ```json
 {
   "expiration_date": "xyz789",
-  "template_id": "4"
+  "template_id": 4
 }
 ```
 
@@ -103,7 +103,7 @@ Contains a notification message for a negotiable quote template.
 ```json
 {
   "message": "xyz789",
-  "type": "xyz789"
+  "type": "abc123"
 }
 ```
 
@@ -128,7 +128,7 @@ For use on numeric product fields
 {
   "count": 987,
   "from": 987.65,
-  "title": "abc123",
+  "title": "xyz789",
   "to": 123.45
 }
 ```
@@ -183,7 +183,7 @@ For use on numeric product fields
 #### Example
 
 ```json
-{"from": 123.45, "to": 123.45}
+{"from": 987.65, "to": 123.45}
 ```
 
 <HorizontalLine />
@@ -230,13 +230,13 @@ Contains reCAPTCHA form configuration details.
 ```json
 {
   "badge_position": "xyz789",
-  "language_code": "abc123",
+  "language_code": "xyz789",
   "minimum_score": 987.65,
   "re_captcha_type": "INVISIBLE",
   "technical_failure_message": "xyz789",
-  "theme": "xyz789",
+  "theme": "abc123",
   "validation_failure_message": "abc123",
-  "website_key": "xyz789"
+  "website_key": "abc123"
 }
 ```
 
@@ -263,14 +263,14 @@ Contains reCAPTCHA V3-Invisible configuration details.
 
 ```json
 {
-  "badge_position": "xyz789",
+  "badge_position": "abc123",
   "failure_message": "xyz789",
   "forms": ["PLACE_ORDER"],
-  "is_enabled": true,
+  "is_enabled": false,
   "language_code": "abc123",
-  "minimum_score": 987.65,
+  "minimum_score": 123.45,
   "theme": "xyz789",
-  "website_key": "xyz789"
+  "website_key": "abc123"
 }
 ```
 
@@ -294,7 +294,7 @@ Contains reCAPTCHA configuration for a specific form type.
 {
   "configurations": ReCaptchaConfiguration,
   "form_type": "PLACE_ORDER",
-  "is_enabled": false
+  "is_enabled": true
 }
 ```
 
@@ -317,6 +317,7 @@ Contains reCAPTCHA configuration for a specific form type.
 | `SENDFRIEND` |  |
 | `BRAINTREE` |  |
 | `RESEND_CONFIRMATION_EMAIL` |  |
+| `COMPANY_CREATE` | Create new company account form. |
 
 #### Example
 
@@ -361,6 +362,7 @@ Recommendation Unit containing product and other details
 | `typeId` - [`String`](#string) | Type of recommendation |
 | `unitId` - [`String`](#string) | Id of the preconfigured unit |
 | `unitName` - [`String`](#string) | Name of the preconfigured unit |
+| `label` - [`String`](#string) | Label of the preconfigured unit |
 | `userError` - [`String`](#string) | User error message if the unit could not be fully resolved (e.g. required currentSku was not provided) |
 
 #### Example
@@ -368,14 +370,15 @@ Recommendation Unit containing product and other details
 ```json
 {
   "displayOrder": 987,
-  "pageType": "xyz789",
+  "pageType": "abc123",
   "productsView": [ProductView],
-  "storefrontLabel": "xyz789",
+  "storefrontLabel": "abc123",
   "totalProducts": 987,
-  "typeId": "abc123",
+  "typeId": "xyz789",
   "unitId": "abc123",
   "unitName": "abc123",
-  "userError": "xyz789"
+  "label": "xyz789",
+  "userError": "abc123"
 }
 ```
 
@@ -416,7 +419,35 @@ Recommendations response
 {
   "code": "xyz789",
   "id": 987,
-  "name": "abc123"
+  "name": "xyz789"
+}
+```
+
+<HorizontalLine />
+
+### RejectedNomination
+
+A single cart item whose source nomination was rejected.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `available_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | The quantity available at the nominated source, when applicable. |
+| `cart_item_uid` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique ID of the cart item the nomination was requested for. |
+| `code` - [`NominatedSourceErrorCode!`](/reference/graphql/saas/types-k-p.md#nominatedsourceerrorcode) | Machine-readable reason the nomination was rejected. |
+| `message` - [`String!`](#string) | Human-readable description of the rejection. |
+| `requested_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | The quantity requested at the nominated source, when applicable. |
+
+#### Example
+
+```json
+{
+  "available_qty": 987.65,
+  "cart_item_uid": 4,
+  "code": "UNKNOWN_SOURCE",
+  "message": "abc123",
+  "requested_qty": 123.45
 }
 ```
 
@@ -435,7 +466,7 @@ Specifies the cart from which to remove a coupon.
 #### Example
 
 ```json
-{"cart_id": "xyz789"}
+{"cart_id": "abc123"}
 ```
 
 <HorizontalLine />
@@ -474,7 +505,7 @@ Remove coupons from the cart.
 ```json
 {
   "cart_id": "abc123",
-  "coupon_codes": ["xyz789"]
+  "coupon_codes": ["abc123"]
 }
 ```
 
@@ -496,7 +527,7 @@ Defines the input required to run the `removeGiftCardFromCart` mutation.
 ```json
 {
   "cart_id": "abc123",
-  "gift_card_code": "xyz789"
+  "gift_card_code": "abc123"
 }
 ```
 
@@ -551,7 +582,7 @@ Contains the results of a request to delete a gift registry.
 #### Example
 
 ```json
-{"success": true}
+{"success": false}
 ```
 
 <HorizontalLine />
@@ -588,7 +619,10 @@ Specifies which items to remove from the cart.
 #### Example
 
 ```json
-{"cart_id": "xyz789", "cart_item_uid": 4}
+{
+  "cart_id": "xyz789",
+  "cart_item_uid": "4"
+}
 ```
 
 <HorizontalLine />
@@ -625,7 +659,7 @@ Defines the items to remove from the specified negotiable quote.
 #### Example
 
 ```json
-{"quote_item_uids": [4], "quote_uid": 4}
+{"quote_item_uids": [4], "quote_uid": "4"}
 ```
 
 <HorizontalLine />
@@ -662,7 +696,7 @@ Defines the items to remove from the specified negotiable quote.
 #### Example
 
 ```json
-{"item_uids": ["4"], "template_id": 4}
+{"item_uids": [4], "template_id": 4}
 ```
 
 <HorizontalLine />
@@ -681,10 +715,7 @@ Defines which products to remove from a compare list.
 #### Example
 
 ```json
-{
-  "products": ["4"],
-  "uid": "4"
-}
+{"products": [4], "uid": 4}
 ```
 
 <HorizontalLine />
@@ -724,7 +755,7 @@ Defines the tracking information to delete.
 #### Example
 
 ```json
-{"return_shipping_tracking_uid": "4"}
+{"return_shipping_tracking_uid": 4}
 ```
 
 <HorizontalLine />
@@ -778,7 +809,7 @@ Defines the input required to run the `removeStoreCreditFromCart` mutation.
 #### Example
 
 ```json
-{"cart_id": "xyz789"}
+{"cart_id": "abc123"}
 ```
 
 <HorizontalLine />
@@ -818,7 +849,7 @@ Sets new name for a negotiable quote.
 ```json
 {
   "quote_comment": "xyz789",
-  "quote_name": "xyz789",
+  "quote_name": "abc123",
   "quote_uid": "4"
 }
 ```
@@ -882,10 +913,10 @@ Contains information needed to start a return request.
 
 ```json
 {
-  "comment_text": "xyz789",
-  "contact_email": "xyz789",
+  "comment_text": "abc123",
+  "contact_email": "abc123",
   "items": [RequestReturnItemInput],
-  "token": "abc123"
+  "token": "xyz789"
 }
 ```
 
@@ -908,9 +939,9 @@ Defines properties of a negotiable quote request.
 
 ```json
 {
-  "cart_id": 4,
+  "cart_id": "4",
   "comment": NegotiableQuoteCommentInput,
-  "is_draft": false,
+  "is_draft": true,
   "quote_name": "xyz789"
 }
 ```
@@ -971,7 +1002,7 @@ Contains information needed to start a return request.
 ```json
 {
   "comment_text": "abc123",
-  "contact_email": "abc123",
+  "contact_email": "xyz789",
   "items": [RequestReturnItemInput],
   "order_uid": 4
 }
@@ -1000,7 +1031,7 @@ Contains details about an item to be returned.
     EnteredCustomAttributeInput
   ],
   "order_item_uid": 4,
-  "quantity_to_return": 123.45,
+  "quantity_to_return": 987.65,
   "selected_custom_attributes": [
     SelectedCustomAttributeInput
   ]
@@ -1040,9 +1071,10 @@ Defines the contents of a requisition list.
 | Field Name | Description |
 |------------|-------------|
 | `description` - [`String`](#string) | Optional text that describes the requisition list. |
-| `items` - [`RequistionListItems`](#requistionlistitems) | An array of products added to the requisition list. |
+| `items` - [`RequistionListItems`](#requistionlistitems) | An array of products added to the requisition list. *(Deprecated: Deprecated. Use requisition_list_items instead. Will be removed in a future release.)* |
 | `items_count` - [`Int!`](/reference/graphql/saas/types-f-i.md#int) | The number of items in the list. |
 | `name` - [`String!`](#string) | The requisition list name. |
+| `requisition_list_items` - [`RequisitionListItems`](#requisitionlistitems) | An array of products added to the requisition list. |
 | `uid` - [`ID!`](/reference/graphql/saas/types-f-i.md#id) | The unique requisition list ID. |
 | `updated_at` - [`String`](#string) | The time of the last modification of the requisition list. |
 
@@ -1050,11 +1082,12 @@ Defines the contents of a requisition list.
 
 ```json
 {
-  "description": "abc123",
+  "description": "xyz789",
   "items": RequistionListItems,
-  "items_count": 987,
-  "name": "abc123",
-  "uid": 4,
+  "items_count": 123,
+  "name": "xyz789",
+  "requisition_list_items": RequisitionListItems,
+  "uid": "4",
   "updated_at": "abc123"
 }
 ```
@@ -1115,8 +1148,32 @@ The interface for requisition list items.
   "customizable_options": [SelectedCustomizableOption],
   "product": ProductInterface,
   "quantity": 987.65,
-  "sku": "abc123",
-  "uid": 4
+  "sku": "xyz789",
+  "uid": "4"
+}
+```
+
+<HorizontalLine />
+
+### RequisitionListItems
+
+Contains an array of items added to a requisition list.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `items` - [`[RequisitionListItemInterface]!`](#requisitionlistiteminterface) | An array of items in the requisition list. |
+| `page_info` - [`SearchResultPageInfo`](#searchresultpageinfo) | Pagination metadata. |
+| `total_pages` - [`Int!`](/reference/graphql/saas/types-f-i.md#int) | The number of pages returned. |
+
+#### Example
+
+```json
+{
+  "items": [RequisitionListItemInterface],
+  "page_info": SearchResultPageInfo,
+  "total_pages": 123
 }
 ```
 
@@ -1214,7 +1271,7 @@ Defines customer requisition lists.
 
 ### RequistionListItems
 
-Contains an array of items added to a requisition list.
+Deprecated. Use RequisitionListItems via requisition_list_items. Will be removed in a future release.
 
 #### Fields
 
@@ -1230,7 +1287,7 @@ Contains an array of items added to a requisition list.
 {
   "items": [RequisitionListItemInterface],
   "page_info": SearchResultPageInfo,
-  "total_pages": 123
+  "total_pages": 987
 }
 ```
 
@@ -1293,7 +1350,7 @@ Contains details about a return comment.
 {
   "author_name": "xyz789",
   "created_at": "abc123",
-  "text": "abc123",
+  "text": "xyz789",
   "uid": 4
 }
 ```
@@ -1316,8 +1373,8 @@ The customer information for the return.
 
 ```json
 {
-  "email": "xyz789",
-  "firstname": "xyz789",
+  "email": "abc123",
+  "firstname": "abc123",
   "lastname": "xyz789"
 }
 ```
@@ -1346,9 +1403,9 @@ Contains details about a product being returned.
   "custom_attributesV2": [AttributeValueInterface],
   "order_item": OrderItemInterface,
   "quantity": 123.45,
-  "request_quantity": 987.65,
+  "request_quantity": 123.45,
   "status": "PENDING",
-  "uid": "4"
+  "uid": 4
 }
 ```
 
@@ -1381,17 +1438,17 @@ Return Item attribute metadata.
 ```json
 {
   "code": 4,
-  "default_value": "xyz789",
+  "default_value": "abc123",
   "entity_type": "CATALOG_PRODUCT",
-  "frontend_class": "xyz789",
+  "frontend_class": "abc123",
   "frontend_input": "BOOLEAN",
   "input_filter": "NONE",
-  "is_required": false,
+  "is_required": true,
   "is_unique": false,
   "label": "xyz789",
-  "multiline_count": 123,
+  "multiline_count": 987,
   "options": [CustomAttributeOptionInterface],
-  "sort_order": 123,
+  "sort_order": 987,
   "validate_rules": [ValidationRule]
 }
 ```
@@ -1464,7 +1521,7 @@ Contains details about the shipping address used for receiving returned items.
   "city": "xyz789",
   "contact_name": "abc123",
   "country": Country,
-  "postcode": "xyz789",
+  "postcode": "abc123",
   "region": Region,
   "street": ["abc123"],
   "telephone": "xyz789"
@@ -1535,7 +1592,7 @@ Contains the status of a shipment.
 #### Example
 
 ```json
-{"text": "xyz789", "type": "INFORMATION"}
+{"text": "abc123", "type": "INFORMATION"}
 ```
 
 <HorizontalLine />
@@ -1603,7 +1660,7 @@ Contains a list of customer return requests.
 {
   "items": [Return],
   "page_info": SearchResultPageInfo,
-  "total_count": 987
+  "total_count": 123
 }
 ```
 
@@ -1665,7 +1722,7 @@ Contains details about a customer's reward points.
 #### Example
 
 ```json
-{"money": Money, "points": 987.65}
+{"money": Money, "points": 123.45}
 ```
 
 <HorizontalLine />
@@ -1688,7 +1745,7 @@ Contain details about the reward points transaction.
 ```json
 {
   "balance": RewardPointsAmount,
-  "change_reason": "abc123",
+  "change_reason": "xyz789",
   "date": "xyz789",
   "points_change": 987.65
 }
@@ -1813,8 +1870,8 @@ Contains details about a comment.
 
 ```json
 {
-  "message": "abc123",
-  "timestamp": "xyz789"
+  "message": "xyz789",
+  "timestamp": "abc123"
 }
 ```
 
@@ -1835,7 +1892,7 @@ For use on string and other scalar product fields
 #### Example
 
 ```json
-{"count": 123, "id": 4, "title": "abc123"}
+{"count": 987, "id": 4, "title": "abc123"}
 ```
 
 <HorizontalLine />
@@ -1879,9 +1936,9 @@ A product attribute to filter on
 
 ```json
 {
-  "attribute": "xyz789",
+  "attribute": "abc123",
   "contains": "abc123",
-  "eq": "xyz789",
+  "eq": "abc123",
   "in": ["xyz789"],
   "range": SearchRangeInput,
   "startsWith": "xyz789"
@@ -1904,7 +1961,7 @@ A range of numeric values for use in a search
 #### Example
 
 ```json
-{"from": 987.65, "to": 987.65}
+{"from": 123.45, "to": 987.65}
 ```
 
 <HorizontalLine />
@@ -1924,7 +1981,51 @@ Provides navigation for the query response.
 #### Example
 
 ```json
-{"current_page": 123, "page_size": 987, "total_pages": 123}
+{"current_page": 987, "page_size": 123, "total_pages": 987}
+```
+
+<HorizontalLine />
+
+### SelectFreeGiftForCartInput
+
+#### Input Fields
+
+| Input Field | Description |
+|-------------|-------------|
+| `cart_id` - [`String!`](#string) | Masked ID of the shopper's cart. |
+| `entered_options` - [`[EnteredOptionInput]`](/reference/graphql/saas/types-c-e.md#enteredoptioninput) | Custom option values entered by the customer, such as text inputs. |
+| `quantity` - [`Int`](/reference/graphql/saas/types-f-i.md#int) | Override the rule's configured gift quantity. Must be a positive integer no greater than the rule's gift_qty. Defaults to the rule's gift_qty. |
+| `rule_id` - [`Int!`](/reference/graphql/saas/types-f-i.md#int) | Identifier of the free-gift rule the selection is for. Must be currently applied to the cart and pending selection. |
+| `selected_options` - [`[ID]`](/reference/graphql/saas/types-f-i.md#id) | UIDs of selected option values, such as configurable variants or bundle selections. |
+| `sku` - [`String!`](#string) | SKU of the gift product to add. Must be one of the rule's configured SKUs. |
+
+#### Example
+
+```json
+{
+  "cart_id": "abc123",
+  "entered_options": [EnteredOptionInput],
+  "quantity": 987,
+  "rule_id": 987,
+  "selected_options": [4],
+  "sku": "abc123"
+}
+```
+
+<HorizontalLine />
+
+### SelectFreeGiftForCartOutput
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `cart` - [`Cart!`](/reference/graphql/saas/types-c-e.md#cart) | The cart after adding the selected free-gift product. |
+
+#### Example
+
+```json
+{"cart": Cart}
 ```
 
 <HorizontalLine />
@@ -1946,9 +2047,9 @@ Contains details about a selected bundle option.
 
 ```json
 {
-  "label": "xyz789",
-  "type": "xyz789",
-  "uid": 4,
+  "label": "abc123",
+  "type": "abc123",
+  "uid": "4",
   "values": [SelectedBundleOptionValue]
 }
 ```
@@ -1976,7 +2077,7 @@ Contains details about a value for a selected bundle option.
   "label": "abc123",
   "original_price": Money,
   "priceV2": Money,
-  "quantity": 987.65,
+  "quantity": 123.45,
   "uid": "4"
 }
 ```
@@ -2001,9 +2102,9 @@ Contains details about a selected configurable option.
 ```json
 {
   "configurable_product_option_uid": 4,
-  "configurable_product_option_value_uid": 4,
-  "option_label": "xyz789",
-  "value_label": "xyz789"
+  "configurable_product_option_value_uid": "4",
+  "option_label": "abc123",
+  "value_label": "abc123"
 }
 ```
 
@@ -2024,7 +2125,7 @@ Contains details about an attribute the buyer selected.
 
 ```json
 {
-  "attribute_code": "xyz789",
+  "attribute_code": "abc123",
   "value": "xyz789"
 }
 ```
@@ -2052,7 +2153,7 @@ Identifies a customized product that has been placed in a cart.
 {
   "customizable_option_uid": 4,
   "is_required": false,
-  "label": "xyz789",
+  "label": "abc123",
   "sort_order": 123,
   "type": "xyz789",
   "values": [SelectedCustomizableOptionValue]
@@ -2078,8 +2179,8 @@ Identifies the value of the selected customized option.
 
 ```json
 {
-  "customizable_option_value_uid": 4,
-  "label": "xyz789",
+  "customizable_option_value_uid": "4",
+  "label": "abc123",
   "price": CartItemSelectedOptionValuePrice,
   "value": "xyz789"
 }
@@ -2104,9 +2205,9 @@ Describes the payment method selected by the shopper.
 
 ```json
 {
-  "code": "xyz789",
+  "code": "abc123",
   "oope_payment_method_config": OopePaymentMethodConfig,
-  "purchase_order_number": "xyz789",
+  "purchase_order_number": "abc123",
   "title": "abc123"
 }
 ```
@@ -2137,9 +2238,9 @@ Contains details about the selected shipping method and carrier.
   "additional_data": [ShippingAdditionalData],
   "amount": Money,
   "carrier_code": "abc123",
-  "carrier_title": "xyz789",
+  "carrier_title": "abc123",
   "method_code": "xyz789",
-  "method_title": "xyz789",
+  "method_title": "abc123",
   "price_excl_tax": Money,
   "price_incl_tax": Money
 }
@@ -2161,7 +2262,10 @@ Specifies which negotiable quote to send for review.
 #### Example
 
 ```json
-{"comment": NegotiableQuoteCommentInput, "quote_uid": 4}
+{
+  "comment": NegotiableQuoteCommentInput,
+  "quote_uid": "4"
+}
 ```
 
 <HorizontalLine />
@@ -2200,7 +2304,7 @@ Sets the billing address.
 ```json
 {
   "billing_address": BillingAddressInput,
-  "cart_id": "xyz789"
+  "cart_id": "abc123"
 }
 ```
 
@@ -2238,7 +2342,7 @@ Sets the cart as inactive
 #### Example
 
 ```json
-{"error": "xyz789", "success": true}
+{"error": "abc123", "success": true}
 ```
 
 <HorizontalLine />
@@ -2340,7 +2444,7 @@ Defines the gift options applied to the cart.
 {
   "cart_id": "xyz789",
   "gift_message": GiftMessageInput,
-  "gift_receipt_included": false,
+  "gift_receipt_included": true,
   "gift_wrapping_id": "4",
   "printed_card_included": false
 }
@@ -2381,8 +2485,8 @@ Defines the guest email and cart.
 
 ```json
 {
-  "cart_id": "abc123",
-  "email": "abc123"
+  "cart_id": "xyz789",
+  "email": "xyz789"
 }
 ```
 
@@ -2440,7 +2544,7 @@ Sets the billing address.
 ```json
 {
   "billing_address": NegotiableQuoteBillingAddressInput,
-  "quote_uid": 4
+  "quote_uid": "4"
 }
 ```
 
@@ -2519,7 +2623,7 @@ Defines the shipping address to assign to the negotiable quote.
 
 ```json
 {
-  "quote_uid": 4,
+  "quote_uid": "4",
   "shipping_addresses": [
     NegotiableQuoteShippingAddressInput
   ]
@@ -2608,6 +2712,50 @@ Defines the shipping address to assign to the negotiable quote template.
 
 <HorizontalLine />
 
+### SetNominatedSourceOnCartItemsInput
+
+Input for the setNominatedSourceOnCartItems mutation.
+
+#### Input Fields
+
+| Input Field | Description |
+|-------------|-------------|
+| `cart_id` - [`String!`](#string) | The masked ID of the cart. |
+| `items` - [`[NominatedSourceItemInput]!`](/reference/graphql/saas/types-k-p.md#nominatedsourceiteminput) | The per-item source nominations to apply or clear. |
+
+#### Example
+
+```json
+{
+  "cart_id": "xyz789",
+  "items": [NominatedSourceItemInput]
+}
+```
+
+<HorizontalLine />
+
+### SetNominatedSourceOnCartItemsOutput
+
+Result of the setNominatedSourceOnCartItems mutation.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `cart` - [`Cart!`](/reference/graphql/saas/types-c-e.md#cart) | The updated cart. |
+| `rejected_items` - [`[RejectedNomination]!`](#rejectednomination) | The cart items whose nomination was rejected, each with a reason. Empty when all nominations were applied or cleared. |
+
+#### Example
+
+```json
+{
+  "cart": Cart,
+  "rejected_items": [RejectedNomination]
+}
+```
+
+<HorizontalLine />
+
 ### SetPaymentMethodOnCartInput
 
 Applies a payment method to the cart.
@@ -2623,7 +2771,7 @@ Applies a payment method to the cart.
 
 ```json
 {
-  "cart_id": "abc123",
+  "cart_id": "xyz789",
   "payment_method": PaymentMethodInput
 }
 ```
@@ -2763,7 +2911,7 @@ Contains the results of a request to share a gift registry.
 #### Example
 
 ```json
-{"is_shared": false}
+{"is_shared": true}
 ```
 
 <HorizontalLine />
@@ -2805,8 +2953,8 @@ An input object that defines which requisition list shared with company users th
 
 ```json
 {
-  "customerUids": ["4"],
-  "requisitionListUid": 4
+  "customerUids": [4],
+  "requisitionListUid": "4"
 }
 ```
 
@@ -2827,7 +2975,7 @@ Result of sharing a requisition list by email.
 
 ```json
 {
-  "sent_count": 987,
+  "sent_count": 123,
   "user_errors": [ShareRequisitionListUserError]
 }
 ```
@@ -2868,7 +3016,7 @@ An error related to a specific recipient or constraint.
 ```json
 {
   "code": "MAX_RECIPIENTS_EXCEEDED",
-  "message": "abc123"
+  "message": "xyz789"
 }
 ```
 
@@ -2993,9 +3141,9 @@ Order shipment item details.
 {
   "id": "4",
   "order_item": OrderItemInterface,
-  "product_name": "abc123",
+  "product_name": "xyz789",
   "product_sale_price": Money,
-  "product_sku": "abc123",
+  "product_sku": "xyz789",
   "quantity_shipped": 123.45
 }
 ```
@@ -3022,7 +3170,7 @@ Contains order shipment tracking details.
   "carrier": "xyz789",
   "number": "abc123",
   "title": "abc123",
-  "tracking_url": "abc123"
+  "tracking_url": "xyz789"
 }
 ```
 
@@ -3043,7 +3191,7 @@ A simple key value object.
 
 ```json
 {
-  "key": "xyz789",
+  "key": "abc123",
   "value": "xyz789"
 }
 ```
@@ -3059,6 +3207,7 @@ Defines a single shipping address.
 | Input Field | Description |
 |-------------|-------------|
 | `address` - [`CartAddressInput`](/reference/graphql/saas/types-c-e.md#cartaddressinput) | Defines a shipping address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | UID of a company address to use for shipping. |
 | `customer_address_id` - [`Int`](/reference/graphql/saas/types-f-i.md#int) | An ID from the customer's address book that uniquely identifies the address to be used for shipping. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID from the customer's address book that uniquely identifies the address to be used for shipping. |
 | `customer_notes` - [`String`](#string) | Text provided by the shopper. |
@@ -3069,10 +3218,11 @@ Defines a single shipping address.
 ```json
 {
   "address": CartAddressInput,
+  "company_address_id": "4",
   "customer_address_id": 987,
-  "customer_address_uid": "4",
+  "customer_address_uid": 4,
   "customer_notes": "xyz789",
-  "pickup_location_code": "abc123"
+  "pickup_location_code": "xyz789"
 }
 ```
 
@@ -3090,6 +3240,7 @@ Contains shipping addresses and methods.
 | `cart_items_v2` - [`[CartItemInterface]`](/reference/graphql/saas/types-c-e.md#cartiteminterface) | An array that lists the items in the cart. |
 | `city` - [`String!`](#string) | The city specified for the billing or shipping address. |
 | `company` - [`String`](#string) | The company specified for the billing or shipping address. |
+| `company_address_id` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | UID of the company address referenced by this cart address, if any. |
 | `country` - [`CartAddressCountry!`](/reference/graphql/saas/types-c-e.md#cartaddresscountry) | An object containing the country label and code. |
 | `custom_attributes` - [`[AttributeValueInterface]!`](/reference/graphql/saas/types-a-b.md#attributevalueinterface) | The custom attribute values of the billing or shipping address. |
 | `customer_address_uid` - [`ID`](/reference/graphql/saas/types-f-i.md#id) | The unique ID from the customer's address book that uniquely identifies the address. |
@@ -3117,28 +3268,29 @@ Contains shipping addresses and methods.
 {
   "available_shipping_methods": [AvailableShippingMethod],
   "cart_items_v2": [CartItemInterface],
-  "city": "abc123",
-  "company": "abc123",
+  "city": "xyz789",
+  "company": "xyz789",
+  "company_address_id": "4",
   "country": CartAddressCountry,
   "custom_attributes": [AttributeValueInterface],
   "customer_address_uid": 4,
-  "customer_notes": "abc123",
+  "customer_notes": "xyz789",
   "fax": "xyz789",
   "firstname": "abc123",
   "id": 987,
   "lastname": "abc123",
-  "middlename": "abc123",
-  "pickup_location_code": "xyz789",
+  "middlename": "xyz789",
+  "pickup_location_code": "abc123",
   "postcode": "abc123",
-  "prefix": "abc123",
+  "prefix": "xyz789",
   "region": CartAddressRegion,
-  "same_as_billing": true,
+  "same_as_billing": false,
   "selected_shipping_method": SelectedShippingMethod,
-  "street": ["xyz789"],
-  "suffix": "xyz789",
+  "street": ["abc123"],
+  "suffix": "abc123",
   "telephone": "abc123",
   "uid": 4,
-  "vat_id": "abc123"
+  "vat_id": "xyz789"
 }
 ```
 
@@ -3205,8 +3357,8 @@ Defines the shipping carrier and method.
 
 ```json
 {
-  "carrier_code": "xyz789",
-  "method_code": "abc123"
+  "carrier_code": "abc123",
+  "method_code": "xyz789"
 }
 ```
 
@@ -3229,9 +3381,12 @@ An implementation for simple product cart items.
 | `gift_message` - [`GiftMessage`](/reference/graphql/saas/types-f-i.md#giftmessage) | The entered gift message for the cart item |
 | `gift_wrapping` - [`GiftWrapping`](/reference/graphql/saas/types-f-i.md#giftwrapping) | The selected gift wrapping for the cart item. |
 | `is_available` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if requested quantity is less than available stock, false otherwise. *(Deprecated: Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration.)* |
+| `is_free_gift` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if this line item was added by a Free Gift cart price rule. |
 | `is_salable` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed. |
 | `max_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item max qty in quote template |
 | `min_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item min qty in quote template |
+| `nominated_source` - [`SourceAvailability`](#sourceavailability) | The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors). |
+| `nominated_source_errors` - [`[NominatedSourceError]!`](/reference/graphql/saas/types-k-p.md#nominatedsourceerror) | Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart. |
 | `not_available_message` - [`String`](#string) | Shortage or unavailability message for the line; null when the item is salable. |
 | `note_from_buyer` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The buyer's quote line item note. |
 | `note_from_seller` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The seller's quote line item note. |
@@ -3245,7 +3400,7 @@ An implementation for simple product cart items.
 ```json
 {
   "available_gift_wrapping": [GiftWrapping],
-  "backorder_message": "xyz789",
+  "backorder_message": "abc123",
   "custom_attributes": [CustomAttribute],
   "customizable_options": [SelectedCustomizableOption],
   "discount": [Discount],
@@ -3253,15 +3408,18 @@ An implementation for simple product cart items.
   "gift_message": GiftMessage,
   "gift_wrapping": GiftWrapping,
   "is_available": true,
+  "is_free_gift": true,
   "is_salable": true,
   "max_qty": 123.45,
-  "min_qty": 987.65,
-  "not_available_message": "xyz789",
+  "min_qty": 123.45,
+  "nominated_source": SourceAvailability,
+  "nominated_source_errors": [NominatedSourceError],
+  "not_available_message": "abc123",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
-  "quantity": 987.65,
+  "quantity": 123.45,
   "uid": 4
 }
 ```
@@ -3322,7 +3480,7 @@ Defines a simple product, which is tangible and is usually sold in single units 
 
 ```json
 {
-  "canonical_url": "abc123",
+  "canonical_url": "xyz789",
   "categories": [CategoryInterface],
   "country_of_manufacture": "abc123",
   "crosssell_products": [ProductInterface],
@@ -3334,14 +3492,14 @@ Defines a simple product, which is tangible and is usually sold in single units 
   "image": ProductImage,
   "is_returnable": "abc123",
   "manufacturer": 123,
-  "max_sale_qty": 123.45,
+  "max_sale_qty": 987.65,
   "media_gallery": [MediaGalleryInterface],
-  "meta_description": "xyz789",
-  "meta_keyword": "abc123",
+  "meta_description": "abc123",
+  "meta_keyword": "xyz789",
   "meta_title": "abc123",
-  "min_sale_qty": 987.65,
+  "min_sale_qty": 123.45,
   "name": "xyz789",
-  "new_from_date": "abc123",
+  "new_from_date": "xyz789",
   "new_to_date": "xyz789",
   "only_x_left_in_stock": 987.65,
   "options": [CustomizableOptionInterface],
@@ -3349,7 +3507,7 @@ Defines a simple product, which is tangible and is usually sold in single units 
   "price_range": PriceRange,
   "price_tiers": [TierPrice],
   "product_links": [ProductLinksInterface],
-  "quantity": 987.65,
+  "quantity": 123.45,
   "related_products": [ProductInterface],
   "short_description": ComplexTextValue,
   "sku": "abc123",
@@ -3359,10 +3517,10 @@ Defines a simple product, which is tangible and is usually sold in single units 
   "stock_status": "IN_STOCK",
   "swatch_image": "xyz789",
   "thumbnail": ProductImage,
-  "uid": 4,
+  "uid": "4",
   "upsell_products": [ProductInterface],
-  "url_key": "xyz789",
-  "weight": 123.45
+  "url_key": "abc123",
+  "weight": 987.65
 }
 ```
 
@@ -3393,7 +3551,8 @@ Represents a single-SKU product without selectable variants. Because there are n
 | `price` - [`ProductViewPrice`](/reference/graphql/saas/types-k-p.md#productviewprice) | Base product price view. |
 | `shortDescription` - [`String`](#string) | A summary of the product. |
 | `sku` - [`String`](#string) | A unique code used for identification of a product. |
-| `externalId` - [`String`](#string) | External Id. For example, `123`, `456` or `789`. *(Deprecated: This field is deprecated and will be removed.)* |
+| `externalId` - [`String`](#string) | External Id *(Deprecated: This field is deprecated and will be removed.)* |
+| `externalIds` - [`[ExternalId]`](/reference/graphql/saas/types-c-e.md#externalid) | External Ids |
 | `url` - [`String`](#string) | Canonical URL of the product. For example, `https://example.com/product-1` or `https://example.com/product-2`. *(Deprecated: This field is deprecated and will be removed.)* |
 | `urlKey` - [`String`](#string) | The URL key of the product. For example, `product-1`, `product-2` or `product-3`. |
 | `links` - [`[ProductViewLink]`](/reference/graphql/saas/types-k-p.md#productviewlink) | A list of product links. For example, a related product, an up-sell product or a cross-sell product. |
@@ -3405,7 +3564,7 @@ Represents a single-SKU product without selectable variants. Because there are n
 ```json
 {
   "addToCartAllowed": true,
-  "inStock": true,
+  "inStock": false,
   "lowStock": true,
   "attributes": [ProductViewAttribute],
   "description": "xyz789",
@@ -3416,17 +3575,18 @@ Represents a single-SKU product without selectable variants. Because there are n
   "lastModifiedAt": "2007-12-03T10:15:30Z",
   "metaDescription": "xyz789",
   "metaKeyword": "xyz789",
-  "metaTitle": "xyz789",
-  "name": "abc123",
+  "metaTitle": "abc123",
+  "name": "xyz789",
   "price": ProductViewPrice,
   "shortDescription": "abc123",
   "sku": "abc123",
-  "externalId": "abc123",
+  "externalId": "xyz789",
+  "externalIds": [ExternalId],
   "url": "xyz789",
   "urlKey": "abc123",
   "links": [ProductViewLink],
   "queryType": "xyz789",
-  "visibility": "abc123"
+  "visibility": "xyz789"
 }
 ```
 
@@ -3481,10 +3641,32 @@ Contains a simple product wish list item.
 {
   "added_at": "abc123",
   "customizable_options": [SelectedCustomizableOption],
-  "description": "xyz789",
-  "id": 4,
+  "description": "abc123",
+  "id": "4",
   "product": ProductInterface,
-  "quantity": 123.45
+  "quantity": 987.65
+}
+```
+
+<HorizontalLine />
+
+### SkuSourceAvailability
+
+Per-source availability for a single SKU across the sources of the current sales channel's stock.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `sku` - [`String!`](#string) | The product SKU the availability applies to. |
+| `sources` - [`[SourceAvailability]!`](#sourceavailability) | Availability at each reported source. |
+
+#### Example
+
+```json
+{
+  "sku": "xyz789",
+  "sources": [SourceAvailability]
 }
 ```
 
@@ -3506,7 +3688,7 @@ Smart button payment inputs
 
 ```json
 {
-  "payment_source": "xyz789",
+  "payment_source": "abc123",
   "payments_order_id": "abc123",
   "paypal_order_id": "abc123"
 }
@@ -3539,9 +3721,9 @@ Smart button payment inputs
   "app_switch_when_available": true,
   "button_styles": ButtonStyles,
   "code": "xyz789",
-  "display_message": false,
+  "display_message": true,
   "display_venmo": false,
-  "is_visible": true,
+  "is_visible": false,
   "message_styles": MessageStyles,
   "payment_intent": "xyz789",
   "sdk_params": [SDKParams],
@@ -3608,7 +3790,7 @@ Contains a default value for sort fields and all available sort fields.
 
 ```json
 {
-  "default": "abc123",
+  "default": "xyz789",
   "options": [SortField]
 }
 ```
@@ -3683,9 +3865,35 @@ Contains product attributes that be used for sorting in a `productSearch` query
 ```json
 {
   "attribute": "xyz789",
-  "frontendInput": "xyz789",
-  "label": "xyz789",
-  "numeric": true
+  "frontendInput": "abc123",
+  "label": "abc123",
+  "numeric": false
+}
+```
+
+<HorizontalLine />
+
+### SourceAvailability
+
+Availability of a SKU at a single inventory source.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `available_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Saleable quantity at the source, net of open source-level reservations. The exact value is returned only when it is at or below the merchant's storefront display threshold (cataloginventory/options/stock_threshold_qty); above the threshold it is null and only is_in_stock is meaningful. That threshold defaults to 0, so by default every positive quantity is masked to null and is_in_stock is the authoritative signal. |
+| `is_in_stock` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Whether the SKU is salable at the source (available quantity greater than zero). |
+| `sku` - [`String!`](#string) | The product SKU the availability applies to. |
+| `source_code` - [`String!`](#string) | The inventory source code. |
+
+#### Example
+
+```json
+{
+  "available_qty": 123.45,
+  "is_in_stock": false,
+  "sku": "xyz789",
+  "source_code": "xyz789"
 }
 ```
 
@@ -3707,7 +3915,7 @@ For retrieving statistics across multiple buckets
 
 ```json
 {
-  "max": 123.45,
+  "max": 987.65,
   "min": 987.65,
   "title": "abc123"
 }
@@ -3775,7 +3983,7 @@ Contains information about a store's configuration.
 | `fixed_product_taxes_display_prices_on_product_view_page` - [`Int!`](/reference/graphql/saas/types-f-i.md#int) | Configuration data from tax/weee/display |
 | `fixed_product_taxes_enable` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from tax/weee/enable |
 | `fixed_product_taxes_include_fpt_in_subtotal` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from tax/weee/include_in_subtotal |
-| `graphql_share_customer_group` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from customer/account_information/graphql_share_customer_group |
+| `graphql_share_customer_group` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from customer/account_information/graphql_share_customer_group |
 | `grid_per_page` - [`Int`](/reference/graphql/saas/types-f-i.md#int) | The default number of products per page in Grid View. |
 | `grid_per_page_values` - [`String`](#string) | A list of numbers that define how many products can be displayed in Grid View. |
 | `grouped_product_image` - [`ProductImageThumbnail!`](/reference/graphql/saas/types-k-p.md#productimagethumbnail) | checkout/cart/grouped_product_image: which image to use for grouped products. |
@@ -3819,7 +4027,11 @@ Contains information about a store's configuration.
 | `orders_invoices_credit_memos_display_shipping_amount` - [`Int!`](/reference/graphql/saas/types-f-i.md#int) | Configuration data from tax/sales_display/shipping |
 | `orders_invoices_credit_memos_display_subtotal` - [`Int!`](/reference/graphql/saas/types-f-i.md#int) | Configuration data from tax/sales_display/subtotal |
 | `orders_invoices_credit_memos_display_zero_tax` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from tax/sales_display/zero_tax |
+| `persistent_enabled` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from persistent/options/enabled |
+| `persistent_options_wishlist` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from persistent/options/wishlist |
+| `persistent_shopping_cart` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from persistent/options/shopping_cart |
 | `printed_card_priceV2` - [`Money`](/reference/graphql/saas/types-k-p.md#money) | The default price of a printed card that accompanies an order. |
+| `product_alert_allow_stock` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether back-in-stock (Notify Me) product alerts are enabled. Configuration data from catalog/productalert/allow_stock. |
 | `product_fixed_product_tax_display_setting` - [`FixedProductTaxDisplaySettings`](/reference/graphql/saas/types-f-i.md#fixedproducttaxdisplaysettings) | Corresponds to the 'Display Prices On Product View Page' field in the Admin. It indicates how FPT information is displayed on product pages. |
 | `product_url_suffix` - [`String`](#string) | The suffix applied to product pages, such as `.htm` or `.html`. |
 | `quickorder_active` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether quick order functionality is enabled. |
@@ -3839,8 +4051,9 @@ Contains information about a store's configuration.
 | `secure_base_media_url` - [`String`](#string) | The secure fully-qualified URL that specifies the location of media files. |
 | `secure_base_static_url` - [`String`](#string) | The secure fully-qualified URL that specifies the location of static view files. |
 | `secure_base_url` - [`String`](#string) | The store’s fully-qualified secure base URL. |
-| `share_active_segments` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from customer/magento_customersegment/share_active_segments |
-| `share_applied_cart_rule` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from promo/graphql/share_applied_cart_rule |
+| `share_active_segments` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from customer/magento_customersegment/share_active_segments |
+| `share_applied_cart_rule` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from promo/graphql/share_applied_cart_rule |
+| `share_customer_accounts_scope` - [`Int!`](/reference/graphql/saas/types-f-i.md#int) | Configuration data from customer/account_share/scope. 0 = Global, 1 = Per Website |
 | `shopping_assistance_checkbox_title` - [`String`](#string) | Configuration data from login_as_customer/general/shopping_assistance_checkbox_title |
 | `shopping_assistance_checkbox_tooltip` - [`String`](#string) | Configuration data from login_as_customer/general/shopping_assistance_checkbox_tooltip |
 | `shopping_assistance_enabled` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | Configuration data from login_as_customer/general/enabled |
@@ -3875,18 +4088,18 @@ Contains information about a store's configuration.
 ```json
 {
   "allow_company_registration": true,
-  "allow_gift_receipt": "xyz789",
+  "allow_gift_receipt": "abc123",
   "allow_gift_wrapping_on_order": "xyz789",
-  "allow_gift_wrapping_on_order_items": "xyz789",
-  "allow_items": "xyz789",
-  "allow_order": "xyz789",
+  "allow_gift_wrapping_on_order_items": "abc123",
+  "allow_items": "abc123",
+  "allow_order": "abc123",
   "allow_printed_card": "abc123",
-  "autocomplete_on_storefront": true,
+  "autocomplete_on_storefront": false,
   "base_currency_code": "abc123",
   "base_link_url": "xyz789",
-  "base_media_url": "xyz789",
+  "base_media_url": "abc123",
   "base_static_url": "abc123",
-  "base_url": "xyz789",
+  "base_url": "abc123",
   "cart_expires_in_days": 987,
   "cart_gift_wrapping": "abc123",
   "cart_merge_preference": "abc123",
@@ -3895,131 +4108,136 @@ Contains information about a store's configuration.
   "catalog_default_sort_by": "xyz789",
   "category_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
   "category_url_suffix": "xyz789",
-  "check_money_order_enable_for_specific_countries": false,
+  "check_money_order_enable_for_specific_countries": true,
   "check_money_order_enabled": true,
-  "check_money_order_make_check_payable_to": "xyz789",
-  "check_money_order_max_order_total": "abc123",
-  "check_money_order_min_order_total": "xyz789",
-  "check_money_order_new_order_status": "xyz789",
+  "check_money_order_make_check_payable_to": "abc123",
+  "check_money_order_max_order_total": "xyz789",
+  "check_money_order_min_order_total": "abc123",
+  "check_money_order_new_order_status": "abc123",
   "check_money_order_payment_from_specific_countries": "abc123",
-  "check_money_order_send_check_to": "xyz789",
+  "check_money_order_send_check_to": "abc123",
   "check_money_order_sort_order": 123,
-  "check_money_order_title": "abc123",
-  "company_credit_enabled": false,
-  "company_enabled": false,
+  "check_money_order_title": "xyz789",
+  "company_credit_enabled": true,
+  "company_enabled": true,
   "configurable_product_image": "ITSELF",
   "configurable_thumbnail_source": "xyz789",
-  "contact_enabled": true,
-  "countries_with_required_region": "xyz789",
+  "contact_enabled": false,
+  "countries_with_required_region": "abc123",
   "create_account_confirmation": false,
-  "customer_access_token_lifetime": 987.65,
+  "customer_access_token_lifetime": 123.45,
   "default_country": "abc123",
-  "default_display_currency_code": "xyz789",
+  "default_display_currency_code": "abc123",
   "display_product_prices_in_catalog": 987,
-  "display_shipping_prices": 987,
+  "display_shipping_prices": 123,
   "display_state_if_optional": true,
   "enable_multiple_wishlists": "abc123",
   "fixed_product_taxes_apply_tax_to_fpt": false,
-  "fixed_product_taxes_display_prices_in_emails": 123,
-  "fixed_product_taxes_display_prices_in_product_lists": 987,
-  "fixed_product_taxes_display_prices_in_sales_modules": 123,
+  "fixed_product_taxes_display_prices_in_emails": 987,
+  "fixed_product_taxes_display_prices_in_product_lists": 123,
+  "fixed_product_taxes_display_prices_in_sales_modules": 987,
   "fixed_product_taxes_display_prices_on_product_view_page": 987,
   "fixed_product_taxes_enable": true,
   "fixed_product_taxes_include_fpt_in_subtotal": false,
-  "graphql_share_customer_group": true,
+  "graphql_share_customer_group": false,
   "grid_per_page": 123,
   "grid_per_page_values": "abc123",
   "grouped_product_image": "ITSELF",
   "is_checkout_agreements_enabled": true,
   "is_default_store": false,
   "is_default_store_group": true,
-  "is_guest_checkout_enabled": true,
-  "is_negotiable_quote_active": false,
+  "is_guest_checkout_enabled": false,
+  "is_negotiable_quote_active": true,
   "is_one_page_checkout_enabled": true,
-  "is_requisition_list_active": "xyz789",
+  "is_requisition_list_active": "abc123",
   "list_mode": "xyz789",
   "list_per_page": 123,
-  "list_per_page_values": "abc123",
+  "list_per_page_values": "xyz789",
   "locale": "abc123",
-  "magento_reward_general_is_enabled": "xyz789",
+  "magento_reward_general_is_enabled": "abc123",
   "magento_reward_general_is_enabled_on_front": "xyz789",
-  "magento_reward_general_min_points_balance": "xyz789",
+  "magento_reward_general_min_points_balance": "abc123",
   "magento_reward_general_publish_history": "abc123",
   "magento_reward_points_invitation_customer": "abc123",
   "magento_reward_points_invitation_customer_limit": "xyz789",
-  "magento_reward_points_invitation_order": "xyz789",
+  "magento_reward_points_invitation_order": "abc123",
   "magento_reward_points_invitation_order_limit": "xyz789",
   "magento_reward_points_newsletter": "xyz789",
   "magento_reward_points_order": "xyz789",
   "magento_reward_points_register": "xyz789",
-  "magento_reward_points_review": "abc123",
-  "magento_reward_points_review_limit": "xyz789",
+  "magento_reward_points_review": "xyz789",
+  "magento_reward_points_review_limit": "abc123",
   "magento_wishlist_general_is_enabled": "xyz789",
-  "max_items_in_order_summary": 987,
-  "maximum_number_of_wishlists": "abc123",
+  "max_items_in_order_summary": 123,
+  "maximum_number_of_wishlists": "xyz789",
   "minicart_display": true,
-  "minicart_max_items": 987,
-  "minimum_password_length": "xyz789",
-  "newsletter_enabled": true,
-  "optional_zip_countries": "xyz789",
+  "minicart_max_items": 123,
+  "minimum_password_length": "abc123",
+  "newsletter_enabled": false,
+  "optional_zip_countries": "abc123",
   "order_cancellation_enabled": false,
   "order_cancellation_reasons": [CancellationReason],
   "orders_invoices_credit_memos_display_full_summary": false,
   "orders_invoices_credit_memos_display_grandtotal": true,
   "orders_invoices_credit_memos_display_price": 987,
   "orders_invoices_credit_memos_display_shipping_amount": 987,
-  "orders_invoices_credit_memos_display_subtotal": 987,
+  "orders_invoices_credit_memos_display_subtotal": 123,
   "orders_invoices_credit_memos_display_zero_tax": true,
+  "persistent_enabled": false,
+  "persistent_options_wishlist": true,
+  "persistent_shopping_cart": true,
   "printed_card_priceV2": Money,
+  "product_alert_allow_stock": true,
   "product_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
   "product_url_suffix": "abc123",
   "quickorder_active": false,
-  "quote_minimum_amount": 123.45,
-  "quote_minimum_amount_message": "abc123",
+  "quote_minimum_amount": 987.65,
+  "quote_minimum_amount_message": "xyz789",
   "required_character_classes_number": "abc123",
   "requisition_list_share_link_validity_days": 987,
   "requisition_list_share_max_recipients": 123,
-  "requisition_list_share_storefront_path": "abc123",
-  "requisition_list_sharing_enabled": true,
+  "requisition_list_share_storefront_path": "xyz789",
+  "requisition_list_sharing_enabled": false,
   "returns_enabled": "xyz789",
-  "root_category_uid": "4",
+  "root_category_uid": 4,
   "sales_fixed_product_tax_display_setting": "INCLUDE_FPT_WITHOUT_DETAILS",
-  "sales_gift_wrapping": "xyz789",
+  "sales_gift_wrapping": "abc123",
   "sales_printed_card": "abc123",
   "secure_base_link_url": "abc123",
   "secure_base_media_url": "abc123",
   "secure_base_static_url": "abc123",
   "secure_base_url": "abc123",
-  "share_active_segments": false,
+  "share_active_segments": true,
   "share_applied_cart_rule": true,
-  "shopping_assistance_checkbox_title": "xyz789",
+  "share_customer_accounts_scope": 123,
+  "shopping_assistance_checkbox_title": "abc123",
   "shopping_assistance_checkbox_tooltip": "abc123",
-  "shopping_assistance_enabled": false,
+  "shopping_assistance_enabled": true,
   "shopping_cart_display_full_summary": false,
-  "shopping_cart_display_grand_total": false,
-  "shopping_cart_display_price": 123,
+  "shopping_cart_display_grand_total": true,
+  "shopping_cart_display_price": 987,
   "shopping_cart_display_shipping": 987,
   "shopping_cart_display_subtotal": 123,
   "shopping_cart_display_tax_gift_wrapping": "DISPLAY_EXCLUDING_TAX",
   "shopping_cart_display_zero_tax": false,
-  "store_code": 4,
-  "store_group_code": 4,
-  "store_group_name": "abc123",
+  "store_code": "4",
+  "store_group_code": "4",
+  "store_group_name": "xyz789",
   "store_name": "xyz789",
-  "store_sort_order": 987,
-  "timezone": "xyz789",
-  "title_separator": "xyz789",
-  "use_store_in_url": false,
+  "store_sort_order": 123,
+  "timezone": "abc123",
+  "title_separator": "abc123",
+  "use_store_in_url": true,
   "website_code": 4,
-  "website_name": "abc123",
+  "website_name": "xyz789",
   "weight_unit": "xyz789",
-  "zero_subtotal_enable_for_specific_countries": false,
-  "zero_subtotal_enabled": true,
+  "zero_subtotal_enable_for_specific_countries": true,
+  "zero_subtotal_enabled": false,
   "zero_subtotal_new_order_status": "abc123",
-  "zero_subtotal_payment_action": "abc123",
-  "zero_subtotal_payment_from_specific_countries": "xyz789",
-  "zero_subtotal_sort_order": 987,
-  "zero_subtotal_title": "abc123"
+  "zero_subtotal_payment_action": "xyz789",
+  "zero_subtotal_payment_from_specific_countries": "abc123",
+  "zero_subtotal_sort_order": 123,
+  "zero_subtotal_title": "xyz789"
 }
 ```
 
@@ -4093,9 +4311,9 @@ Specifies the quote template properties to update.
 {
   "attachments": [NegotiableQuoteCommentAttachmentInput],
   "comment": "abc123",
-  "max_order_commitment": 123,
+  "max_order_commitment": 987,
   "min_order_commitment": 987,
-  "name": "abc123",
+  "name": "xyz789",
   "reference_document_links": [
     NegotiableQuoteTemplateReferenceDocumentLinkInput
   ],
@@ -4158,7 +4376,7 @@ Represents the subtree of the categories to retrieve.
 #### Example
 
 ```json
-{"depth": 987, "startLevel": 987}
+{"depth": 123, "startLevel": 987}
 ```
 
 <HorizontalLine />
@@ -4182,7 +4400,7 @@ Represents the subtree of the categories to retrieve.
 #### Example
 
 ```json
-{"value": "xyz789"}
+{"value": "abc123"}
 ```
 
 <HorizontalLine />
@@ -4258,8 +4476,8 @@ Synchronizes the payment order details
 
 ```json
 {
-  "cartId": "abc123",
-  "id": "abc123"
+  "cartId": "xyz789",
+  "id": "xyz789"
 }
 ```
 

--- a/src/pages/includes/autogenerated/graphql-api-saas-types-t-z.md
+++ b/src/pages/includes/autogenerated/graphql-api-saas-types-t-z.md
@@ -17,8 +17,8 @@ Contains tax item details.
 ```json
 {
   "amount": Money,
-  "rate": 987.65,
-  "title": "xyz789"
+  "rate": 123.45,
+  "title": "abc123"
 }
 ```
 
@@ -157,14 +157,36 @@ Contains the response to the request to unassign a child company.
 
 ```json
 {
-  "unitName": "abc123",
-  "storefrontLabel": "xyz789",
+  "unitName": "xyz789",
+  "storefrontLabel": "abc123",
   "pagePlacement": "xyz789",
   "displayNumber": 123,
-  "pageType": "abc123",
-  "unitStatus": "xyz789",
-  "typeId": "xyz789",
+  "pageType": "xyz789",
+  "unitStatus": "abc123",
+  "typeId": "abc123",
   "filterRules": [FilterRuleInput]
+}
+```
+
+<HorizontalLine />
+
+### UnitSelector
+
+Provide either rec unit ids or labels to retrieve rec units
+
+#### Input Fields
+
+| Input Field | Description |
+|-------------|-------------|
+| `unitIds` - [`[String!]`](/reference/graphql/saas/types-q-s.md#string) | List unit IDs of preconfigured units |
+| `labels` - [`[String!]`](/reference/graphql/saas/types-q-s.md#string) | List of labels of the preconfigured unit |
+
+#### Example
+
+```json
+{
+  "unitIds": ["xyz789"],
+  "labels": ["abc123"]
 }
 ```
 
@@ -185,7 +207,7 @@ Modifies the specified items in the cart.
 
 ```json
 {
-  "cart_id": "abc123",
+  "cart_id": "xyz789",
   "cart_items": [CartItemUpdateInput]
 }
 ```
@@ -210,6 +232,43 @@ Contains details about the cart after updating items.
   "cart": Cart,
   "errors": [CartUserInputError]
 }
+```
+
+<HorizontalLine />
+
+### UpdateCompanyConfigInput
+
+Defines the input schema for updating company configuration.
+
+#### Input Fields
+
+| Input Field | Description |
+|-------------|-------------|
+| `address_book_enabled` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether the company address book is enabled. |
+| `custom_shipping_address_enabled` - [`Boolean`](/reference/graphql/saas/types-a-b.md#boolean) | Indicates whether custom shipping address entry is allowed when the company address book is enabled. |
+
+#### Example
+
+```json
+{"address_book_enabled": false, "custom_shipping_address_enabled": true}
+```
+
+<HorizontalLine />
+
+### UpdateCompanyConfigOutput
+
+Contains the response to the request to update company configuration.
+
+#### Fields
+
+| Field Name | Description |
+|------------|-------------|
+| `company` - [`Company`](/reference/graphql/saas/types-c-e.md#company) | The updated company. |
+
+#### Example
+
+```json
+{"company": Company}
 ```
 
 <HorizontalLine />
@@ -327,7 +386,7 @@ Defines updates to a `GiftRegistry` object.
     GiftRegistryDynamicAttributeInput
   ],
   "event_name": "abc123",
-  "message": "abc123",
+  "message": "xyz789",
   "privacy_settings": "PRIVATE",
   "shipping_address": GiftRegistryShippingAddressInput,
   "status": "ACTIVE"
@@ -353,8 +412,8 @@ Defines updates to an item in a gift registry.
 ```json
 {
   "gift_registry_item_uid": "4",
-  "note": "abc123",
-  "quantity": 123.45
+  "note": "xyz789",
+  "quantity": 987.65
 }
 ```
 
@@ -417,9 +476,9 @@ Defines updates to an existing registrant.
   "dynamic_attributes": [
     GiftRegistryDynamicAttributeInput
   ],
-  "email": "abc123",
-  "firstname": "abc123",
-  "gift_registry_registrant_uid": 4,
+  "email": "xyz789",
+  "firstname": "xyz789",
+  "gift_registry_registrant_uid": "4",
   "lastname": "abc123"
 }
 ```
@@ -566,8 +625,8 @@ Defines the changes to be made to an approval rule.
 
 ```json
 {
-  "applies_to": ["4"],
-  "approvers": [4],
+  "applies_to": [4],
+  "approvers": ["4"],
   "condition": CreatePurchaseOrderApprovalRuleConditionInput,
   "description": "abc123",
   "name": "xyz789",
@@ -618,9 +677,9 @@ Defines which items in a requisition list to update.
 ```json
 {
   "entered_options": [EnteredOptionInput],
-  "item_id": "4",
+  "item_id": 4,
   "quantity": 123.45,
-  "selected_options": ["abc123"]
+  "selected_options": ["xyz789"]
 }
 ```
 
@@ -679,7 +738,7 @@ Contains the name and visibility of an updated wish list.
 ```json
 {
   "name": "abc123",
-  "uid": 4,
+  "uid": "4",
   "visibility": "PUBLIC"
 }
 ```
@@ -703,7 +762,7 @@ Defines the input for returning matching companies the customer is assigned to.
 ```json
 {
   "currentPage": 123,
-  "pageSize": 987,
+  "pageSize": 123,
   "sort": [CompaniesSortInput]
 }
 ```
@@ -746,7 +805,7 @@ Contains details about a failed validation attempt.
 #### Example
 
 ```json
-{"message": "abc123", "type": "NOT_FOUND"}
+{"message": "xyz789", "type": "NOT_FOUND"}
 ```
 
 <HorizontalLine />
@@ -784,7 +843,7 @@ Defines the purchase orders to be validated.
 #### Example
 
 ```json
-{"purchase_order_uids": ["4"]}
+{"purchase_order_uids": [4]}
 ```
 
 <HorizontalLine />
@@ -827,7 +886,7 @@ Defines a customer attribute validation rule.
 ```json
 {
   "name": "DATE_RANGE_MAX",
-  "value": "abc123"
+  "value": "xyz789"
 }
 ```
 
@@ -959,7 +1018,7 @@ User view history
 ```json
 {
   "date": "2007-12-03T10:15:30Z",
-  "sku": "xyz789"
+  "sku": "abc123"
 }
 ```
 
@@ -1001,9 +1060,12 @@ An implementation for virtual product cart items.
 | `discount` - [`[Discount]`](/reference/graphql/saas/types-c-e.md#discount) | Contains discount for quote line item. |
 | `errors` - [`[CartItemError]`](/reference/graphql/saas/types-c-e.md#cartitemerror) | An array of errors encountered while loading the cart item |
 | `is_available` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if requested quantity is less than available stock, false otherwise. *(Deprecated: Use `is_salable` instead. It indicates whether the line can be purchased, including backorder configuration.)* |
+| `is_free_gift` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True if this line item was added by a Free Gift cart price rule. |
 | `is_salable` - [`Boolean!`](/reference/graphql/saas/types-a-b.md#boolean) | True when the item can be purchased and should not block checkout: stock status is in stock and either physical quantity covers the requested quantity or backorders are allowed. |
 | `max_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item max qty in quote template |
 | `min_qty` - [`Float`](/reference/graphql/saas/types-f-i.md#float) | Line item min qty in quote template |
+| `nominated_source` - [`SourceAvailability`](/reference/graphql/saas/types-q-s.md#sourceavailability) | The source currently nominated for this cart item, with its live availability snapshot. Null when no source is nominated, or when the nominated source no longer resolves or is disabled (see nominated_source_errors). |
+| `nominated_source_errors` - [`[NominatedSourceError]!`](/reference/graphql/saas/types-k-p.md#nominatedsourceerror) | Live validation errors for this item's current nomination: UNKNOWN_SOURCE if the source no longer exists, SOURCE_DISABLED if it exists but is disabled, NOT_ENOUGH_QTY if available quantity has since dropped below the item's quantity. Empty when there is no nomination or it is still valid. SKU_SOURCE_CONFLICT never appears here — it is enforced only by the setNominatedSourceOnCartItems write path and cannot occur on an already-persisted cart. |
 | `not_available_message` - [`String`](/reference/graphql/saas/types-q-s.md#string) | Shortage or unavailability message for the line; null when the item is salable. |
 | `note_from_buyer` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The buyer's quote line item note. |
 | `note_from_seller` - [`[ItemNote]`](/reference/graphql/saas/types-f-i.md#itemnote) | The seller's quote line item note. |
@@ -1016,22 +1078,25 @@ An implementation for virtual product cart items.
 
 ```json
 {
-  "backorder_message": "xyz789",
+  "backorder_message": "abc123",
   "custom_attributes": [CustomAttribute],
   "customizable_options": [SelectedCustomizableOption],
   "discount": [Discount],
   "errors": [CartItemError],
-  "is_available": false,
-  "is_salable": false,
-  "max_qty": 123.45,
+  "is_available": true,
+  "is_free_gift": false,
+  "is_salable": true,
+  "max_qty": 987.65,
   "min_qty": 123.45,
-  "not_available_message": "xyz789",
+  "nominated_source": SourceAvailability,
+  "nominated_source_errors": [NominatedSourceError],
+  "not_available_message": "abc123",
   "note_from_buyer": [ItemNote],
   "note_from_seller": [ItemNote],
   "prices": CartItemPrices,
   "product": ProductInterface,
-  "quantity": 123.45,
-  "uid": "4"
+  "quantity": 987.65,
+  "uid": 4
 }
 ```
 
@@ -1092,7 +1157,7 @@ Defines a virtual product, which is a non-tangible product that does not require
 {
   "canonical_url": "xyz789",
   "categories": [CategoryInterface],
-  "country_of_manufacture": "xyz789",
+  "country_of_manufacture": "abc123",
   "crosssell_products": [ProductInterface],
   "custom_attributesV2": ProductCustomAttributes,
   "description": ComplexTextValue,
@@ -1100,18 +1165,18 @@ Defines a virtual product, which is a non-tangible product that does not require
   "gift_wrapping_available": true,
   "gift_wrapping_price": Money,
   "image": ProductImage,
-  "is_returnable": "abc123",
-  "manufacturer": 987,
+  "is_returnable": "xyz789",
+  "manufacturer": 123,
   "max_sale_qty": 987.65,
   "media_gallery": [MediaGalleryInterface],
-  "meta_description": "xyz789",
+  "meta_description": "abc123",
   "meta_keyword": "xyz789",
-  "meta_title": "abc123",
+  "meta_title": "xyz789",
   "min_sale_qty": 123.45,
   "name": "xyz789",
-  "new_from_date": "abc123",
-  "new_to_date": "xyz789",
-  "only_x_left_in_stock": 123.45,
+  "new_from_date": "xyz789",
+  "new_to_date": "abc123",
+  "only_x_left_in_stock": 987.65,
   "options": [CustomizableOptionInterface],
   "options_container": "xyz789",
   "price_range": PriceRange,
@@ -1122,12 +1187,12 @@ Defines a virtual product, which is a non-tangible product that does not require
   "short_description": ComplexTextValue,
   "sku": "abc123",
   "small_image": ProductImage,
-  "special_price": 123.45,
+  "special_price": 987.65,
   "special_to_date": "abc123",
   "stock_status": "IN_STOCK",
   "swatch_image": "xyz789",
   "thumbnail": ProductImage,
-  "uid": "4",
+  "uid": 4,
   "upsell_products": [ProductInterface],
   "url_key": "abc123"
 }
@@ -1155,8 +1220,8 @@ Contains details about virtual products added to a requisition list.
 {
   "customizable_options": [SelectedCustomizableOption],
   "product": ProductInterface,
-  "quantity": 987.65,
-  "sku": "xyz789",
+  "quantity": 123.45,
+  "sku": "abc123",
   "uid": 4
 }
 ```
@@ -1182,12 +1247,12 @@ Contains a virtual product wish list item.
 
 ```json
 {
-  "added_at": "xyz789",
+  "added_at": "abc123",
   "customizable_options": [SelectedCustomizableOption],
-  "description": "abc123",
-  "id": "4",
+  "description": "xyz789",
+  "id": 4,
   "product": ProductInterface,
-  "quantity": 123.45
+  "quantity": 987.65
 }
 ```
 
@@ -1257,7 +1322,7 @@ Contains a customer wish list.
   "id": "4",
   "items_count": 123,
   "items_v2": WishlistItems,
-  "name": "xyz789",
+  "name": "abc123",
   "sharing_code": "xyz789",
   "updated_at": "xyz789",
   "visibility": "PUBLIC"
@@ -1284,9 +1349,9 @@ Contains details about errors encountered when a customer added wish list items 
 ```json
 {
   "code": "PRODUCT_NOT_FOUND",
-  "message": "xyz789",
+  "message": "abc123",
   "wishlistId": "4",
-  "wishlistItemId": 4
+  "wishlistItemId": "4"
 }
 ```
 
@@ -1301,10 +1366,10 @@ A list of possible error types.
 | Enum Value | Description |
 |------------|-------------|
 | `PRODUCT_NOT_FOUND` |  |
+| `REQUIRED_PARAMETER_MISSING` |  |
 | `NOT_SALABLE` |  |
 | `INSUFFICIENT_STOCK` |  |
 | `UNDEFINED` |  |
-| `REQUIRED_PARAMETER_MISSING` |  |
 
 #### Example
 
@@ -1329,7 +1394,7 @@ Specifies the IDs of items to copy and their quantities.
 
 ```json
 {
-  "quantity": 987.65,
+  "quantity": 123.45,
   "wishlist_item_id": "4"
 }
 ```
@@ -1357,7 +1422,7 @@ Defines the items to add to a wish list.
   "entered_options": [EnteredOptionInput],
   "parent_sku": "xyz789",
   "quantity": 987.65,
-  "selected_options": ["4"],
+  "selected_options": [4],
   "sku": "xyz789"
 }
 ```
@@ -1400,7 +1465,7 @@ The interface for wish list items.
   "description": "abc123",
   "id": "4",
   "product": ProductInterface,
-  "quantity": 123.45
+  "quantity": 987.65
 }
 ```
 
@@ -1420,10 +1485,7 @@ Specifies the IDs of the items to move and their quantities.
 #### Example
 
 ```json
-{
-  "quantity": 987.65,
-  "wishlist_item_id": "4"
-}
+{"quantity": 123.45, "wishlist_item_id": 4}
 ```
 
 <HorizontalLine />
@@ -1446,11 +1508,11 @@ Defines updates to items in a wish list.
 
 ```json
 {
-  "description": "abc123",
+  "description": "xyz789",
   "entered_options": [EnteredOptionInput],
   "quantity": 123.45,
   "selected_options": ["4"],
-  "wishlist_item_id": 4
+  "wishlist_item_id": "4"
 }
 ```
 


### PR DESCRIPTION
This PR updates the REST and GraphQL schemas for the September ACCS release:

### New REST Endpoints

- DELETE /V1/carts/{cartId}/balance/unapply
- DELETE /V1/company-address/{addressId}
- DELETE /V1/custom-email/templates/{templateId}
- GET /V1/attributeMetadata/companyAddress
- GET /V1/attributeMetadata/companyAddress/attribute/{attributeCode}
- GET /V1/attributeMetadata/companyAddress/custom
- GET /V1/attributeMetadata/companyAddress/form/{formCode}
- GET /V1/companies/{companyId}/billingAddress
- GET /V1/companies/{companyId}/shippingAddress
- GET /V1/company-address/{addressId}
- GET /V1/company/{companyId}/addresses
- GET /V1/system/config
- POST /V1/adminuisdk/permission/check
- POST /V1/carts/{cartId}/balance/apply
- POST /V1/company/{companyId}/address
- PUT /V1/adminuisdk/config
- PUT /V1/company-address/{addressId}
- PUT /V1/company-addresses/{addressId}/default
- PUT /V1/custom-email/templates/{templateId}
- PUT /V1/system/config

### New GraphQL Queries

- payByLinkCart
- recommendationsByUnits
- sourceAvailability

### New GraphQL Mutations

- clearCart
- createCompanyAddress
- createPaymentLink
- deleteCompanyAddress
- selectFreeGiftForCart
- setDefaultCompanyAddress
- setNominatedSourceOnCartItems
- updateCompanyAddress
- updateCompanyConfig

### New GraphQL Types

- AvailableFreeGift
- CategorySortInput
- CategoryViewAttribute
- ClearCartError
- ClearCartErrorType
- ClearCartInput
- ClearCartOutput
- CompanyAddress
- CompanyAddressInput
- CompanyAddressTypeEnum
- CompanyAddressUpdateInput
- CompanyAddresses
- CompanyConfig
- CreatePaymentLinkOutput
- ExternalId
- GiftCartAttributeValue
- NominatedSourceItemInput
- PayByLinkCartOutput
- RequisitionListItems
- SelectFreeGiftForCartInput
- SelectFreeGiftForCartOutput
- SetNominatedSourceOnCartItemsInput
- SetNominatedSourceOnCartItemsOutput
- SkuSourceAvailability
- SortDirectionEnum
- UnitSelector
- UpdateCompanyConfigInput
- UpdateCompanyConfigOutput

whatsnew
Updated the [REST](https://developer.adobe.com/commerce/webapi/reference/rest/saas) and [GraphQL](https://developer.adobe.com/commerce/webapi/reference/graphql/saas/) schemas for Adobe Commerce as a Cloud Service.