### PR TITLE
Update links to storefront docs

### DIFF
--- a/src/pages/graphql/index.md
+++ b/src/pages/graphql/index.md
@@ -9,11 +9,11 @@ keywords:
 
 [GraphQL](https://graphql.org/) is a data query language and runtime that revolutionizes how you build and consume APIs. Originally developed by Facebook in 2012 and open-sourced in 2015, GraphQL has become the preferred choice for modern applications that need efficient, flexible, and performant data fetching.
 
-Adobe Commerce provides two comprehensive GraphQL implementations that serve as the ideal foundation for building next-generation commerce experiences, including [headless storefronts](https://experienceleague.adobe.com/developer/commerce/storefront/get-started/) and sophisticated mobile applications.
+Adobe Commerce provides two comprehensive GraphQL implementations that serve as the ideal foundation for building next-generation commerce experiences, including [headless storefronts](https://experienceleague.adobe.com/en/tools/commerce-storefront/get-started/) and sophisticated mobile applications.
 
 -  Adobe Commerce on Cloud and on-premises (PaaS) projects can implement the GraphQL schemas that have long been available to Adobe Commerce and Magento Open Source projects. Separate schemas are available for [core and B2B Commerce](../reference/graphql/2-4-8/index.md) functionality and service-based features, including [Catalog Service](schema/catalog-service/index.md), [Live Search](schema/live-search/index.md), and [Recommendations](schema/product-recommendations/index.md). These schemas do not natively interact, but can be integrated with [API Mesh](https://developer.adobe.com/graphql-mesh-gateway/).
 
-- [Adobe Commerce as a Cloud Service](/reference/graphql/saas/index.md) (SaaS) projects can connect to a supergraph that not only combines and streamlines the schemas available to PaaS projects, but provides instant access to the latest features added in the [Storefront Compatability Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and other sources. Therefore, SaaS projects can take advantage of the latest GraphQL features without needing to wait for a new release.
+- [Adobe Commerce as a Cloud Service](/reference/graphql/saas/index.md) (SaaS) projects can connect to a supergraph that not only combines and streamlines the schemas available to PaaS projects, but provides instant access to the latest features added in the [Storefront Compatability Package](https://experienceleague.adobe.com/en/tools/commerce-storefront/setup/configuration/storefront-compatibility/v248/) and other sources. Therefore, SaaS projects can take advantage of the latest GraphQL features without needing to wait for a new release.
 
 <InlineAlert variant="info" slots="text"/>
 
@@ -106,4 +106,4 @@ Ready to experience the power of Adobe Commerce GraphQL? Here's how to get start
 
 ## Commerce API playground
 
-The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) enables you to run selected queries against a live instance of Adobe Commerce with Luma sample data. The playground includes example core and Storefront Services queries. You can customize the output of the queries to help you understand the power of our GraphQL APIs.
+The [Commerce API playground](https://experienceleague.adobe.com/en/tools/commerce-storefront/playgrounds/commerce-services/) enables you to run selected queries against a live instance of Adobe Commerce with Luma sample data. The playground includes example core and Storefront Services queries. You can customize the output of the queries to help you understand the power of our GraphQL APIs.

--- a/src/pages/graphql/schema/cart/queries/cart.md
+++ b/src/pages/graphql/schema/cart/queries/cart.md
@@ -27,7 +27,7 @@ The `cart` reference provides detailed information about the types and fields de
 
 ## Sample queries
 
-The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) provides a sample `cart` query that you can run against a live instance of Adobe Commerce with Luma sample data.
+The [Commerce API playground](https://experienceleague.adobe.com/en/tools/commerce-storefront/playgrounds/commerce-services/) provides a sample `cart` query that you can run against a live instance of Adobe Commerce with Luma sample data.
 
 You can convert the hardcoded `cart_id` values in the following sample queries to a [variable](../../../usage/index.md#query-variables) and run them in the API playground. Note that the responses may vary, depending on the configuration of the Commerce instance.
 

--- a/src/pages/graphql/schema/catalog-service/queries/products.md
+++ b/src/pages/graphql/schema/catalog-service/queries/products.md
@@ -55,7 +55,7 @@ You must specify the following HTTP headers to run this query.
 
 ## Example usage
 
-The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) provides a sample `products` query that you can run against a live instance of Adobe Commerce with Luma sample data. Note that the responses may vary, depending on the configuration of the Commerce instance.
+The [Commerce API playground](https://experienceleague.adobe.com/en/tools/commerce-storefront/playgrounds/commerce-services/) provides a sample `products` query that you can run against a live instance of Adobe Commerce with Luma sample data. Note that the responses may vary, depending on the configuration of the Commerce instance.
 
 ### Return details about a simple product
 

--- a/src/pages/graphql/schema/customer/mutations/delete-address-v2.md
+++ b/src/pages/graphql/schema/customer/mutations/delete-address-v2.md
@@ -13,7 +13,7 @@ We recommend you use a customer token in the header of your call to delete a cus
 
 <InlineAlert variant="info" slots="text1" />
 
-This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
+This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/en/tools/commerce-storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
 ## Syntax
 

--- a/src/pages/graphql/schema/customer/mutations/exchange-external-customer-token.md
+++ b/src/pages/graphql/schema/customer/mutations/exchange-external-customer-token.md
@@ -8,7 +8,7 @@ ee_only: true
 
 <InlineAlert variant="info" slots="text" />
 
-This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
+This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/en/tools/commerce-storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
 The `exchangeExternalCustomerToken` mutation provides the capability for social login authentication using App Builder. With integration token credentials, it allows a shopper to log in. If the shopper does not have an account, the mutation creates one.. It returns a customer authentication token.
 

--- a/src/pages/graphql/schema/customer/mutations/update-address-v2.md
+++ b/src/pages/graphql/schema/customer/mutations/update-address-v2.md
@@ -14,7 +14,7 @@ To return or modify information about a customer, we recommend you use customer 
 
 <InlineAlert variant="info" slots="text1" />
 
-This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
+This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/en/tools/commerce-storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
 ## Syntax
 

--- a/src/pages/graphql/schema/customer/queries/customer-group.md
+++ b/src/pages/graphql/schema/customer/queries/customer-group.md
@@ -7,7 +7,7 @@ description: Provides the encoded ID of a customer group assigned to the logged-
 
 <InlineAlert variant="info" slots="text" />
 
-This query was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
+This query was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/en/tools/commerce-storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
 The `customerGroup` query provides encoded ID of a customer group assigned to the logged-in customer or guest shopper.
 

--- a/src/pages/graphql/schema/customer/queries/customer-segments.md
+++ b/src/pages/graphql/schema/customer/queries/customer-segments.md
@@ -8,7 +8,7 @@ ee_only: true
 
 <InlineAlert variant="info" slots="text" />
 
-This query was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
+This query was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/en/tools/commerce-storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
 The `customerSegments` query provides the encoded ID of customer segments assigned to the logged-in customer or guest shopper.
 

--- a/src/pages/graphql/schema/live-search/queries/product-search.md
+++ b/src/pages/graphql/schema/live-search/queries/product-search.md
@@ -201,7 +201,7 @@ Learn how to implement these new search capabilities in your Live Search API by 
 
 Layered search is available on the following architectures:
 
-- Commerce Optimizer [Product Discovery drop-ins](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-discovery/functions/)
+- Commerce Optimizer [Product Discovery drop-ins](https://experienceleague.adobe.com/en/tools/commerce-storefront/dropins/product-discovery/functions/)
 - Live Search (headless)
 
 <InlineAlert variant="info" slots="text" />

--- a/src/pages/graphql/schema/product-recommendations/queries/recommendations.md
+++ b/src/pages/graphql/schema/product-recommendations/queries/recommendations.md
@@ -16,7 +16,7 @@ Merchants must have both Product Recommendations and Catalog Service (v2.2.0+) i
 
 The `recommendations` query does not support the `alternateEnvironmentId` attribute.
 
-The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) provides a sample `recommendations` query that you can run against a live instance of Adobe Commerce with Luma sample data. Note that the responses may vary, depending on the configuration of the Commerce instance.
+The [Commerce API playground](https://experienceleague.adobe.com/en/tools/commerce-storefront/playgrounds/commerce-services/) provides a sample `recommendations` query that you can run against a live instance of Adobe Commerce with Luma sample data. Note that the responses may vary, depending on the configuration of the Commerce instance.
 
 ## Required headers
 

--- a/src/pages/graphql/schema/store/queries/store-config.md
+++ b/src/pages/graphql/schema/store/queries/store-config.md
@@ -21,7 +21,7 @@ The `storeConfig` reference provides detailed information about the types and fi
 
 ## Example usage
 
-The [Commerce API playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) provides a sample `storeConfig` query that you can run against a live instance of Adobe Commerce with Luma sample data. Note that the responses may vary, depending on the configuration of the Commerce instance.
+The [Commerce API playground](https://experienceleague.adobe.com/en/tools/commerce-storefront/playgrounds/commerce-services/) provides a sample `storeConfig` query that you can run against a live instance of Adobe Commerce with Luma sample data. Note that the responses may vary, depending on the configuration of the Commerce instance.
 
 ### Query a store's configuration
 

--- a/src/pages/graphql/schema/wishlist/mutations/clear.md
+++ b/src/pages/graphql/schema/wishlist/mutations/clear.md
@@ -11,7 +11,7 @@ This mutation requires a valid [customer authentication token](../../customer/mu
 
 <InlineAlert variant="info" slots="text1" />
 
-This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
+This mutation was created for the [Storefront Compatibility Package](https://experienceleague.adobe.com/en/tools/commerce-storefront/setup/configuration/storefront-compatibility/v248/) and is now available on Adobe Commerce 2.4.9.
 
 ## Syntax
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates outdated links to the Storefront Compatibility Package, Commerce API playground, and Product Discovery drop-ins docs. The old `/developer/commerce/storefront/...` paths have moved to `/en/tools/commerce-storefront/...`.

## Affected pages

- https://developer.adobe.com/commerce/webapi/graphql/
- https://developer.adobe.com/commerce/webapi/graphql/schema/cart/queries/cart/
- https://developer.adobe.com/commerce/webapi/graphql/schema/catalog-service/queries/products/
- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/delete-address-v2/
- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/exchange-external-customer-token/
- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/update-address-v2/
- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer-group/
- https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer-segments/
- https://developer.adobe.com/commerce/webapi/graphql/schema/live-search/queries/product-search/
- https://developer.adobe.com/commerce/webapi/graphql/schema/product-recommendations/queries/recommendations/
- https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/
- https://developer.adobe.com/commerce/webapi/graphql/schema/wishlist/mutations/clear/

